### PR TITLE
Adding --include PATH and --exclude PATH to download and handover

### DIFF
--- a/ddsc/cmdparser.py
+++ b/ddsc/cmdparser.py
@@ -147,6 +147,7 @@ def add_email_arg(arg_parser):
                             help="Email of the person you want to give permission."
                                  " You must specify either --user or this flag.")
 
+
 def _add_auth_role_arg(arg_parser):
     """
     Adds optional auth_role parameter to a parser.
@@ -159,6 +160,7 @@ def _add_auth_role_arg(arg_parser):
                             help="Specifies authorization role for the user ('project_admin').",
                             default='project_admin')
 
+
 def _add_copy_project_arg(arg_parser):
     """
     Adds optional copy_project parameter to a parser.
@@ -169,6 +171,7 @@ def _add_copy_project_arg(arg_parser):
                             action='store_true',
                             default=False,
                             dest='skip_copy_project')
+
 
 def _add_resend_arg(arg_parser, type_str):
     """
@@ -193,6 +196,34 @@ def _add_force_arg(arg_parser, help_text):
                             help=help_text,
                             action='store_true',
                             dest='force')
+
+
+def _add_include_arg(arg_parser):
+    """
+    Adds optional repeatable include parameter to a parser.
+    :param arg_parser: ArgumentParser parser to add this argument to.
+    """
+    arg_parser.add_argument("--include",
+                            metavar='IncludePaths',
+                            action='append',
+                            type=to_unicode,
+                            dest='include_paths',
+                            help="Specifies comma separated list of paths to include.",
+                            default=[])
+
+
+def _add_exclude_arg(arg_parser):
+    """
+    Adds optional repeatable exclude parameter to a parser.
+    :param arg_parser: ArgumentParser parser to add this argument to.
+    """
+    arg_parser.add_argument("--exclude",
+                            metavar='ExcludePaths',
+                            action='append',
+                            type=to_unicode,
+                            dest='exclude_paths',
+                            help="Specifies comma separated list of paths to exclude.",
+                            default=[])
 
 
 class CommandParser(object):
@@ -244,6 +275,9 @@ class CommandParser(object):
         download_parser = self.subparsers.add_parser('download', description=description)
         add_project_name_arg(download_parser, help_text="Name of the project to download.")
         _add_folder_positional_arg(download_parser)
+        include_or_exclude = download_parser.add_mutually_exclusive_group(required=False)
+        _add_include_arg(include_or_exclude)
+        _add_exclude_arg(include_or_exclude)
         download_parser.set_defaults(func=download_func)
 
     def register_mail_draft_command(self, mail_draft_func):
@@ -276,6 +310,10 @@ class CommandParser(object):
         add_email_arg(user_or_email)
         _add_copy_project_arg(handover_parser)
         _add_resend_arg(handover_parser, "handover")
+        include_or_exclude = handover_parser.add_mutually_exclusive_group(required=False)
+        _add_include_arg(include_or_exclude)
+        _add_exclude_arg(include_or_exclude)
+
         handover_parser.set_defaults(func=handover_func)
 
     def register_list_command(self, list_func):

--- a/ddsc/cmdparser.py
+++ b/ddsc/cmdparser.py
@@ -204,11 +204,11 @@ def _add_include_arg(arg_parser):
     :param arg_parser: ArgumentParser parser to add this argument to.
     """
     arg_parser.add_argument("--include",
-                            metavar='IncludePaths',
+                            metavar='Path',
                             action='append',
                             type=to_unicode,
                             dest='include_paths',
-                            help="Specifies comma separated list of paths to include.",
+                            help="Specifies a single path to include. This argument can be repeated.",
                             default=[])
 
 
