### PR TITLE
Allow for lowercase utf in encoding check

### DIFF
--- a/ddsc/cmdparser.py
+++ b/ddsc/cmdparser.py
@@ -4,6 +4,7 @@ Command line parser for the application.
 import os
 import argparse
 import six
+from builtins import str
 
 
 INVALID_PATH_CHARS = (':', '/', '\\')
@@ -26,7 +27,7 @@ def to_unicode(s):
     :param s: string to convert to unicode
     :return: unicode string for argument
     """
-    return s if six.PY3 else unicode(s, 'utf-8')
+    return s if six.PY3 else str(s, 'utf-8')
 
 
 def add_project_name_arg(arg_parser, required=True, help_text="Name of the remote project to manage."):

--- a/ddsc/cmdparser.py
+++ b/ddsc/cmdparser.py
@@ -3,7 +3,7 @@ Command line parser for the application.
 """
 import os
 import argparse
-from builtins import str
+import six
 
 
 INVALID_PATH_CHARS = (':', '/', '\\')
@@ -26,7 +26,7 @@ def to_unicode(s):
     :param s: string to convert to unicode
     :return: unicode string for argument
     """
-    return str(s)
+    return s if six.PY3 else unicode(s, 'utf-8')
 
 
 def add_project_name_arg(arg_parser, required=True, help_text="Name of the remote project to manage."):

--- a/ddsc/core/tests/test_util.py
+++ b/ddsc/core/tests/test_util.py
@@ -1,0 +1,24 @@
+from unittest import TestCase
+
+from ddsc.core.util import verify_terminal_encoding
+
+
+class TestUtil(TestCase):
+
+    def test_verify_terminal_encoding_upper(self):
+        verify_terminal_encoding('UTF')
+
+    def test_verify_terminal_encoding_lower(self):
+        verify_terminal_encoding('utf')
+
+    def test_verify_terminal_encoding_ascii_raises(self):
+        with self.assertRaises(ValueError):
+            verify_terminal_encoding('ascii')
+
+    def test_verify_terminal_encoding_empty_raises(self):
+        with self.assertRaises(ValueError):
+            verify_terminal_encoding('')
+
+    def test_verify_terminal_encoding_none_raises(self):
+        with self.assertRaises(ValueError):
+            verify_terminal_encoding(None)

--- a/ddsc/core/util.py
+++ b/ddsc/core/util.py
@@ -232,9 +232,9 @@ def wait_for_processes(processes, size, progress_queue, watcher, item):
 
 def verify_terminal_encoding(encoding):
     """
-    Raises ValueError with error message when terminal encoding is not Unicode(contains UTF).
+    Raises ValueError with error message when terminal encoding is not Unicode(contains UTF ignoring case).
     :param encoding: str: encoding we want to check
     """
     encoding = encoding or ''
-    if not ("UTF" in encoding):
+    if not ("UTF" in encoding.upper()):
         raise ValueError(TERMINAL_ENCODING_NOT_UTF_ERROR)


### PR DESCRIPTION
Changes in python3.6 on windows modify the way the PYTHONIOENCODING works.
There are three different flags introduced for IOENCODING now and the PYTHONIOENCODING value is no longer returned for stdout.encoding.
The returned value seems is always lowercase "utf-8".
Now we ignore case when checking the encoding for UTF.

Fixes #112