### PR TITLE
Parallel Download

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist/
 .DS_Store
 .eggs
 duke-data-service
+env/

--- a/ddsc/config.py
+++ b/ddsc/config.py
@@ -130,6 +130,7 @@ class Config(object):
         Return the number of parallel works to use when downloading a file.
         :return: int number of workers. Specify None or 1 to disable parallel downloading
         """
+        # Profiling download on different servers showed half the number of CPUs to be optimum for speed.
         default_workers = int(math.ceil(multiprocessing.cpu_count()/2))
         return self.values.get(Config.DOWNLOAD_WORKERS, default_workers)
 

--- a/ddsc/config.py
+++ b/ddsc/config.py
@@ -1,6 +1,7 @@
 """ Global configuration for the utility based on config files and environment variables."""
 import os
 import re
+import math
 import yaml
 import multiprocessing
 try:
@@ -129,7 +130,8 @@ class Config(object):
         Return the number of parallel works to use when downloading a file.
         :return: int number of workers. Specify None or 1 to disable parallel downloading
         """
-        return self.values.get(Config.DOWNLOAD_WORKERS, multiprocessing.cpu_count())
+        default_workers = int(math.ceil(multiprocessing.cpu_count()/2))
+        return self.values.get(Config.DOWNLOAD_WORKERS, default_workers)
 
     @property
     def debug_mode(self):

--- a/ddsc/core/download.py
+++ b/ddsc/core/download.py
@@ -72,14 +72,9 @@ class ProjectDownload(object):
         """
         parent_path = self.id_to_path[parent.id]
         path = os.path.join(parent_path, item.name)
-
-        workers = self.remote_store.config.download_workers
-        if not workers or workers == 1 or workers == 'None':
-            self.remote_store.download_file(item, path, self.watcher)
-        else:
-            url_json = self.remote_store.data_service.get_file_url(item.id).json()
-            downloader = FileDownloader(self.remote_store.config, item, url_json, path, item.size, self.watcher)
-            downloader.run()
+        url_json = self.remote_store.data_service.get_file_url(item.id).json()
+        downloader = FileDownloader(self.remote_store.config, item, url_json, path, self.watcher)
+        downloader.run()
         ProjectDownload.check_file_size(item, path)
 
     @staticmethod

--- a/ddsc/core/download.py
+++ b/ddsc/core/download.py
@@ -1,6 +1,7 @@
 import os
 
 from ddsc.core.util import ProgressPrinter, ProjectWalker
+from ddsc.core.filedownloader import FileDownloader
 
 
 class ProjectDownload(object):
@@ -71,9 +72,13 @@ class ProjectDownload(object):
         """
         parent_path = self.id_to_path[parent.id]
         path = os.path.join(parent_path, item.name)
-        self.remote_store.download_file(item, path, self.watcher)
-        ProjectDownload.check_file_size(item, path)
+        #self.remote_store.download_file(item, path, self.watcher)
+        #
 
+        url_json = self.remote_store.data_service.get_file_url(item.id).json()
+        downloader = FileDownloader(self.remote_store.config, url_json, path, item.size, self.watcher)
+        downloader.run()
+        ProjectDownload.check_file_size(item, path)
 
     @staticmethod
     def check_file_size(item, path):

