### PR TITLE
skip un-necessary hidden files when uploading

### DIFF
--- a/ddsc/config.py
+++ b/ddsc/config.py
@@ -17,6 +17,8 @@ HANDOVER_SERVICE_URL = 'https://itlab-1.gcb.duke.edu/api/v1'
 MB_TO_BYTES = 1024 * 1024
 DDS_DEFAULT_UPLOAD_CHUNKS = 100 * MB_TO_BYTES
 AUTH_ENV_KEY_NAME = 'DUKE_DATA_SERVICE_AUTH'
+# when uploading skip .DS_Store, our key file, and ._ (resource fork metadata)
+FILE_EXCLUDE_REGEX_DEFAULT = '^\.DS_Store$|^\.ddsclient$|^\.\_'
 
 
 def create_config():
@@ -43,7 +45,7 @@ class Config(object):
     DOWNLOAD_WORKERS = 'download_workers'              # how many worker processes used for downloading
     DEBUG_MODE = 'debug'                               # show stack traces
     HANDOVER_URL = 'handover_url'                      # url for use with the handover service
-
+    FILE_EXCLUDE_REGEX = 'file_exclude_regex'          # allows customization of which filenames will be uploaded
 
     def __init__(self):
         self.values = {}
@@ -165,3 +167,11 @@ class Config(object):
                 return int(value)
         else:
             return value
+
+    @property
+    def file_exclude_regex(self):
+        """
+        Returns regex that should be used to filter out filenames.
+        :return: str: regex that when matches we should exclude a file from uploading.
+        """
+        return self.values.get(Config.FILE_EXCLUDE_REGEX, FILE_EXCLUDE_REGEX_DEFAULT)

--- a/ddsc/core/upload.py
+++ b/ddsc/core/upload.py
@@ -3,6 +3,7 @@ from ddsc.core.localstore import LocalProject
 from ddsc.core.remotestore import RemoteStore
 from ddsc.core.util import ProgressPrinter, ProjectWalker
 from ddsc.core.fileuploader import FileUploader
+import re
 
 
 class ProjectUpload(object):
@@ -21,13 +22,13 @@ class ProjectUpload(object):
         self.remote_store = RemoteStore(config)
         self.project_name = project_name
         self.remote_project = self.remote_store.fetch_remote_project(project_name)
-        self.local_project = ProjectUpload._load_local_project(folders, follow_symlinks)
+        self.local_project = ProjectUpload._load_local_project(folders, follow_symlinks, config.file_exclude_regex)
         self.local_project.update_remote_ids(self.remote_project)
         self.different_items = self._count_differences()
 
     @staticmethod
-    def _load_local_project(folders, follow_symlinks):
-        local_project = LocalProject(followsymlinks=follow_symlinks)
+    def _load_local_project(folders, follow_symlinks, file_exclude_regex):
+        local_project = LocalProject(followsymlinks=follow_symlinks, file_exclude_regex=file_exclude_regex)
         local_project.add_paths(folders)
         return local_project
 

--- a/test_scripts/.hidden_file
+++ b/test_scripts/.hidden_file
@@ -1,0 +1,1 @@
+Intentional hidden file to test hidden file finding code.


### PR DESCRIPTION
adding file_exclude_regex to allow customization of which files are uploaded
it is currently set to a default regex that will exclude .DS_Store, .ddsclient and ._*