### PR TITLE
Add list_auth_roles command to view project permission types

### DIFF
--- a/ddsc/cmdparser.py
+++ b/ddsc/cmdparser.py
@@ -293,7 +293,7 @@ class CommandParser(object):
     def register_delete_command(self, delete_func):
         """
         Add 'delete' command delete a project from the remote store.
-        :param list_func: function: run when user choses this option.
+        :param delete_func: function: run when user choses this option.
         """
         description = "Permanently delete a project."
         delete_parser = self.subparsers.add_parser('delete', description=description)
@@ -303,8 +303,8 @@ class CommandParser(object):
 
     def register_list_auth_roles_command(self, list_auth_roles_func):
         """
-        Add 'delete' command delete a project from the remote store.
-        :param list_func: function: run when user choses this option.
+        Add 'list_auth_roles' command to list project authorization roles that can be used with add_user.
+        :param list_auth_roles_func: function: run when user choses this option.
         """
         description = "List authorization roles for use with add_user command."
         delete_parser = self.subparsers.add_parser('list_auth_roles', description=description)

--- a/ddsc/cmdparser.py
+++ b/ddsc/cmdparser.py
@@ -226,7 +226,8 @@ class CommandParser(object):
         when chosen.
         :param add_user_func: func Called when this option is chosen: upload_func(project_name, user_full_name, auth_role).
         """
-        description = "Gives user permission to access a remote project."
+        description = "Gives user permission to access a remote project. " \
+            "See command list_auth_roles for auth_role values."
         add_user_parser = self.subparsers.add_parser('add_user', description=description)
         add_project_name_arg(add_user_parser, help_text="Name of the project to add a user to.")
         user_or_email = add_user_parser.add_mutually_exclusive_group(required=True)
@@ -298,6 +299,15 @@ class CommandParser(object):
         add_project_name_arg(delete_parser, help_text="Name of the project to delete.")
         _add_force_arg(delete_parser, "Do not prompt before deleting.")
         delete_parser.set_defaults(func=delete_func)
+
+    def register_list_auth_roles_command(self, list_auth_roles_func):
+        """
+        Add 'delete' command delete a project from the remote store.
+        :param list_func: function: run when user choses this option.
+        """
+        description = "List authorization roles for use with add_user command."
+        delete_parser = self.subparsers.add_parser('list_auth_roles', description=description)
+        delete_parser.set_defaults(func=list_auth_roles_func)
 
     def run_command(self, args):
         """

--- a/ddsc/cmdparser.py
+++ b/ddsc/cmdparser.py
@@ -152,11 +152,13 @@ def _add_auth_role_arg(arg_parser):
     Adds optional auth_role parameter to a parser.
     :param arg_parser: ArgumentParser parser to add this argument to.
     """
+    help_text = "Specifies which project permissions to give to the user. Example: 'project_admin'. "
+    help_text += "See command list_auth_roles for AuthRole values."
     arg_parser.add_argument("--auth_role",
                             metavar='AuthRole',
                             type=to_unicode,
                             dest='auth_role',
-                            help="Specifies authorization role for the user ('project_admin').",
+                            help=help_text,
                             default='project_admin')
 
 def _add_copy_project_arg(arg_parser):
@@ -226,8 +228,7 @@ class CommandParser(object):
         when chosen.
         :param add_user_func: func Called when this option is chosen: upload_func(project_name, user_full_name, auth_role).
         """
-        description = "Gives user permission to access a remote project. " \
-            "See command list_auth_roles for auth_role values."
+        description = "Gives user permission to access a remote project."
         add_user_parser = self.subparsers.add_parser('add_user', description=description)
         add_project_name_arg(add_user_parser, help_text="Name of the project to add a user to.")
         user_or_email = add_user_parser.add_mutually_exclusive_group(required=True)

--- a/ddsc/cmdparser.py
+++ b/ddsc/cmdparser.py
@@ -307,8 +307,8 @@ class CommandParser(object):
         :param list_auth_roles_func: function: run when user choses this option.
         """
         description = "List authorization roles for use with add_user command."
-        delete_parser = self.subparsers.add_parser('list_auth_roles', description=description)
-        delete_parser.set_defaults(func=list_auth_roles_func)
+        list_auth_roles_parser = self.subparsers.add_parser('list_auth_roles', description=description)
+        list_auth_roles_parser.set_defaults(func=list_auth_roles_func)
 
     def run_command(self, args):
         """

--- a/ddsc/core/ddsapi.py
+++ b/ddsc/core/ddsapi.py
@@ -531,4 +531,4 @@ class DataServiceApi(object):
         :param context: str which roles do we want 'project' or 'system'
         :return: requests.Response containing the successful result
         """
-        return self._get("/auth_roles", context)
+        return self._get("/auth_roles", {"context": context}, content_type=ContentType.form)

--- a/ddsc/core/ddsapi.py
+++ b/ddsc/core/ddsapi.py
@@ -524,3 +524,11 @@ class DataServiceApi(object):
         :return: requests.Response containing the successful result
         """
         return self._delete("/projects/" + project_id, {})
+
+    def get_auth_roles(self, context):
+        """
+        Send GET request to get list of auth_roles for a context.
+        :param context: str which roles do we want 'project' or 'system'
+        :return: requests.Response containing the successful result
+        """
+        return self._get("/auth_roles", context)