--- a/ddsc/core/download.py
+++ b/ddsc/core/download.py
@@ -72,12 +72,14 @@ class ProjectDownload(object):
         """
         parent_path = self.id_to_path[parent.id]
         path = os.path.join(parent_path, item.name)
-        #self.remote_store.download_file(item, path, self.watcher)
-        #
 
-        url_json = self.remote_store.data_service.get_file_url(item.id).json()
-        downloader = FileDownloader(self.remote_store.config, url_json, path, item.size, self.watcher)
-        downloader.run()
+        workers = self.remote_store.config.download_workers
+        if not workers or workers == 1 or workers == 'None':
+            self.remote_store.download_file(item, path, self.watcher)
+        else:
+            url_json = self.remote_store.data_service.get_file_url(item.id).json()
+            downloader = FileDownloader(self.remote_store.config, item, url_json, path, item.size, self.watcher)
+            downloader.run()
         ProjectDownload.check_file_size(item, path)
 
     @staticmethod

--- a/ddsc/core/filedownloader.py
+++ b/ddsc/core/filedownloader.py
@@ -1,0 +1,129 @@
+"""
+Downloads a file based on ranges.
+"""
+import math
+import tempfile
+import requests
+from multiprocessing import Process, Queue
+
+DOWNLOAD_FILE_CHUNK_SIZE = 1024
+MIN_DOWNLOAD_CHUNK_SIZE = 10 * 1024 * 1024
+
+
+class FileDownloader(object):
+    def __init__(self, config, url_parts, path, file_size, watcher):
+        self.config = config
+        self.url_parts = url_parts
+        self.path = path
+        self.file_size = file_size
+        self.watcher = watcher
+        self.file_parts = []
+
+    @property
+    def http_verb(self):
+        verb = self.url_parts['http_verb']
+        if verb != 'GET':
+            raise ValueError("Unsupported download method: {}".format(verb))
+        return verb
+
+    @property
+    def host(self):
+        return self.url_parts['host']
+
+    @property
+    def url(self):
+        return self.url_parts['url']
+
+    @property
+    def http_headers(self):
+        return self.url_parts['http_headers']
+
+    def make_ranges(self):
+        size = int(self.file_size)
+        bytes_per_chunk = self.determine_bytes_per_chunk()
+        start = 0
+        ranges = []
+        while size > 0:
+            amount = bytes_per_chunk
+            if amount > size:
+                amount = size
+            ranges.append("{}-{}".format(start, start + amount - 1))
+            start += amount
+            size -= amount
+        return ranges
+
+    def determine_bytes_per_chunk(self):
+        workers = self.config.download_workers
+        if not workers:
+            workers = 1
+        size = int(self.file_size)
+        bytes_per_chunk = int(math.ceil(size / float(workers)))
+        if bytes_per_chunk < MIN_DOWNLOAD_CHUNK_SIZE:
+            bytes_per_chunk = MIN_DOWNLOAD_CHUNK_SIZE
+        return bytes_per_chunk
+
+    def run(self):
+        self.file_parts = []
+        ranges = self.make_ranges()
+        processes = []
+        progress_queue = Queue()
+        index = 0
+        for range in ranges:
+            (temp_handle, temp_path) = tempfile.mkstemp()
+            self.file_parts.append(temp_path)
+            processes.append(self.make_and_start_process(temp_path, range, progress_queue))
+            index += 1
+        self.wait_for_processes(len(ranges), progress_queue, processes)
+        self.merge_file_parts()
+
+    def make_and_start_process(self, temp_path, range, progress_queue):
+        http_headers = {'Range': 'bytes=' + range}
+        process = Process(target=download_async,
+                          args=(self.host + self.url, http_headers, temp_path, progress_queue))
+        process.start()
+        return process
+
+    def wait_for_processes(self, num_expected_files, progress_queue, processes):
+        while num_expected_files > 0:
+            progress_type, value = progress_queue.get()
+            if progress_type == ChunkDownloader.RECEIVED:
+                chunks_sent = value
+                #self.watcher.transferring_item(self.local_file, chunks_sent)
+                num_expected_files -= 1
+            else:
+                error_message = value
+                for process in processes:
+                    process.terminate()
+                raise ValueError(error_message)
+        for process in processes:
+            process.join()
+
+    def merge_file_parts(self):
+        with open(self.path, "w") as outfile:
+            for temp_path in self.file_parts:
+                with open(temp_path, "r") as infile:
+                    outfile.write(infile.read())
+
+
+def download_async(url, headers, path, progress_queue):
+    downloader = ChunkDownloader(url, headers, path, progress_queue)
+    downloader.run()
+
+
+class ChunkDownloader(object):
+    RECEIVED = 'received'
+    ERROR = 'error'
+
+    def __init__(self, url, http_headers, path, progress_queue):
+        self.url = url
+        self.http_headers = http_headers
+        self.path = path
+        self.progress_queue = progress_queue
+
+    def run(self):
+        response = requests.get(self.url, headers=self.http_headers, stream=True)
+        with open(self.path, 'w') as outfile:
+            for chunk in response.iter_content(chunk_size=DOWNLOAD_FILE_CHUNK_SIZE):
+                if chunk:  # filter out keep-alive chunks
+                    outfile.write(chunk)
+        self.progress_queue.put((ChunkDownloader.RECEIVED, 1))

--- a/ddsc/core/filedownloader.py
+++ b/ddsc/core/filedownloader.py
@@ -103,7 +103,10 @@ class FileDownloader(object):
         with open(self.path, "wb") as outfile:
             for temp_path in self.file_parts:
                 with open(temp_path, "rb") as infile:
-                    outfile.write(infile.read())
+                    data = infile.readlines(MIN_DOWNLOAD_CHUNK_SIZE)
+                    if not data:
+                        break
+                    outfile.write(data)
         for temp_path in self.file_parts:
             os.remove(temp_path)
 

--- a/ddsc/core/filedownloader.py
+++ b/ddsc/core/filedownloader.py
@@ -103,10 +103,7 @@ class FileDownloader(object):
         with open(self.path, "wb") as outfile:
             for temp_path in self.file_parts:
                 with open(temp_path, "rb") as infile:
-                    data = infile.readlines(MIN_DOWNLOAD_CHUNK_SIZE)
-                    if not data:
-                        break
-                    outfile.write(data)
+                    outfile.write(infile.read())
         for temp_path in self.file_parts:
             os.remove(temp_path)
 

--- a/ddsc/core/filedownloader.py
+++ b/ddsc/core/filedownloader.py
@@ -169,7 +169,7 @@ class ChunkDownloader(object):
                 for chunk in response.iter_content(chunk_size=DOWNLOAD_FILE_CHUNK_SIZE):
                     if chunk:  # filter out keep-alive chunks
                         outfile.write(chunk)
-                        self.progress_queue.procssed(len(chunk))
+                        self.progress_queue.processed(len(chunk))
         except Exception as ex:
             self.progress_queue.error(str(ex))
 

--- a/ddsc/core/filedownloader.py
+++ b/ddsc/core/filedownloader.py
@@ -1,13 +1,14 @@
 """
 Downloads a file based on ranges.
 """
+import os
 import math
 import tempfile
 import requests
 from multiprocessing import Process, Queue
 
-DOWNLOAD_FILE_CHUNK_SIZE = 1024
-MIN_DOWNLOAD_CHUNK_SIZE = 10 * 1024 * 1024
+DOWNLOAD_FILE_CHUNK_SIZE = 20 * 1024 * 1024
+MIN_DOWNLOAD_CHUNK_SIZE = 20 * 1024 * 1024
 
 
 class FileDownloader(object):
@@ -103,6 +104,8 @@ class FileDownloader(object):
             for temp_path in self.file_parts:
                 with open(temp_path, "rb") as infile:
                     outfile.write(infile.read())
+        for temp_path in self.file_parts:
+            os.remove(temp_path)
 
 
 def download_async(url, headers, path, progress_queue):

--- a/ddsc/core/filedownloader.py
+++ b/ddsc/core/filedownloader.py
@@ -1,23 +1,35 @@
 """
 Downloads a file based on ranges.
 """
-import os
 import math
 import tempfile
 import requests
 from multiprocessing import Process, Queue
 
 DOWNLOAD_FILE_CHUNK_SIZE = 20 * 1024 * 1024
-MIN_DOWNLOAD_CHUNK_SIZE = 20 * 1024 * 1024
+MIN_DOWNLOAD_CHUNK_SIZE = DOWNLOAD_FILE_CHUNK_SIZE
 
 
 class FileDownloader(object):
-    def __init__(self, config, remote_file, url_parts, path, file_size, watcher):
+    """
+    Downloads a file using a number of worker processes who download different ranges.
+    Creates an empty file.
+    Each worker seeks to their spot and streams the data from their url data into the file.
+    """
+    def __init__(self, config, remote_file, url_parts, path, watcher):
+        """
+        Setup details on what to download and watcher to notify of progress.
+        :param config: Config: configuration settings for download (number workers)
+        :param remote_file: RemoteFile: info about the file we are downloading
+        :param url_parts: dictionary of fields related to url ('http_verb','host','http_headers')
+        :param path: str: path to where we will save the file
+        :param watcher: ProgressPrinter: we notify of our progress
+        """
         self.config = config
         self.remote_file = remote_file
+        self.file_size = remote_file.size
         self.url_parts = url_parts
         self.path = path
-        self.file_size = file_size
         self.watcher = watcher
         self.file_parts = []
 
@@ -41,6 +53,10 @@ class FileDownloader(object):
         return self.url_parts['http_headers']
 
     def make_ranges(self):
+        """
+        Divides file size into an array of ranges to be downloaded by workers.
+        :return: [(int,int)]: array of (start, end) tuples
+        """
         size = int(self.file_size)
         bytes_per_chunk = self.determine_bytes_per_chunk()
         start = 0
@@ -49,14 +65,19 @@ class FileDownloader(object):
             amount = bytes_per_chunk
             if amount > size:
                 amount = size
-            ranges.append("{}-{}".format(start, start + amount - 1))
+            ranges.append((start, start + amount - 1))
             start += amount
             size -= amount
         return ranges
 
     def determine_bytes_per_chunk(self):
+        """
+        Calculate the size of chunk a worker should download.
+        The last worker may download less than this depending on file size.
+        :return: int: byte size for a worker
+        """
         workers = self.config.download_workers
-        if not workers:
+        if not workers or workers == 'None':
             workers = 1
         size = int(self.file_size)
         bytes_per_chunk = int(math.ceil(size / float(workers)))
@@ -65,32 +86,52 @@ class FileDownloader(object):
         return bytes_per_chunk
 
     def run(self):
+        """
+        Download a file using separate processes.
+        """
         self.file_parts = []
         ranges = self.make_ranges()
         processes = []
         progress_queue = Queue()
         self.make_big_empty_file()
-        for range in ranges:
+        for range_start, range_end in ranges:
             (temp_handle, temp_path) = tempfile.mkstemp()
             self.file_parts.append(temp_path)
-            processes.append(self.make_and_start_process(range, progress_queue))
+            processes.append(self.make_and_start_process(range_start, range_end, progress_queue))
         self.wait_for_processes(progress_queue, processes)
-        #self.merge_file_parts()
 
     def make_big_empty_file(self):
+        """
+        Write out a empty file so the workers can seek to where they should write and write their data.
+        """
         with open(self.path, "wb") as outfile:
             outfile.seek(int(self.file_size) - 1)
-            outfile.write("\0")
+            outfile.write(b'\0')
 
-    def make_and_start_process(self, bytesRange, progress_queue):
-        http_headers = {'Range': 'bytes=' + bytesRange}
-        seek_amt = int(bytesRange.split("-")[0])
+    def make_and_start_process(self, range_start, range_end, progress_queue):
+        """
+        Create a process that will download the specified range and notify progress_queue of progress or errors.
+        :param range_start: int: file offset to download
+        :param range_end: int: file ending offset to download
+        :param progress_queue: Queue: queue to notify as we make progress
+        :return: Process: the process we created
+        """
+        http_headers = {'Range': 'bytes={}-{}'.format(range_start, range_end)}
+        if self.http_headers:
+            http_headers.update(self.http_headers)
+        seek_amt = range_start
         process = Process(target=download_async,
                           args=(self.host + self.url, http_headers, self.path, seek_amt, progress_queue))
         process.start()
         return process
 
     def wait_for_processes(self, progress_queue, processes):
+        """
+        Watch progress queue for errors or progress.
+        Cleanup processes on error or success.
+        :param progress_queue: Queue: queue which will receive tuples of progress or error
+        :param processes: [Process]: processes we are waiting to finish downloading a file
+        """
         file_bytes = int(self.file_size)
         while file_bytes > 0:
             progress_type, value = progress_queue.get()
@@ -106,25 +147,38 @@ class FileDownloader(object):
         for process in processes:
             process.join()
 
-    def merge_file_parts(self):
-        with open(self.path, "wb") as outfile:
-            for temp_path in self.file_parts:
-                with open(temp_path, "rb") as infile:
-                    outfile.write(infile.read())
-        for temp_path in self.file_parts:
-            os.remove(temp_path)
-
 
 def download_async(url, headers, path, seek_amt, progress_queue):
+    """
+    Called in separate process to download a chunk of a file.
+    :param url: str: url to file we should download
+    :param headers: dict: header to use with url, should contain Range to limit what we download
+    :param path: str: path to where we should save our chunk we download
+    :param seek_amt: int: offset to seek before writing our chunk out to path
+    :param progress_queue: Queue: queue of tuples we will add progress/errors to
+    :return:
+    """
     downloader = ChunkDownloader(url, headers, path, seek_amt, progress_queue)
     downloader.run()
 
 
 class ChunkDownloader(object):
+    """
+    Downloads part of a file and writes it to a location in a local pre-existing file.
+    This runs in a separate process from the main application.
+    """
     RECEIVED = 'received'
     ERROR = 'error'
 
     def __init__(self, url, http_headers, path, seek_amt, progress_queue):
+        """
+        Setup for downloading part of a file.
+        :param url: str: url to the file
+        :param http_headers: dict: headers for use with the url should contain byte Range
+        :param path: str: path to file to write data to
+        :param seek_amt: int: offset amount to seek into the file
+        :param progress_queue: Queue: queue we notify of progress or errors
+        """
         self.url = url
         self.http_headers = http_headers
         self.path = path
@@ -132,11 +186,14 @@ class ChunkDownloader(object):
         self.progress_queue = progress_queue
 
     def run(self):
-        response = requests.get(self.url, headers=self.http_headers, stream=True)
-        with open(self.path, 'r+b') as outfile:
-            outfile.seek(self.seek_amt)
-            for chunk in response.iter_content(chunk_size=DOWNLOAD_FILE_CHUNK_SIZE):
-                if chunk:  # filter out keep-alive chunks
-                    outfile.write(chunk)
-                    self.progress_queue.put((ChunkDownloader.RECEIVED, len(chunk)))
+        try:
+            response = requests.get(self.url, headers=self.http_headers, stream=True)
+            with open(self.path, 'r+b') as outfile:
+                outfile.seek(self.seek_amt)
+                for chunk in response.iter_content(chunk_size=DOWNLOAD_FILE_CHUNK_SIZE):
+                    if chunk:  # filter out keep-alive chunks
+                        outfile.write(chunk)
+                        self.progress_queue.put((ChunkDownloader.RECEIVED, len(chunk)))
+        except Exception as ex:
+            self.progress_queue.put((ChunkDownloader.ERROR, str(ex)))
 

--- a/ddsc/core/remotestore.py
+++ b/ddsc/core/remotestore.py
@@ -2,7 +2,7 @@ from ddsc.core.ddsapi import DataServiceApi, DataServiceError, DataServiceAuth
 from ddsc.core.util import KindType
 
 FETCH_ALL_USERS_PAGE_SIZE = 25
-DOWNLOAD_FILE_CHUNK_SIZE = 1024
+DOWNLOAD_FILE_CHUNK_SIZE = 20 * 1024 * 1024
 
 
 class RemoteStore(object):

--- a/ddsc/core/tests/test_filedownloader.py
+++ b/ddsc/core/tests/test_filedownloader.py
@@ -1,0 +1,57 @@
+from unittest import TestCase
+from ddsc.core.filedownloader import FileDownloader
+
+
+class FakeConfig(object):
+    def __init__(self, download_workers):
+        self.download_workers = download_workers
+
+
+class TestFileDownloader(TestCase):
+    def test_make_chunk_processor_with_none(self):
+        # Only one worker because file size is too small
+        self.assert_make_ranges(
+            workers=2,
+            file_size=100,
+            expected=[
+                '0-99',
+            ]
+        )
+
+        # Big enough file should split into two
+        self.assert_make_ranges(
+            workers=2,
+            file_size=100 * 1000 * 1000,
+            expected=[
+                '0-49999999',
+                '50000000-99999999'
+            ]
+        )
+
+
+        # Big enough file should split into three
+        self.assert_make_ranges(
+            workers=3,
+            file_size=100 * 1000 * 1000,
+            expected=[
+                '0-33333333',
+                '33333334-66666667',
+                '66666668-99999999',
+            ]
+        )
+
+        # Uneven split
+        self.assert_make_ranges(
+            workers=3,
+            file_size=100 * 1000 * 1000 - 1,
+            expected=[
+                '0-33333332',
+                '33333333-66666665',
+                '66666666-99999998',
+            ]
+        )
+
+    def assert_make_ranges(self, workers, file_size, expected):
+        config = FakeConfig(workers)
+        downloader = FileDownloader(config, None, None, file_size, None)
+        self.assertEqual(expected, downloader.make_ranges())

--- a/ddsc/core/tests/test_filedownloader.py
+++ b/ddsc/core/tests/test_filedownloader.py
@@ -7,6 +7,11 @@ class FakeConfig(object):
         self.download_workers = download_workers
 
 
+class FakeFile(object):
+    def __init__(self, size):
+        self.size = size
+
+
 class TestFileDownloader(TestCase):
     def test_make_chunk_processor_with_none(self):
         # Only one worker because file size is too small
@@ -14,7 +19,7 @@ class TestFileDownloader(TestCase):
             workers=2,
             file_size=100,
             expected=[
-                '0-99',
+                (0, 99),
             ]
         )
 
@@ -23,8 +28,8 @@ class TestFileDownloader(TestCase):
             workers=2,
             file_size=100 * 1000 * 1000,
             expected=[
-                '0-49999999',
-                '50000000-99999999'
+                (0, 49999999),
+                (50000000, 99999999)
             ]
         )
 
@@ -34,9 +39,9 @@ class TestFileDownloader(TestCase):
             workers=3,
             file_size=100 * 1000 * 1000,
             expected=[
-                '0-33333333',
-                '33333334-66666667',
-                '66666668-99999999',
+                (0, 33333333),
+                (33333334, 66666667),
+                (66666668, 99999999),
             ]
         )
 
@@ -45,13 +50,13 @@ class TestFileDownloader(TestCase):
             workers=3,
             file_size=100 * 1000 * 1000 - 1,
             expected=[
-                '0-33333332',
-                '33333333-66666665',
-                '66666666-99999998',
+                (0, 33333332),
+                (33333333, 66666665),
+                (66666666, 99999998),
             ]
         )
 
     def assert_make_ranges(self, workers, file_size, expected):
         config = FakeConfig(workers)
-        downloader = FileDownloader(config, None, None, None, file_size, None)
+        downloader = FileDownloader(config, FakeFile(file_size), None, None, None)
         self.assertEqual(expected, downloader.make_ranges())

--- a/ddsc/core/tests/test_filedownloader.py
+++ b/ddsc/core/tests/test_filedownloader.py
@@ -53,5 +53,5 @@ class TestFileDownloader(TestCase):
 
     def assert_make_ranges(self, workers, file_size, expected):
         config = FakeConfig(workers)
-        downloader = FileDownloader(config, None, None, file_size, None)
+        downloader = FileDownloader(config, None, None, None, file_size, None)
         self.assertEqual(expected, downloader.make_ranges())

--- a/ddsc/core/tests/test_filedownloader.py
+++ b/ddsc/core/tests/test_filedownloader.py
@@ -95,7 +95,7 @@ class TestFileDownloader(TestCase):
             self.assertEqual("oops", str(err))
 
     def chunk_download_fails(self, url, headers, path, seek_amt, progress_queue):
-        progress_queue.put((ChunkDownloader.ERROR, "oops"))
+        progress_queue.error("oops")
 
     def test_download_whole_chunk(self):
         file_size = 83833112
@@ -107,9 +107,9 @@ class TestFileDownloader(TestCase):
         self.assertEqual(file_size, watcher.amt)
 
     def chunk_download_one_piece(self, url, headers, path, seek_amt, progress_queue):
-        start, end = headers['Range'].replace("bytes=","").split('-')
+        start, end = headers['Range'].replace("bytes=", "").split('-')
         total = (int(end) - int(start) + 1)
-        progress_queue.put((ChunkDownloader.RECEIVED, total))
+        progress_queue.processed(total)
 
     def test_download_chunk_in_two_parts(self):
         file_size = 83833112
@@ -125,5 +125,5 @@ class TestFileDownloader(TestCase):
         total = (int(end) - int(start) + 1)
         first = int(total/2)
         rest = total - first
-        progress_queue.put((ChunkDownloader.RECEIVED, first))
-        progress_queue.put((ChunkDownloader.RECEIVED, rest))
+        progress_queue.processed(first)
+        progress_queue.processed(rest)

--- a/ddsc/tests/test_config.py
+++ b/ddsc/tests/test_config.py
@@ -1,4 +1,5 @@
 from unittest import TestCase
+import math
 import ddsc.config
 import multiprocessing
 
@@ -37,7 +38,7 @@ class TestConfig(TestCase):
         self.assertEqual(config.auth, 'secret')
         self.assertEqual(config.upload_bytes_per_chunk, 1293892)
         self.assertEqual(config.upload_workers, multiprocessing.cpu_count())
-        self.assertEqual(config.download_workers, multiprocessing.cpu_count())
+        self.assertEqual(config.download_workers, int(math.ceil(multiprocessing.cpu_count()/2)))
 
         config.update_properties(local_config)
         self.assertEqual(config.url, 'dataservice2.com')
@@ -84,6 +85,8 @@ class TestConfig(TestCase):
 
     def test_parse_bytes_str(self):
         value_and_expected = {
+            (1, 1),
+            (2, 2),
             ("1", 1),
             ("2", 2),
             ("1MB", 1024 * 1024),

--- a/ddsc/tests/test_config.py
+++ b/ddsc/tests/test_config.py
@@ -20,13 +20,14 @@ class TestConfig(TestCase):
             'user_key': 'abc',
             'agent_key': '123',
             'auth': 'secret',
-            'upload_bytes_per_chunk': 1293892
+            'upload_bytes_per_chunk': 1293892,
         }
         local_config = {
             'url':'dataservice2.com',
             'user_key': 'cde',
             'agent_key': '456',
             'upload_workers': 45,
+            'download_workers': 44,
         }
 
         config.update_properties(global_config)
@@ -36,6 +37,7 @@ class TestConfig(TestCase):
         self.assertEqual(config.auth, 'secret')
         self.assertEqual(config.upload_bytes_per_chunk, 1293892)
         self.assertEqual(config.upload_workers, multiprocessing.cpu_count())
+        self.assertEqual(config.download_workers, multiprocessing.cpu_count())
 
         config.update_properties(local_config)
         self.assertEqual(config.url, 'dataservice2.com')
@@ -44,16 +46,18 @@ class TestConfig(TestCase):
         self.assertEqual(config.auth, 'secret')
         self.assertEqual(config.upload_bytes_per_chunk, 1293892)
         self.assertEqual(config.upload_workers, 45)
+        self.assertEqual(config.download_workers, 44)
 
     def test_MB_chunk_convert(self):
         config = ddsc.config.Config()
         some_config = {
-            'upload_bytes_per_chunk': '10MB'
+            'upload_bytes_per_chunk': '10MB',
+            'download_bytes_per_chunk': '20MB',
         }
         config.update_properties(some_config)
         self.assertEqual(config.upload_bytes_per_chunk, 10485760)
         some_config = {
-            'upload_bytes_per_chunk': '20MB'
+            'upload_bytes_per_chunk': '20MB',
         }
         config.update_properties(some_config)
         self.assertEqual(config.upload_bytes_per_chunk, 20971520)
@@ -77,3 +81,15 @@ class TestConfig(TestCase):
         }
         config.update_properties(config3)
         self.assertEqual(config.get_portal_url_base(), 'dev.dataservice1.com')
+
+    def test_parse_bytes_str(self):
+        value_and_expected = {
+            ("1", 1),
+            ("2", 2),
+            ("1MB", 1024 * 1024),
+            ("1 MB", 1024 * 1024),
+            ("3MB", 3 * 1024 * 1024),
+            ("100MB", 100 * 1024 * 1024),
+        }
+        for value, exp in value_and_expected:
+            self.assertEqual(exp, ddsc.config.Config.parse_bytes_str(value))

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 
 setup(name='DukeDSClient',
-        version='0.2.7',
+        version='0.2.8',
         description='Command line tool(ddsclient) to upload/manage projects on the duke-data-service.',
         url='https://github.com/Duke-GCB/DukeDSClient',
         keywords='duke dds dukedataservice',

--- a/test_scripts/inside_docker.sh
+++ b/test_scripts/inside_docker.sh
@@ -5,7 +5,7 @@ echo "user_key: $DDS_USER_KEY" >> $CONFIG_FILE
 echo "agent_key: $DDS_AGENT_KEY" >> $CONFIG_FILE
 echo "upload_bytes_per_chunk: $UPLOAD_CHUNK_SIZE" >> $CONFIG_FILE
 echo "upload_workers: $UPLOAD_WORKERS" >> $CONFIG_FILE
-
+echo "download_workers: $DOWNLOAD_WORKERS" >> $CONFIG_FILE
 
 set -e
 echo "Installing ddsclient"

--- a/test_scripts/run.sh
+++ b/test_scripts/run.sh
@@ -55,12 +55,14 @@ run_test()
     TEST_PYTHON=$2
     UPLOAD_CHUNK_SIZE=$3
     UPLOAD_WORKERS=$4
+    DOWNLOAD_WORKERS=$4
     CUR_DIR=`pwd`
     create_user_data
     #run python2 tests
     TEMPFILE=/tmp/DukeDSClientTest.$$
-    echo "Running tests for $TEST_PYTHON uploadSize:$UPLOAD_CHUNK_SIZE uploadWorkers:$UPLOAD_WORKERS" | tee $TEMPFILE
+    echo "Running tests for $TEST_PYTHON uploadSize:$UPLOAD_CHUNK_SIZE workers:$UPLOAD_WORKERS/$DOWNLOAD_WORKERS" | tee $TEMPFILE
     docker run -it -e UPLOAD_CHUNK_SIZE=$UPLOAD_CHUNK_SIZE -e UPLOAD_WORKERS=$UPLOAD_WORKERS \
+                   -e DOWNLOAD_WORKERS=$DOWNLOAD_WORKERS \
                    -e INTEGRATION_TESTS="Y" \
                    -e TEST_PYTHON=$TEST_PYTHON -e DDS_IP=$DDS_IP \
                    -e DDS_USER_KEY=$DDS_USER_KEY -e DDS_AGENT_KEY=$DDS_AGENT_KEY \
@@ -84,10 +86,10 @@ docker rm $(docker ps -a -q --filter="name=dukedataservice_") 2>/dev/null
 build_docker_file
 start_dds
 
-run_test python2 python 100MB 1
-run_test python2 python 50MB 4
-run_test python3 python3 100MB 1
-run_test python3 python3 100MB 4
+run_test python2 python 100MB 1 1
+run_test python2 python 50MB 4 4
+run_test python3 python3 100MB 1 3
+run_test python3 python3 100MB 4 2
 
 #delete stopped containers
 docker rm $(docker ps -a -q --filter="name=dukedataservice_") 2>/dev/null


### PR DESCRIPTION
Changes download to use multiple processes similar to how upload works.
Added a `download_workers` config option to set how many processes to use.
We create a file to hold the parts by opening, seeking, writing(0).
Then create separate processes to download chunks and write to their part of the file.
We use the range header to download just the parts we need in each worker.
Using this method rather than separate files/merge due to performance differences.

The default setting for download_workers is number_cpu / 2. This seems to be optimum for the different places I tried this out.
Ran integration testing and did some manual testing.
Verified that we were spawning separate processes and after download checked file sizes/cksum/md5.
