### PR TITLE
remove_user command

### DIFF
--- a/ddsc/cmdparser.py
+++ b/ddsc/cmdparser.py
@@ -274,12 +274,12 @@ class CommandParser(object):
         :param remove_user_func: func Called when this option is chosen: remove_user_func(project_name, user_full_name).
         """
         description = "Removes user permission to access a remote project."
-        add_user_parser = self.subparsers.add_parser('remove_user', description=description)
-        add_project_name_arg(add_user_parser, help_text="Name of the project to remove a user from.")
-        user_or_email = add_user_parser.add_mutually_exclusive_group(required=True)
+        remove_user_parser = self.subparsers.add_parser('remove_user', description=description)
+        add_project_name_arg(remove_user_parser, help_text="Name of the project to remove a user from.")
+        user_or_email = remove_user_parser.add_mutually_exclusive_group(required=True)
         add_user_arg(user_or_email)
         add_email_arg(user_or_email)
-        add_user_parser.set_defaults(func=remove_user_func)
+        remove_user_parser.set_defaults(func=remove_user_func)
 
     def register_download_command(self, download_func):
         """

--- a/ddsc/cmdparser.py
+++ b/ddsc/cmdparser.py
@@ -131,7 +131,7 @@ def add_user_arg(arg_parser):
                             metavar='Username',
                             type=to_unicode,
                             dest='username',
-                            help="Username(NetID) to give permissions. "
+                            help="Username(NetID) to update permissions on. "
                                  "You must specify either --email or this flag.")
 
 
@@ -144,7 +144,7 @@ def add_email_arg(arg_parser):
                             metavar='UserEmail',
                             type=to_unicode,
                             dest='email',
-                            help="Email of the person you want to give permission."
+                            help="Email of the person you want to update permissions on."
                                  " You must specify either --user or this flag.")
 
 
@@ -267,6 +267,19 @@ class CommandParser(object):
         add_email_arg(user_or_email)
         _add_auth_role_arg(add_user_parser)
         add_user_parser.set_defaults(func=add_user_func)
+
+    def register_remove_user_command(self, remove_user_func):
+        """
+        Add the remove_user command to the parser and call remove_user_func(project_name, user_full_name) when chosen.
+        :param remove_user_func: func Called when this option is chosen: remove_user_func(project_name, user_full_name).
+        """
+        description = "Removes user permission to access a remote project."
+        add_user_parser = self.subparsers.add_parser('remove_user', description=description)
+        add_project_name_arg(add_user_parser, help_text="Name of the project to remove a user from.")
+        user_or_email = add_user_parser.add_mutually_exclusive_group(required=True)
+        add_user_arg(user_or_email)
+        add_email_arg(user_or_email)
+        add_user_parser.set_defaults(func=remove_user_func)
 
     def register_download_command(self, download_func):
         """

--- a/ddsc/core/remotestore.py
+++ b/ddsc/core/remotestore.py
@@ -19,15 +19,18 @@ class RemoteStore(object):
         auth = DataServiceAuth(self.config)
         self.data_service = DataServiceApi(auth, self.config.url)
 
-    def fetch_remote_project(self, project_name, must_exist=False):
+    def fetch_remote_project(self, project_name, must_exist=False, include_children=True):
         """
-        Retrieve the project via project_name
+        Retrieve the project via project_name.
         :param project_name: str name of the project to try and download
-        :return: RemoteProject project requested or None if not found
+        :param must_exist: should we error if the project doesn't exist
+        :param include_children: should we read children(folders/files)
+        :return: RemoteProject project requested or None if not found(and must_exist=False)
         """
         project = self._get_my_project(project_name)
         if project:
-            self._add_project_children(project)
+            if include_children:
+                self._add_project_children(project)
         else:
             if must_exist:
                 raise ValueError(u'There is no project with the name {}'.format(project_name).encode('utf-8'))

--- a/integration_test.sh
+++ b/integration_test.sh
@@ -36,6 +36,7 @@ export PROJ2="python3$PROJECT_PREFIX"
 echo "test upload $PROJ2"
 python3 -m ddsc upload -p $PROJ2 ddsc/tests
 python3 -m ddsc add_user -p $PROJ2 --user $USERNAME
+python3 -m ddsc remove_user -p $PROJ2 --user $USERNAME
 
 echo "test download $PROJ2"
 rm -rf /tmp/$PROJ2


### PR DESCRIPTION
Fixes #77

Adds `remove_user` command.
Functionality was already there from previous changes just added a command line option to use it.

Improves how long `add_user` takes by not downloading all the metadata for folders and files.
This data is not necessary for `add_user` or `remove_user`.