--- a/ddsc/core/remotestore.py
+++ b/ddsc/core/remotestore.py
@@ -253,6 +253,31 @@ class RemoteStore(object):
         else:
             raise ValueError("No project named '{}' found.\n".format(project_name))
 
+    def get_active_auth_roles(self, context):
+        """
+        Retrieve non-deprecated authorization roles based on a context.
+        Context should be RemoteAuthRole.PROJECT_CONTEXT or RemoteAuthRole.SYSTEM_CONTEXT.
+        :param context: str: context for which auth roles to retrieve
+        :return: [RemoteAuthRole]: list of active auth_role objects
+        """
+        response = self.data_service.get_auth_roles(context).json()
+        return self.get_active_auth_roles_from_json(response)
+
+    @staticmethod
+    def get_active_auth_roles_from_json(json_data):
+        """
+        Given a json blob response containing a list of authorization roles return the active ones
+        in an array of RemoteAuthRole objects.
+        :param json_data: list of dictionaries - data from dds in auth_role format
+        :return: [RemoteAuthRole] list of active auth_role objects
+        """
+        result = []
+        for auth_role_properties in json_data['results']:
+            auth_role = RemoteAuthRole(auth_role_properties)
+            if not auth_role.is_deprecated:
+                result.append(auth_role)
+        return result
+
 
 class RemoteProject(object):
     """
@@ -370,3 +395,23 @@ class RemoteUser(object):
 
     def __str__(self):
         return 'id:{} username:{} full_name:{}'.format(self.id, self.username, self.full_name)
+
+
+class RemoteAuthRole(object):
+    PROJECT_CONTEXT = "project"
+    SYSTEM_CONTEXT = "system"
+    """
+    Permissions a user can be given on a project.
+    """
+    def __init__(self, json_data):
+        """
+        Set properties based on json_data.
+        :param json_data: dict JSON data containing auth_role info
+        """
+        self.id = json_data['id']
+        self.name = json_data['name']
+        self.description = json_data['description']
+        self.is_deprecated = json_data['is_deprecated']
+
+    def __str__(self):
+        return 'id:{} name:{} description:{}'.format(self.id, self.name, self.description)

--- a/ddsc/ddsclient.py
+++ b/ddsc/ddsclient.py
@@ -4,7 +4,7 @@ import sys
 import datetime
 import pipes
 from ddsc.core.handover import ProjectHandover, HandoverError
-from ddsc.core.remotestore import RemoteStore
+from ddsc.core.remotestore import RemoteStore, RemoteAuthRole
 from ddsc.core.upload import ProjectUpload
 from ddsc.cmdparser import CommandParser, path_does_not_exist_or_is_empty, replace_invalid_path_chars
 from ddsc.core.download import ProjectDownload
@@ -45,7 +45,7 @@ class DDSClient(object):
         parser.register_mail_draft_command(self._setup_run_command(MailDraftCommand))
         parser.register_handover_command(self._setup_run_command(HandoverCommand))
         parser.register_delete_command(self._setup_run_command(DeleteCommand))
-
+        parser.register_list_auth_roles_command(self._setup_run_command(ListAuthRolesCommand))
         return parser
 
     def _setup_run_command(self, command_constructor):
@@ -295,6 +295,30 @@ class DeleteCommand(object):
                 if not boolean_input_prompt(delete_prompt):
                     return
             self.remote_store.delete_project_by_name(args.project_name)
+
+
+class ListAuthRolesCommand(object):
+    """
+    List available auth roles for a project.
+    """
+    def __init__(self, config):
+        """
+        Pass in the config who can create a remote_store so we can access the remote data.
+        :param config: Config global configuration for use with this command.
+        """
+        self.remote_store = RemoteStore(config)
+
+    def run(self, args):
+        """
+        Prints out non deprecated auth roles.
+        :param args Namespace arguments parsed from the command line
+        """
+        auth_roles = self.remote_store.get_active_auth_roles(RemoteAuthRole.PROJECT_CONTEXT)
+        if auth_roles:
+            for auth_role in auth_roles:
+                print(auth_role.id, "-", auth_role.description)
+        else:
+            print("No authorization roles found.")
 
 
 def boolean_input_prompt(message):

--- a/ddsc/ddsclient.py
+++ b/ddsc/ddsclient.py
@@ -299,7 +299,8 @@ class DeleteCommand(object):
 
 class ListAuthRolesCommand(object):
     """
-    List available auth roles for a project.
+    List available auth roles for a project. Intentionally excludes system-type auth roles.
+    System-type auth roles are accepted by DukeDS add_user API endpoint but are non-functional.
     """
     def __init__(self, config):
         """
@@ -310,7 +311,7 @@ class ListAuthRolesCommand(object):
 
     def run(self, args):
         """
-        Prints out non deprecated auth roles.
+        Prints out non deprecated project-type auth roles.
         :param args Namespace arguments parsed from the command line
         """
         auth_roles = self.remote_store.get_active_auth_roles(RemoteAuthRole.PROJECT_CONTEXT)


### PR DESCRIPTION
Adding `list_auth_roles` to ddsclient to display the current project level auth_roles from DukeDS.
This will allow a user to determine which values are valid for the `--auth_role` argument to the`add_user` command.

Usage: 
```ddsclient list_auth_roles```

Current Output:
```
project_admin - Can update project details, delete project, manage project level permissions and perform all file operations
project_viewer - Can only view project and file meta-data
file_downloader - Can download files
file_editor - Can view download create update and delete files
file_uploader - Can update files
```

Fixes #69.