@@ -218,11 +218,11 @@ def _add_exclude_arg(arg_parser):
     :param arg_parser: ArgumentParser parser to add this argument to.
     """
     arg_parser.add_argument("--exclude",
-                            metavar='ExcludePaths',
+                            metavar='Path',
                             action='append',
                             type=to_unicode,
                             dest='exclude_paths',
-                            help="Specifies comma separated list of paths to exclude.",
+                            help="Specifies a single path to exclude. This argument can be repeated.",
                             default=[])
 
 

--- a/ddsc/core/download.py
+++ b/ddsc/core/download.py
@@ -1,6 +1,4 @@
-from __future__ import print_function
 import os
-
 from ddsc.core.util import ProgressPrinter
 from ddsc.core.filedownloader import FileDownloader
 from ddsc.core.pathfilter import PathFilteredProject
@@ -43,7 +41,6 @@ class ProjectDownload(object):
         self.watcher = ProgressPrinter(counter.count, msg_verb='downloading')
         path_filtered_project = PathFilteredProject(self.path_filter, self)
         path_filtered_project.run(project)  # calls visit_project, visit_folder, visit_file below
-
         self.watcher.finished()
         warnings = self.check_warnings()
         if warnings:
@@ -66,7 +63,7 @@ class ProjectDownload(object):
         Create the parent directory if necessary.
         :param item: RemoteProject
         """
-        self.try_create_dir('')
+        self.try_create_dir(item.remote_path)
 
     def visit_folder(self, item, parent):
         """

--- a/ddsc/core/download.py
+++ b/ddsc/core/download.py
@@ -104,7 +104,7 @@ class ProjectDownload(object):
     def check_warnings(self):
         unused_paths = self.path_filter.get_unused_paths()
         if unused_paths:
-            return 'WARNING: Path(s) not found {}.'.format(','.join(unused_paths))
+            return 'WARNING: Path(s) not found: {}.'.format(','.join(unused_paths))
         return None
 
 

--- a/ddsc/core/handover.py
+++ b/ddsc/core/handover.py
@@ -263,6 +263,7 @@ class ProjectHandover(object):
         Copy pre-existing project with name project_name to non-existing project new_project_name.
         :param project_name: str project to copy from
         :param new_project_name: str project to copy to
+        :param path_filter: PathFilter: filters what files are shared
         :return: RemoteProject new project we copied data to
         """
         temp_directory = tempfile.mkdtemp()
@@ -279,6 +280,7 @@ class ProjectHandover(object):
         Download the project with project_name to temp_directory.
         :param project_name: str name of the pre-existing project
         :param temp_directory: str path to directory we can download into
