### PR TITLE
Gemnasium monitoring for modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 # DukeDSClient
 Command line tool to upload/manage project on the [duke-data-service](https://github.com/Duke-Translational-Bioinformatics/duke-data-service).
+
 [![Build Status](https://travis-ci.org/Duke-GCB/DukeDSClient.svg?branch=master)](https://travis-ci.org/Duke-GCB/DukeDSClient)
 [![Coverage Status](https://coveralls.io/repos/github/Duke-GCB/DukeDSClient/badge.svg?branch=coveralls)](https://coveralls.io/github/Duke-GCB/DukeDSClient?branch=coveralls)
+[![Dependency Status](https://gemnasium.com/badges/github.com/Duke-GCB/DukeDSClient.svg)](https://gemnasium.com/github.com/Duke-GCB/DukeDSClient)
+
 
 # Requirements
 - [python](https://www.python.org/) - version 2.7+ with a functional ssl module. 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-requests==2.9.1
-PyYAML==3.11
+requests==2.13.0
+PyYAML==3.12


### PR DESCRIPTION
Added DukeDSClient to Gemnasium to monitor required dependencies for vulnerabilities.
URL: https://gemnasium.com/github.com/Duke-GCB/DukeDSClient/
Gemnasium sends out emails when a dependency has a vulerability so we will know to upgrade.
Added the badge to the README.
Updated the dependencies to the latest version.