### PR TITLE
Fast proj api

### DIFF
--- a/api_test.py
+++ b/api_test.py
@@ -18,10 +18,16 @@ from ddsc.config import create_config
 from ddsc.core.remotestore import RemoteStore
 
 
+def convertNoneStr(arg):
+    if arg == 'None':
+        return None
+    return arg
+
 
 def main(args=None):
     if args is None:
         args = sys.argv[1:]
+    args = [convertNoneStr(arg) for arg in args]
     config = create_config()
     remote_store = RemoteStore(config)
     ds = remote_store.data_service
@@ -37,7 +43,6 @@ def main(args=None):
         f = getattr(ds, args[0])
         ret = f.__call__(*args[1:])
         result = ret.json()
-
         print(yaml.safe_dump(result))
 
 

--- a/ddsc/core/ddsapi.py
+++ b/ddsc/core/ddsapi.py
@@ -281,7 +281,7 @@ class DataServiceApi(object):
         """
         Send GET to /projects/{project_id} filtering by a name.
         :param project_id: str uuid of the project
-        :param name_contains: str name to filter folders by
+        :param name_contains: str name to filter folders by (if not None this method works recursively)
         :return: requests.Response containing the successful result
         """
         return self._get_children('projects', project_id, name_contains)
@@ -290,7 +290,7 @@ class DataServiceApi(object):
         """
         Send GET to /folders/{folder_id} filtering by a name.
         :param folder_id: str uuid of the folder
-        :param name_contains: str name to filter children by
+        :param name_contains: str name to filter children by (if not None this method works recursively)
         :return: requests.Response containing the successful result
         """
         return self._get_children('folders', folder_id, name_contains)
@@ -300,13 +300,13 @@ class DataServiceApi(object):
         Send GET message to /<parent_name>/<parent_id>/children to fetch info about children(files and folders)
         :param parent_name: str 'projects' or 'folders'
         :param parent_id: str uuid of project or folder
-        :param name_contains: name filtering
+        :param name_contains: name filtering (if not None this method works recursively)
         :return: requests.Response containing the successful result
         """
-        data = {
-            'name_contains': name_contains
-        }
-        return self._get("/" + parent_name + "/" + parent_id + "/children", data)
+        data = {}
+        if not name_contains is None:
+            data['name_contains'] = name_contains
+        return self._get("/" + parent_name + "/" + parent_id + "/children", data, content_type=ContentType.form)
 
     def create_upload(self, project_id, filename, content_type, size,
                       hash_value, hash_alg):

--- a/ddsc/core/remotestore.py
+++ b/ddsc/core/remotestore.py
@@ -322,9 +322,14 @@ class RemoteFile(object):
         self.name = json_data['name']
         self.path = self.name # for compatibilty with ProgressPrinter
         self.is_deleted = json_data['is_deleted']
-        self.size = RemoteFile.get_upload_from_json(json_data)['size']
+        upload = RemoteFile.get_upload_from_json(json_data)
+        self.size = upload['size']
         self.file_hash = None
         self.hash_alg = None
+        hash_data = upload.get('hash')
+        if hash_data:
+            self.file_hash = hash_data.get('value')
+            self.hash_alg = hash_data.get('algorithm')
         self.remote_path = os.path.join(parent_remote_path, self.name)
 
     def set_hash(self, file_hash, hash_alg):

--- a/ddsc/core/tests/test_remotestore.py
+++ b/ddsc/core/tests/test_remotestore.py
@@ -447,6 +447,7 @@ class TestRemoteProjectChildren(TestCase):
         self.assertEqual(folder_id, tree[0].id)
         self.assertEqual(1, len(tree[0].children))
         self.assertEqual(file_id, tree[0].children[0].id)
+        self.assertEqual('3664d6f3812dbb0d80302ef990b96b51', tree[0].children[0].file_hash)
 
     def assert_field_values(self, items, field_name, expected_values):
         values = [item[field_name] for item in items]
@@ -485,13 +486,16 @@ class TestRemoteProjectChildren(TestCase):
                         'upload':
                             {'id': 'ecd507c4-8f04-404d-acef-0ced912e4cdf',
                              'size': 10,
-                             'hash':
-                                 {'algorithm': 'md5', 'value': '240ad484da9838ab138a1a6ef864753b'}},
+                             'hash': None,
+                            },
                         'parent': {'id': project_id, 'kind': 'dds-project'}}]
 
         remote_children = RemoteProjectChildren(project_id, sample_data)
         tree = remote_children.get_tree()
         self.assertEqual(3, len(tree))
         self.assertEqual(file1_id, tree[0].id)
+        self.assertEqual('b9dea26997ca089d9f20e372c50565e8', tree[0].file_hash)
         self.assertEqual(file2_id, tree[1].id)
+        self.assertEqual('99003d4d61ca0f5367e5d88a24db7812', tree[1].file_hash)
         self.assertEqual(file3_id, tree[2].id)
+        self.assertEqual(None, tree[2].file_hash)


### PR DESCRIPTION
**GOAL** 
Speed up how long it takes to retrieve the metadata about folders and files for a remote project.
When re-uploading a project with few file changes but containing many files/folders takes quite a while fetching remote folder/file metadata. This also effects downloading.

**SOLUTION**
Use DukeDS API recursive children option for a project.
This works via a unique feature of their API where specifying contains='' for children endpoints triggers a recursive search mode. More details here: https://github.com/Duke-Translational-Bioinformatics/duke-data-service/issues/671.

**CHANGES** 
Created RemoteProjectChildren class to parse list of files found in recursive project listing and create RemoteFiles/RemoteFolders. This works by iterating the list of files/folders looking for items based on their parent.
Changed api_test.py to allow passing 'None' on command line to test the recursive/non-recursive functionality of the DukeDS children API.

**RESULTS**
Comparing uploading a project with no file modifications before and after this change.
```
PROJECT CONTENT   BEFORE        AFTER
1 dir 16 files    6-7 seconds   2-3 seconds   
8 dir 73 files    25-26 seconds 2-4 seconds   
```