+        :param path_filter: PathFilter: filters what files are shared
         """
         self.print_func("Downloading a copy of '{}'.".format(project_name))
         downloader = ProjectDownload(self.remote_store, project_name, temp_directory, path_filter)

--- a/ddsc/core/pathfilter.py
+++ b/ddsc/core/pathfilter.py
@@ -4,7 +4,6 @@ from ddsc.core.util import FilteredProject
 
 class PathFilter(object):
     def __init__(self):
-        self.paths = []
         self.filter = IncludeAll()
         self.seen_paths = set()
 
@@ -37,7 +36,7 @@ class PathFilter(object):
         self.seen_paths = set()
 
     def get_unused_paths(self):
-        return [path for path in self.paths if path not in self.seen_paths]
+        return [path for path in self.filter.paths if path not in self.seen_paths]
 
 
 class PathFilterUtil(object):
@@ -68,6 +67,8 @@ class PathFilterUtil(object):
 
 
 class IncludeAll(object):
+    def __init__(self):
+        self.paths = []
     """
     Path filter that will include all paths.
     """
@@ -79,13 +80,13 @@ class IncludeFilter(object):
     """
     Path filter that will include paths that are parent/children/equal to include_paths.
     """
-    def __init__(self, include_paths):
-        self.include_paths = include_paths
+    def __init__(self, paths):
+        self.paths = paths
 
     def include(self, some_path):
-        if some_path in self.include_paths:
+        if some_path in self.paths:
             return True
-        for path in self.include_paths:
+        for path in self.paths:
             if PathFilterUtil.parent_child_paths(path, some_path):
                 return True
         return False
@@ -95,13 +96,13 @@ class ExcludeFilter(object):
     """
     Path filter that will exclude paths that are children/equal to include_paths.
     """
-    def __init__(self, exclude_paths):
-        self.exclude_paths = exclude_paths
+    def __init__(self, paths):
+        self.paths = paths
 
     def include(self, some_path):
-        if some_path in self.exclude_paths:
+        if some_path in self.paths:
             return False
-        for path in self.exclude_paths:
+        for path in self.paths:
             if PathFilterUtil.is_child(some_path, path):
                 return False
         return True

--- a/ddsc/core/pathfilter.py
+++ b/ddsc/core/pathfilter.py
@@ -1,0 +1,127 @@
+import os
+from ddsc.core.util import FilteredProject
+
+
+class PathFilter(object):
+    def __init__(self):
+        self.paths = []
+        self.filter = IncludeAll()
+        self.seen_paths = set()
+
+    @staticmethod
+    def create(include_paths, exclude_paths):
+        path_filter = PathFilter()
+        if include_paths and exclude_paths:
+            raise ValueError("Programming Error: Should not specify both include_path and exclude_paths")
+        if include_paths:
+            path_filter.set_include_paths(include_paths)
+        elif exclude_paths:
+            path_filter.set_exclude_paths(exclude_paths)
+        return path_filter
+
+    @staticmethod
+    def strip_trailing_slash(paths):
+        return [path.rstrip('/') for path in paths]
+
+    def set_include_paths(self, paths):
+        self.filter = IncludeFilter(PathFilter.strip_trailing_slash(paths))
+
+    def set_exclude_paths(self, paths):
+        self.filter = ExcludeFilter(PathFilter.strip_trailing_slash(paths))
+
+    def include_path(self, path):
+        self.seen_paths.add(path)
+        return self.filter.include(path)
+
+    def reset_seen_paths(self):
+        self.seen_paths = set()
+
+    def get_unused_paths(self):
+        return [path for path in self.paths if path not in self.seen_paths]
+
+
+class PathFilterUtil(object):
+    """
+    Utility methods used in building path filtering objects.
+    """
+    @staticmethod
+    def is_child(child_path, parent_path):
+        """
+        Is parent_path a parent(or grandparent) directory of child_path.
+        :param child_path: str: remote file path
+        :param parent_path: str: remote file path
+        :return: bool: True when parent_path is child_path's parent
+        """
+        parent_dir = os.path.join(parent_path, '')
+        child_dir = os.path.join(child_path, '')
+        return child_dir.startswith(parent_dir)
+
+    @staticmethod
+    def parent_child_paths(path, some_path):
+        """
+        Is path a parent of some_path or some_path is a parent of path.
+        :param path: str: remote file path
+        :param some_path: str: remote file path
+        :return: bool: True when they are parents
+        """
+        return PathFilterUtil.is_child(path, some_path) or PathFilterUtil.is_child(some_path, path)
+
+
+class IncludeAll(object):
+    """
+    Path filter that will include all paths.
+    """
+    def include(self, some_path):
+        return True
+
+
+class IncludeFilter(object):
+    """
+    Path filter that will include paths that are parent/children/equal to include_paths.
+    """
+    def __init__(self, include_paths):
+        self.include_paths = include_paths
+
+    def include(self, some_path):
+        if some_path in self.include_paths:
+            return True
+        for path in self.include_paths:
+            if PathFilterUtil.parent_child_paths(path, some_path):
+                return True
+        return False
+
+
+class ExcludeFilter(object):
+    """
+    Path filter that will exclude paths that are children/equal to include_paths.
+    """
+    def __init__(self, exclude_paths):
+        self.exclude_paths = exclude_paths
+
+    def include(self, some_path):
+        if some_path in self.exclude_paths:
+            return False
+        for path in self.exclude_paths:
+            if PathFilterUtil.is_child(some_path, path):
+                return False
+        return True
+
+
+class PathFilteredProject(object):
+    """
+    Lets visitor visit only nodes in project that are acceptable to a path_filter.
+    """
+    def __init__(self, path_filter, visitor):
+        self.path_filter = path_filter
+        self.visitor = visitor
+        self.skipped_folder_paths = set()
+        self.filtered_project = FilteredProject(self.include, visitor)
+
+    def run(self, project):
+        self.filtered_project.walk_project(project)
+
+    def include(self, item):
+        return self.path_filter.include_path(item.remote_path)
+
+
+

--- a/ddsc/core/remotestore.py
+++ b/ddsc/core/remotestore.py
@@ -67,6 +67,7 @@ class RemoteStore(object):
         """
         Add file or folder(child) to parent.
         :param parent: RemoteProject/RemoteFolder to add child to
