### PR TITLE
enable http connection pooling

### DIFF
--- a/ddsc/core/fileuploader.py
+++ b/ddsc/core/fileuploader.py
@@ -3,6 +3,7 @@ Objects to upload a number of chunks from a file to a remote store as part of an
 """
 
 import math
+import requests
 from multiprocessing import Process, Queue
 from ddsc.core.localstore import HashUtil
 from ddsc.core.ddsapi import DataServiceAuth, DataServiceApi
@@ -244,7 +245,7 @@ def upload_async(data_service_auth_data, config, upload_id,
     """
     auth = DataServiceAuth(config)
     auth.set_auth_data(data_service_auth_data)
-    data_service = DataServiceApi(auth, config.url)
+    data_service = DataServiceApi(auth, config.url, requests.Session())
     sender = ChunkSender(data_service, upload_id, filename, config.upload_bytes_per_chunk, index, num_chunks_to_send, progress_queue)
     error_msg = sender.send()
     if error_msg:

--- a/ddsc/core/remotestore.py
+++ b/ddsc/core/remotestore.py
@@ -1,4 +1,5 @@
 import os
+import requests
 from ddsc.core.ddsapi import DataServiceApi, DataServiceError, DataServiceAuth
 from ddsc.core.util import KindType
 
@@ -17,7 +18,7 @@ class RemoteStore(object):
         """
         self.config = config
         auth = DataServiceAuth(self.config)
-        self.data_service = DataServiceApi(auth, self.config.url)
+        self.data_service = DataServiceApi(auth, self.config.url, requests.Session())
 
     def fetch_remote_project(self, project_name, must_exist=False, include_children=True):
         """


### PR DESCRIPTION
Turning on HTTP persistent connection for both main and background processes.
This is supported in requests by creating a Session()
http://docs.python-requests.org/en/master/user/advanced/
This will help some with issue #80. 

Intentionally not using Session for external actions(Swift) as using it slowed them down a little bit.