### PR TITLE
Adds methods to get/fetch project by id

### DIFF
--- a/ddsc/core/ddsapi.py
+++ b/ddsc/core/ddsapi.py
@@ -226,6 +226,14 @@ class DataServiceApi(object):
         """
         return self._get("/projects", {})
 
+    def get_project_by_id(self, id):
+        """
+        Send GET request to /projects/{id} to get project details
+        :param id: str uuid of the project
+        :return: requests.Response containing the successful result
+        """
+        return self._get('/projects/{}'.format(id), {})
+
     def get_file_url(self, file_id):
         """
         Send GET to /files/{}/url returning a url to download the file.

--- a/ddsc/core/remotestore.py
+++ b/ddsc/core/remotestore.py
@@ -33,6 +33,15 @@ class RemoteStore(object):
                 raise ValueError(u'There is no project with the name {}'.format(project_name).encode('utf-8'))
         return project
 
+    def fetch_remote_project_by_id(self, id):
+        """
+        Retrieves project from via id
+        :param id: str id of project from data service
+        :return: RemoteProject we downloaded
+        """
+        response = self.data_service.get_project_by_id(id)
+        return RemoteProject(response)
+
     def _get_my_project(self, project_name):
         """
         Return project tree root for project_name.

--- a/ddsc/core/remotestore.py
+++ b/ddsc/core/remotestore.py
@@ -39,7 +39,7 @@ class RemoteStore(object):
         :param id: str id of project from data service
         :return: RemoteProject we downloaded
         """
-        response = self.data_service.get_project_by_id(id)
+        response = self.data_service.get_project_by_id(id).json()
         return RemoteProject(response)
 
     def _get_my_project(self, project_name):

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 
 setup(name='DukeDSClient',
-        version='0.2.2',
+        version='0.2.3',
         description='Command line tool(ddsclient) to upload/manage projects on the duke-data-service.',
         url='https://github.com/Duke-GCB/DukeDSClient',
         keywords='duke dds dukedataservice',


### PR DESCRIPTION
These are used by the handover service to get project details from DukeDS
a `fetch_remote_project` method already existed that took a project name as an argument, so this change set adds `fetch_remote_project_by_id`