+        :param parent_remote_path: remote_path path to this child's parent
         :param child: dict JSON data back from remote store
         """
         kind = child['kind']
@@ -80,6 +81,7 @@ class RemoteStore(object):
     def _read_folder(self, parent_remote_path, folder_json):
         """
         Create RemoteFolder and query it's children.
+        :param parent_remote_path: remote_path path to this child's parent
         :param folder_json: dict JSON data back from remote store
         :return: RemoteFolder folder we filled in
         """
@@ -92,6 +94,7 @@ class RemoteStore(object):
     def _read_file_metadata(self, parent_remote_path, file_json):
         """
         Create RemoteFile based on file_json and fetching it's hash.
+        :param parent_remote_path: remote_path path to this child's parent
         :param file_json: dict JSON data back from remote store
         :return: RemoteFile file we created from file_json
         """

--- a/ddsc/core/tests/test_pathfilter.py
+++ b/ddsc/core/tests/test_pathfilter.py
@@ -106,6 +106,7 @@ class TestPathFilteredProject(TestCase):
             '',
         ]
         self.assertEqual(set(expected), set(collector.visited_paths))
+        self.assertEqual(["stuff"], path_filter.get_unused_paths())
 
     def test_nested_dir_include_filter(self):
         path_filter = PathFilter.create(include_paths=['data/results'], exclude_paths=[])

--- a/ddsc/core/tests/test_pathfilter.py
+++ b/ddsc/core/tests/test_pathfilter.py
@@ -6,7 +6,7 @@ from ddsc.core.remotestore import RemoteProject, RemoteFolder, RemoteFile
 class TestPathFilter(TestCase):
     def test_invalid_path_setup(self):
         with self.assertRaises(ValueError):
-            PathFilter.create(include_paths=['data'], exclude_paths=['results'])
+            PathFilter(include_paths=['data'], exclude_paths=['results'])
 
 
 class TestPathFilteredProject(TestCase):
@@ -71,7 +71,7 @@ class TestPathFilteredProject(TestCase):
         folder2.add_child(file3)
 
     def test_no_filter(self):
-        path_filter = PathFilter.create(include_paths=[], exclude_paths=[])
+        path_filter = PathFilter(include_paths=[], exclude_paths=[])
         collector = ItemPathCollector()
         path_filtered_project = PathFilteredProject(path_filter, collector)
         path_filtered_project.run(self.project)
@@ -86,7 +86,7 @@ class TestPathFilteredProject(TestCase):
         self.assertEqual(set(expected), set(collector.visited_paths))
 
     def test_single_file_include_filter(self):
-        path_filter = PathFilter.create(include_paths=['data/rg45.txt'], exclude_paths=[])
+        path_filter = PathFilter(include_paths=['data/rg45.txt'], exclude_paths=[])
         collector = ItemPathCollector()
         path_filtered_project = PathFilteredProject(path_filter, collector)
         path_filtered_project.run(self.project)
@@ -98,7 +98,7 @@ class TestPathFilteredProject(TestCase):
         self.assertEqual(set(expected), set(collector.visited_paths))
 
     def test_single_dir_include_filter(self):
-        path_filter = PathFilter.create(include_paths=['stuff'], exclude_paths=[])
+        path_filter = PathFilter(include_paths=['stuff'], exclude_paths=[])
         collector = ItemPathCollector()
         path_filtered_project = PathFilteredProject(path_filter, collector)
         path_filtered_project.run(self.project)
@@ -109,7 +109,7 @@ class TestPathFilteredProject(TestCase):
         self.assertEqual(["stuff"], path_filter.get_unused_paths())
 
     def test_nested_dir_include_filter(self):
-        path_filter = PathFilter.create(include_paths=['data/results'], exclude_paths=[])
+        path_filter = PathFilter(include_paths=['data/results'], exclude_paths=[])
         collector = ItemPathCollector()
         path_filtered_project = PathFilteredProject(path_filter, collector)
         path_filtered_project.run(self.project)
@@ -123,7 +123,7 @@ class TestPathFilteredProject(TestCase):
         self.assertEqual(set(expected), set(collector.visited_paths))
 
     def test_nested_file_include_filter(self):
-        path_filter = PathFilter.create(include_paths=['data/results/results.csv'], exclude_paths=[])
+        path_filter = PathFilter(include_paths=['data/results/results.csv'], exclude_paths=[])
         collector = ItemPathCollector()
         path_filtered_project = PathFilteredProject(path_filter, collector)
         path_filtered_project.run(self.project)
@@ -136,7 +136,7 @@ class TestPathFilteredProject(TestCase):
         self.assertEqual(set(expected), set(collector.visited_paths))
 
     def test_nested_dir_exclude_filter(self):
-        path_filter = PathFilter.create(include_paths=[], exclude_paths=['data/results'])
+        path_filter = PathFilter(include_paths=[], exclude_paths=['data/results'])
         collector = ItemPathCollector()
         path_filtered_project = PathFilteredProject(path_filter, collector)
         path_filtered_project.run(self.project)

--- a/ddsc/core/tests/test_pathfilter.py
+++ b/ddsc/core/tests/test_pathfilter.py
@@ -1,0 +1,316 @@
+from unittest import TestCase
+from ddsc.core.pathfilter import PathFilter, IncludeFilter, ExcludeFilter, PathFilteredProject
+from ddsc.core.remotestore import RemoteProject, RemoteFolder, RemoteFile
+
+
+class TestPathFilter(TestCase):
+    def test_invalid_path_setup(self):
+        with self.assertRaises(ValueError):
+            PathFilter.create(include_paths=['data'], exclude_paths=['results'])
+
+
+class TestPathFilteredProject(TestCase):
+    def setUp(self):
+        project_fields = {
+            "id": "12345",
+            "kind": "dds-project",
+            "name": "mouse",
+            "description": "Mouse RNA Data",
+            "is_deleted": False
+            }
+        folder1_fields = {
+            "id": "12346",
+            "kind": "dds-folder",
+            "name": "data",
+            "is_deleted": False
+        }
+        folder2_fields = {
+            "id": "12347",
+            "kind": "dds-folder",
+            "name": "results",
+            "is_deleted": False
+        }
+        file1_fields = {
+            "id": "12348",
+            "kind": "dds-file",
+            "name": "rg45.txt",
+            "is_deleted": False,
+            "upload": {
+                "size": 100
+            }
+        }
+        file2_fields = {
+            "id": "12349",
+            "kind": "dds-file",
+            "name": "results.doc",
+            "is_deleted": False,
+            "upload": {
+                "size": 100
+            }
+        }
+        file3_fields = {
+            "id": "12310",
+            "kind": "dds-file",
+            "name": "results.csv",
+            "is_deleted": False,
+            "upload": {
+                "size": 100
+            }
+        }
+
+        self.project = RemoteProject(project_fields)
+        folder1 = RemoteFolder(folder1_fields, "")
+        self.project.add_child(folder1)
+        folder2 = RemoteFolder(folder2_fields, "data")
+        folder1.add_child(folder2)
+        file1 = RemoteFile(file1_fields, "data")
+        self.project.add_child(file1)
+        file2 = RemoteFile(file2_fields, "data/results")
+        folder2.add_child(file2)
+        file3 = RemoteFile(file3_fields, "data/results")
+        folder2.add_child(file3)
+
+    def test_no_filter(self):
+        path_filter = PathFilter.create(include_paths=[], exclude_paths=[])
+        collector = ItemPathCollector()
+        path_filtered_project = PathFilteredProject(path_filter, collector)
+        path_filtered_project.run(self.project)
+        expected = [
+            '',
+            'data',
+            'data/rg45.txt',
+            'data/results',
+            'data/results/results.doc',
+            'data/results/results.csv',
+        ]
+        self.assertEqual(set(expected), set(collector.visited_paths))
+
+    def test_single_file_include_filter(self):
+        path_filter = PathFilter.create(include_paths=['data/rg45.txt'], exclude_paths=[])
+        collector = ItemPathCollector()
+        path_filtered_project = PathFilteredProject(path_filter, collector)
+        path_filtered_project.run(self.project)
+        expected = [
+            '',
+            'data',
+            'data/rg45.txt',
+        ]
+        self.assertEqual(set(expected), set(collector.visited_paths))
+
+    def test_single_dir_include_filter(self):
+        path_filter = PathFilter.create(include_paths=['stuff'], exclude_paths=[])
+        collector = ItemPathCollector()
+        path_filtered_project = PathFilteredProject(path_filter, collector)
+        path_filtered_project.run(self.project)
+        expected = [
+            '',
+        ]
+        self.assertEqual(set(expected), set(collector.visited_paths))
+
+    def test_nested_dir_include_filter(self):
+        path_filter = PathFilter.create(include_paths=['data/results'], exclude_paths=[])
+        collector = ItemPathCollector()
+        path_filtered_project = PathFilteredProject(path_filter, collector)
+        path_filtered_project.run(self.project)
+        expected = [
+            '',
+            'data',
+            'data/results',
+            'data/results/results.doc',
+            'data/results/results.csv',
+        ]
+        self.assertEqual(set(expected), set(collector.visited_paths))
+
+    def test_nested_file_include_filter(self):
+        path_filter = PathFilter.create(include_paths=['data/results/results.csv'], exclude_paths=[])
+        collector = ItemPathCollector()
+        path_filtered_project = PathFilteredProject(path_filter, collector)
+        path_filtered_project.run(self.project)
+        expected = [
+            '',
+            'data',
+            'data/results',
+            'data/results/results.csv',
+        ]
+        self.assertEqual(set(expected), set(collector.visited_paths))
+
+    def test_nested_dir_exclude_filter(self):
+        path_filter = PathFilter.create(include_paths=[], exclude_paths=['data/results'])
+        collector = ItemPathCollector()
+        path_filtered_project = PathFilteredProject(path_filter, collector)
+        path_filtered_project.run(self.project)
+        expected = [
+            '',
+            'data',
+            'data/rg45.txt',
+        ]
+        self.assertEqual(set(expected), set(collector.visited_paths))
+
+
+class ItemPathCollector(object):
+    def __init__(self):
+        self.visited_paths = []
+
+    def visit_project(self, item):
+        self.visited_paths.append(item.remote_path)
+
+    def visit_folder(self, item, parent):
+        self.visited_paths.append(item.remote_path)
+
+    def visit_file(self, item, parent):
+        self.visited_paths.append(item.remote_path)
+
+
+class TestIncludeFilter(TestCase):
+    def check_filter(self, path_filter, yes_values, no_values):
+        for value in yes_values:
+            self.assertEqual(True, path_filter.include(value), "should be True {}".format(value))
+        for value in no_values:
+            self.assertEqual(False, path_filter.include(value), "should be False {}".format(value))
+
+    def test_include_top_level_file(self):
+        path_filter = IncludeFilter(["123.txt"])
+        yes_values = [
+            "123.txt"
+        ]
+        no_values = [
+            "data",
+            ".txt",
+            "123",
+            "data/123.txt",
+            "results/123.txt"
+        ]
+        self.check_filter(path_filter, yes_values, no_values)
+
+    def test_include_top_level_dir(self):
+        path_filter = IncludeFilter(["data"])
+        yes_values = [
+            "data",
+            "data/raw_files",
+            "data/123.txt",
+        ]
+        no_values = [
+            "123.txt"
+            ".txt",
+            "123",
+            "results/123.txt"
+            "results/data"
+        ]
+        self.check_filter(path_filter, yes_values, no_values)
+
+    def test_include_nested_dir(self):
+        path_filter = IncludeFilter(["data/raw_files"])
+        yes_values = [
+            "data",
+            "data/raw_files",
+            "data/raw_files/123.txt",
+            "data/raw_files/data",
+            "data/raw_files/one/two",
+        ]
+        no_values = [
+            "data/123.txt",
+            "some/raw_files"
+            "raw_files"
+            "raw_files/data.txt"
+        ]
+        self.check_filter(path_filter, yes_values, no_values)
+
+    def test_include_nested_file(self):
+        path_filter = IncludeFilter(["data/raw_files/mine.txt"])
+        yes_values = [
+            "data",
+            "data/raw_files",
+            "data/raw_files/mine.txt",
+        ]
+        no_values = [
+            "mine.txt",
+            "raw_files/mine.txt",
+            "dat/raw_files/mine.txt"
+            "data/raw_files/other.txt",
+        ]
+        self.check_filter(path_filter, yes_values, no_values)
+
+    def test_include_multiple(self):
+        path_filter = IncludeFilter(["data", "stuff/info.txt"])
+        yes_values = [
+            "data",
+            "data/raw_files",
+            "data/raw_files/mine.txt",
+            "stuff",
+            "stuff/info.txt"
+        ]
+        no_values = [
+            "mine.txt",
+            "raw_files/mine.txt",
+            "dat/raw_files/mine.txt"
+            "data/raw_files/other.txt",
+            "stuff/other.txt"
+        ]
+        self.check_filter(path_filter, yes_values, no_values)
+
+
+class TestExcludeFilter(TestCase):
+    def check_filter(self, path_filter, yes_values, no_values):
+        for value in yes_values:
+            self.assertEqual(True, path_filter.include(value), "should be True {}".format(value))
+        for value in no_values:
+            self.assertEqual(False, path_filter.include(value), "should be False {}".format(value))
+
+    def test_include_top_level_file(self):
+        path_filter = ExcludeFilter(["123.txt"])
+        yes_values = [
+            "data",
+            ".txt",
+            "123",
+            "data/123.txt",
+            "results/123.txt"
+        ]
+        no_values = [
+            "123.txt"
+        ]
+        self.check_filter(path_filter, yes_values, no_values)
+
+    def test_include_top_level_dir(self):
+        path_filter = ExcludeFilter(["data"])
+        yes_values = [
+            "123.txt",
+            ".txt",
+            "123",
+            "results/123.txt"
+        ]
+        no_values = [
+            "data",
+            "data/123.txt",
+            "data/something",
+            "data/something/123.txt"
+        ]
+        self.check_filter(path_filter, yes_values, no_values)
+
+    def test_nested_dir(self):
+        path_filter = ExcludeFilter(["data/results"])
+        yes_values = [
+            "data",
+            "results"
+            "results/123.txt",
+        ]
+        no_values = [
+            "data/results",
+            "data/results/123.txt"
+        ]
+        self.check_filter(path_filter, yes_values, no_values)
+
+    def test_include_multiple(self):
+        path_filter = ExcludeFilter(["data/results","test/data.txt"])
+        yes_values = [
+            "data",
+            "results"
+            "results/123.txt",
+            "test",
+            "test/data.doc"
+        ]
+        no_values = [
+            "data/results",
+            "data/results/123.txt",
+            "test/data.txt"
+        ]
+        self.check_filter(path_filter, yes_values, no_values)

--- a/ddsc/core/tests/test_remotestore.py
+++ b/ddsc/core/tests/test_remotestore.py
@@ -41,6 +41,7 @@ class TestProjectFolderFile(TestCase):
         self.assertEqual('test4', project.name)
         self.assertEqual('test4desc', project.description)
         self.assertEqual(False, project.is_deleted)
+        self.assertEqual('', project.remote_path)
 
     def test_folder_item(self):
         projects_id_children_sample_json = """
