### PR TITLE
duke-data-service GET files payload change

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ python setup.py test
 This also requires a [Duke NetID](https://oit.duke.edu/email-accounts/netid/).
 
 ### Upload Settings
-The default upload settings is to use a single worker and upload 100MB chunks.
+The default upload settings is to use a worker per cpu and upload 100MB chunks.
 You can change this via the `upload_bytes_per_chunk` and `upload_workers` config file options.
 These options should be added to your `~/.ddsclient` config file.
 `upload_workers` should be an integer for the number of upload workers you want.

--- a/ddsc/config.py
+++ b/ddsc/config.py
@@ -2,6 +2,7 @@
 import os
 import re
 import yaml
+import multiprocessing
 try:
     from urllib.parse import urlparse
 except ImportError:
@@ -119,7 +120,7 @@ class Config(object):
         Return the number of parallel works to use when uploading a file.
         :return: int number of workers. Specify None or 1 to disable parallel uploading
         """
-        return self.values.get(Config.UPLOAD_WORKERS, None)
+        return self.values.get(Config.UPLOAD_WORKERS, multiprocessing.cpu_count())
 
     @property
     def debug_mode(self):

--- a/ddsc/core/tests/test_remotestore.py
+++ b/ddsc/core/tests/test_remotestore.py
@@ -88,6 +88,71 @@ class TestProjectFolderFile(TestCase):
         self.assertEqual('thistest', folder.name)
         self.assertEqual(False, folder.is_deleted)
 
+    def test_file_item_new_version(self):
+        folders_id_children_sample_json = """
+        {
+          "results": [
+            {
+              "kind": "dds-file",
+              "id": "3a14eac9-90f4-4667-9999-1625dd6c3d9a",
+              "parent": {
+                "kind": "dds-folder",
+                "id": "cf99a8f1-aebd-4640-8854-f34d03b7511e"
+              },
+              "name": "bigWigToWig",
+              "audit": {
+                "created_on": "2016-02-19T16:38:56.229Z",
+                "created_by": {
+                  "id": "5dd78297-1604-457c-87c1-e3a792be16b9",
+                  "username": "jpb67",
+                  "full_name": "John Bradley"
+                },
+                "last_updated_on": null,
+                "last_updated_by": null,
+                "deleted_on": null,
+                "deleted_by": null
+              },
+              "is_deleted": false,
+              "current_version": {
+                  "upload": {
+                    "id": "fbdaf8bd-949f-427e-9601-18e8a71b30db",
+                    "size": 1874572,
+                    "hash": null,
+                    "storage_provider": {
+                      "id": "90b31bfd-dabe-4d4b-a040-0ac448ede0ad",
+                      "name": "duke_swift",
+                      "description": "Duke OIT Swift Service"
+                    }
+                  }
+              },
+              "project": {
+                "id": "bc6d2ac6-4a52-4421-b6ef-89b96731e843"
+              },
+              "ancestors": [
+                {
+                  "kind": "dds-project",
+                  "id": "bc6d2ac6-4a52-4421-b6ef-89b96731e843",
+                  "name": "test4"
+                },
+                {
+                  "kind": "dds-folder",
+                  "id": "cf99a8f1-aebd-4640-8854-f34d03b7511e",
+                  "name": "thistest"
+                }
+              ]
+            }
+          ]
+        }
+        """
+        blob = json.loads(folders_id_children_sample_json)
+        file_json = blob['results'][0]
+        file = RemoteFile(file_json)
+        self.assertEqual('dds-file', file.kind)
+        self.assertEqual('3a14eac9-90f4-4667-9999-1625dd6c3d9a', file.id)
+        self.assertEqual('bigWigToWig', file.name)
+        self.assertEqual(False, file.is_deleted)
+        self.assertEqual(1874572, file.size)
+
     def test_file_item(self):
         folders_id_children_sample_json = """
         {

--- a/ddsc/tests/test_config.py
+++ b/ddsc/tests/test_config.py
@@ -1,5 +1,6 @@
 from unittest import TestCase
 import ddsc.config
+import multiprocessing
 
 
 class TestConfig(TestCase):
@@ -10,7 +11,7 @@ class TestConfig(TestCase):
         self.assertEqual(config.agent_key, None)
         self.assertEqual(config.auth, None)
         self.assertEqual(config.upload_bytes_per_chunk, ddsc.config.DDS_DEFAULT_UPLOAD_CHUNKS)
-        self.assertEqual(config.upload_workers, None)
+        self.assertEqual(config.upload_workers, multiprocessing.cpu_count())
 
     def test_global_then_local(self):
         config = ddsc.config.Config()
@@ -34,7 +35,7 @@ class TestConfig(TestCase):
         self.assertEqual(config.agent_key, '123')
         self.assertEqual(config.auth, 'secret')
         self.assertEqual(config.upload_bytes_per_chunk, 1293892)
-        self.assertEqual(config.upload_workers, None)
+        self.assertEqual(config.upload_workers, multiprocessing.cpu_count())
 
         config.update_properties(local_config)
         self.assertEqual(config.url, 'dataservice2.com')

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 
 setup(name='DukeDSClient',
-        version='0.2.6',
+        version='0.2.7',
         description='Command line tool(ddsclient) to upload/manage projects on the duke-data-service.',
         url='https://github.com/Duke-GCB/DukeDSClient',
         keywords='duke dds dukedataservice',


### PR DESCRIPTION
Changes to support old and new versions of duke-data-service GET /api/v1/files/{id} payload.
Changed upload workers to default to the num CPUs.