### PR TITLE
Adds User agent to header

### DIFF
--- a/ddsc/core/ddsapi.py
+++ b/ddsc/core/ddsapi.py
@@ -3,6 +3,7 @@ import json
 import requests
 import time
 from ddsc.config import LOCAL_CONFIG_FILENAME
+from ddsc.versioncheck import APP_NAME, get_internal_version_str
 
 AUTH_TOKEN_CLOCK_SKEW_MAX = 5 * 60  # 5 minutes
 SETUP_GUIDE_URL = "https://github.com/Duke-GCB/DukeDSClient/blob/master/docs/GettingAgentAndUserKeys.md"
@@ -158,6 +159,7 @@ class DataServiceApi(object):
         self.auth = auth
         self.base_url = url
         self.http = http
+        self.version_str = '{}/{}'.format(APP_NAME, get_internal_version_str())
 
     def _url_parts(self, url_suffix, data, content_type):
         """
@@ -173,6 +175,7 @@ class DataServiceApi(object):
             send_data = json.dumps(data)
         headers = {
             'Content-Type': content_type,
+            'User-Agent': self.version_str,
         }
         if self.auth:
             headers['Authorization'] = self.auth.get_auth()

--- a/ddsc/core/ddsapi.py
+++ b/ddsc/core/ddsapi.py
@@ -21,8 +21,16 @@ Try upgrading ddsclient: pip install --upgrade DukeDSClient
 """
 
 DEFAULT_RESULTS_PER_PAGE = 100
-
 requests_session = requests.Session()
+
+
+def get_user_agent_str():
+    """
+    Returns the user agent: DukeDSClient/<versigon>
+    :return: str: user agent value
+    """
+    return '{}/{}'.format(APP_NAME, get_internal_version_str())
+
 
 class ContentType(object):
     """
@@ -44,6 +52,7 @@ class DataServiceAuth(object):
         self.config = config
         self._auth = self.config.auth
         self._expires = None
+        self.user_agent_str = get_user_agent_str()
 
     def get_auth(self):
         """
@@ -64,6 +73,7 @@ class DataServiceAuth(object):
         # Intentionally doing this manually so we don't have a chicken and egg problem with DataServiceApi.
         headers = {
             'Content-Type': ContentType.json,
+            'User-Agent': self.user_agent_str,
         }
         data = {
             "agent_key": self.config.agent_key,
@@ -159,7 +169,7 @@ class DataServiceApi(object):
         self.auth = auth
         self.base_url = url
         self.http = http
-        self.version_str = '{}/{}'.format(APP_NAME, get_internal_version_str())
+        self.user_agent_str = get_user_agent_str()
 
     def _url_parts(self, url_suffix, data, content_type):
         """
@@ -175,7 +185,7 @@ class DataServiceApi(object):
             send_data = json.dumps(data)
         headers = {
             'Content-Type': content_type,
-            'User-Agent': self.version_str,
+            'User-Agent': self.user_agent_str,
         }
         if self.auth:
             headers['Authorization'] = self.auth.get_auth()

--- a/ddsc/core/tests/test_ddsapi.py
+++ b/ddsc/core/tests/test_ddsapi.py
@@ -56,7 +56,8 @@ class TestDataServiceApi(TestCase):
         first_param = call_args[0][0]
         self.assertEqual('something.com/v1/users', first_param)
         dict_param = call_args[1]
-        self.assertEqual({'Content-Type': 'application/json'}, dict_param['headers'])
+        self.assertEqual('application/json', dict_param['headers']['Content-Type'])
+        self.assertIn("DukeDSClient/", dict_param['headers']['User-Agent'])
         self.assertIn('"per_page": 100', dict_param['params'])
 
     def test_get_collection_two_pages(self):
@@ -79,14 +80,16 @@ class TestDataServiceApi(TestCase):
         first_param = call_args[0][0]
         self.assertEqual('something.com/v1/projects', first_param)
         dict_param = call_args[1]
-        self.assertEqual({'Content-Type': 'application/json'}, dict_param['headers'])
+        self.assertEqual('application/json', dict_param['headers']['Content-Type'])
+        self.assertIn("DukeDSClient/", dict_param['headers']['User-Agent'])
         self.assertIn('"per_page": 100', dict_param['params'])
         # Check second request
         call_args = call_args_list[1]
         first_param = call_args[0][0]
         self.assertEqual('something.com/v1/projects', first_param)
         dict_param = call_args[1]
-        self.assertEqual({'Content-Type': 'application/json'}, dict_param['headers'])
+        self.assertEqual('application/json', dict_param['headers']['Content-Type'])
+        self.assertIn("DukeDSClient/", dict_param['headers']['User-Agent'])
         self.assertIn('"per_page": 100', dict_param['params'])
         self.assertIn('"page": 2', dict_param['params'])
 
@@ -113,14 +116,16 @@ class TestDataServiceApi(TestCase):
         first_param = call_args[0][0]
         self.assertEqual('something.com/v1/uploads', first_param)
         dict_param = call_args[1]
-        self.assertEqual({'Content-Type': 'application/json'}, dict_param['headers'])
+        self.assertEqual('application/json', dict_param['headers']['Content-Type'])
+        self.assertIn("DukeDSClient/", dict_param['headers']['User-Agent'])
         self.assertIn('"per_page": 100', dict_param['params'])
         # Check second request
         call_args = call_args_list[1]
         first_param = call_args[0][0]
         self.assertEqual('something.com/v1/uploads', first_param)
         dict_param = call_args[1]
-        self.assertEqual({'Content-Type': 'application/json'}, dict_param['headers'])
+        self.assertEqual('application/json', dict_param['headers']['Content-Type'])
+        self.assertIn("DukeDSClient/", dict_param['headers']['User-Agent'])
         self.assertIn('"per_page": 100', dict_param['params'])
         self.assertIn('"page": 2', dict_param['params'])
         # Check third request
@@ -128,7 +133,8 @@ class TestDataServiceApi(TestCase):
         first_param = call_args[0][0]
         self.assertEqual('something.com/v1/uploads', first_param)
         dict_param = call_args[1]
-        self.assertEqual({'Content-Type': 'application/json'}, dict_param['headers'])
+        self.assertEqual('application/json', dict_param['headers']['Content-Type'])
+        self.assertIn("DukeDSClient/", dict_param['headers']['User-Agent'])
         self.assertIn('"per_page": 100', dict_param['params'])
         self.assertIn('"page": 3', dict_param['params'])
 

--- a/ddsc/versioncheck.py
+++ b/ddsc/versioncheck.py
@@ -35,8 +35,15 @@ def get_internal_version():
     """
     Returns internal version info.
     """
-    version_str = pkg_resources.get_distribution(APP_NAME).version
+    version_str = get_internal_version_str()
     return _parse_version_str(version_str)
+
+
+def get_internal_version_str():
+    """
+    Returns internal version string.
+    """
+    return pkg_resources.get_distribution(APP_NAME).version
 
 
 def _parse_version_str(version_str):


### PR DESCRIPTION
Sends  `User-Agent: DukeDSClient/<version>` in header for requests to DukeDS API.
This will help tracking down versions that have breaking API changes.