@@ -82,11 +83,12 @@ class TestProjectFolderFile(TestCase):
         }"""
         blob = json.loads(projects_id_children_sample_json)
         folder_json = blob['results'][0]
-        folder = RemoteFolder(folder_json)
+        folder = RemoteFolder(folder_json, 'tmp')
         self.assertEqual('dds-folder', folder.kind)
         self.assertEqual('cf99a8f1-aebd-4640-8854-f34d03b7511e', folder.id)
         self.assertEqual('thistest', folder.name)
         self.assertEqual(False, folder.is_deleted)
+        self.assertEqual('tmp/thistest', folder.remote_path)
 
     def test_file_item_new_version(self):
         folders_id_children_sample_json = """
@@ -146,12 +148,13 @@ class TestProjectFolderFile(TestCase):
         """
         blob = json.loads(folders_id_children_sample_json)
         file_json = blob['results'][0]
-        file = RemoteFile(file_json)
+        file = RemoteFile(file_json, '')
         self.assertEqual('dds-file', file.kind)
         self.assertEqual('3a14eac9-90f4-4667-9999-1625dd6c3d9a', file.id)
         self.assertEqual('bigWigToWig', file.name)
         self.assertEqual(False, file.is_deleted)
         self.assertEqual(1874572, file.size)
+        self.assertEqual('bigWigToWig', file.remote_path)
 
     def test_file_item(self):
         folders_id_children_sample_json = """
