### PR TITLE
file_downloader for mail_draft

### DIFF
--- a/ddsc/core/handover.py
+++ b/ddsc/core/handover.py
@@ -8,7 +8,7 @@ import requests
 from ddsc.core.upload import ProjectUpload
 from ddsc.core.download import ProjectDownload
 
-DRAFT_USER_ACCESS_ROLE = 'project_viewer'
+DRAFT_USER_ACCESS_ROLE = 'file_downloader'
 
 
 class HandoverError(Exception):


### PR DESCRIPTION
Switching from `project_viewer` to `file_downloader`.
Project viewer can only see filenames and sizes so it wouldn't be useful for evaluating a draft project.