@@ -209,12 +212,13 @@ class TestProjectFolderFile(TestCase):
         """
         blob = json.loads(folders_id_children_sample_json)
         file_json = blob['results'][0]
-        file = RemoteFile(file_json)
+        file = RemoteFile(file_json, 'test')
         self.assertEqual('dds-file', file.kind)
         self.assertEqual('3a14eac9-90f4-4667-9999-1625dd6c3d9a', file.id)
         self.assertEqual('bigWigToWig', file.name)
         self.assertEqual(False, file.is_deleted)
         self.assertEqual(1874572, file.size)
+        self.assertEqual('test/bigWigToWig', file.remote_path)
 
 
 class TestRemoteUser(TestCase):

--- a/ddsc/ddsclient.py
+++ b/ddsc/ddsclient.py
@@ -125,7 +125,7 @@ class DownloadCommand(object):
         if not folder:
             fixed_path = replace_invalid_path_chars(project_name.replace(' ', '_'))
             folder = path_does_not_exist_or_is_empty(fixed_path)
-        path_filter = PathFilter.create(args.include_paths, args.exclude_paths)
+        path_filter = PathFilter(args.include_paths, args.exclude_paths)
         project_download = ProjectDownload(self.remote_store, project_name, folder, path_filter)
         project_download.run()
 
@@ -215,7 +215,7 @@ class HandoverCommand(object):
             new_project_name = self.get_new_project_name(project_name)
         to_user = self.remote_store.lookup_user_by_email_or_username(email, username)
         try:
-            path_filter = PathFilter.create(args.include_paths, args.exclude_paths)
+            path_filter = PathFilter(args.include_paths, args.exclude_paths)
             dest_email = self.project_handover.handover(project_name, new_project_name, to_user, force_send, path_filter)
             print("Handover message sent to " + dest_email)
         except HandoverError as ex:

--- a/ddsc/ddsclient.py
+++ b/ddsc/ddsclient.py
@@ -9,6 +9,7 @@ from ddsc.core.upload import ProjectUpload
 from ddsc.cmdparser import CommandParser, path_does_not_exist_or_is_empty, replace_invalid_path_chars
 from ddsc.core.download import ProjectDownload
 from ddsc.core.util import ProjectFilenameList, verify_terminal_encoding
+from ddsc.core.pathfilter import PathFilter
 
 NO_PROJECTS_FOUND_MESSAGE = 'No projects found.'
 
@@ -124,7 +125,8 @@ class DownloadCommand(object):
         if not folder:
             fixed_path = replace_invalid_path_chars(project_name.replace(' ', '_'))
             folder = path_does_not_exist_or_is_empty(fixed_path)
-        project_download = ProjectDownload(self.remote_store, project_name, folder)
+        path_filter = PathFilter.create(args.include_paths, args.exclude_paths)
+        project_download = ProjectDownload(self.remote_store, project_name, folder, path_filter)
         project_download.run()
 
 
@@ -213,7 +215,8 @@ class HandoverCommand(object):
             new_project_name = self.get_new_project_name(project_name)
         to_user = self.remote_store.lookup_user_by_email_or_username(email, username)
         try:
-            dest_email = self.project_handover.handover(project_name, new_project_name, to_user, force_send)
+            path_filter = PathFilter.create(args.include_paths, args.exclude_paths)
+            dest_email = self.project_handover.handover(project_name, new_project_name, to_user, force_send, path_filter)
             print("Handover message sent to " + dest_email)
         except HandoverError as ex:
             if ex.warning:


### PR DESCRIPTION
Adds two new mutually exclusive parameters to download and handover commands.
Adds remote_path to RemoteProject, RemoteFolder, and RemoteItem to simplify checking paths.
Created PathFilter to hold values from `--include` or `--exclude` and determine if a file should be added to download/handover.
Created PathFilteredProject which applies PathFilter to ProjectWalker via new FilteredProject class.

Fixes #73.