### PR TITLE
Check config perm

### DIFF
--- a/ddsc/__main__.py
+++ b/ddsc/__main__.py
@@ -1,33 +1,20 @@
 """Duke data service command line project management utility."""
 import sys
-from ddsc.config import create_config
 from ddsc.ddsclient import DDSClient
-
-
-def print_exception_and_exit(ex):
-    """
-    Print out error message and exit
-    :param ex: exception that was raised
-    """
-    sys.stderr.write(str(ex))
-    sys.exit(2)
 
 
 def main(args=None):
     if args is None:
         args = sys.argv[1:]
+    client = DDSClient()
     try:
-        config = create_config()
-    except ValueError as ex:
-        print_exception_and_exit(ex)
-    try:
-        client = DDSClient(config)
         client.run_command(args)
     except Exception as ex:
-        if config.debug_mode:
+        if client.show_error_stack_trace:
             raise
         else:
-            print_exception_and_exit(ex)
+            sys.stderr.write(str(ex))
+            sys.exit(2)
 
 
 if __name__ == '__main__':

--- a/ddsc/__main__.py
+++ b/ddsc/__main__.py
@@ -3,6 +3,7 @@ import sys
 from ddsc.config import create_config
 from ddsc.ddsclient import DDSClient
 
+
 def print_exception_and_exit(ex):
     """
     Print out error message and exit

--- a/ddsc/__main__.py
+++ b/ddsc/__main__.py
@@ -3,11 +3,22 @@ import sys
 from ddsc.config import create_config
 from ddsc.ddsclient import DDSClient
 
+def print_exception_and_exit(ex):
+    """
+    Print out error message and exit
+    :param ex: exception that was raised
+    """
+    sys.stderr.write(str(ex))
+    sys.exit(2)
+
 
 def main(args=None):
     if args is None:
         args = sys.argv[1:]
-    config = create_config()
+    try:
+        config = create_config()
+    except ValueError as ex:
+        print_exception_and_exit(ex)
     try:
         client = DDSClient(config)
         client.run_command(args)
@@ -15,8 +26,7 @@ def main(args=None):
         if config.debug_mode:
             raise
         else:
-            sys.stderr.write(str(ex))
-            sys.exit(2)
+            print_exception_and_exit(ex)
 
 
 if __name__ == '__main__':

--- a/ddsc/cmdparser.py
+++ b/ddsc/cmdparser.py
@@ -225,6 +225,18 @@ def _add_exclude_arg(arg_parser):
                             default=[])
 
 
+def _skip_config_file_permission_check(arg_parser):
+    """
+    Adds optional follow_symlinks parameter to a parser.
+    :param arg_parser: ArgumentParser parser to add this argument to.
+    """
+    arg_parser.add_argument("--allow_insecure_config_file",
+                            help="Do not check the config file ~/.ddsclient permissions.",
+                            action='store_true',
+                            dest='allow_insecure_config_file',
+                            default=False)
+
+
 class CommandParser(object):
     """
     Root command line parser. Supports the following commands: upload and add_user.
@@ -233,6 +245,7 @@ class CommandParser(object):
     """
     def __init__(self):
         self.parser = argparse.ArgumentParser()
+        _skip_config_file_permission_check(self.parser)
         self.subparsers = self.parser.add_subparsers()
         self.upload_func = None
         self.add_user_func = None

--- a/ddsc/config.py
+++ b/ddsc/config.py
@@ -24,9 +24,10 @@ FILE_EXCLUDE_REGEX_DEFAULT = '^\.DS_Store$|^\.ddsclient$|^\.\_'
 MAX_DEFAULT_WORKERS = 8
 
 
-def create_config():
+def create_config(allow_insecure_config_file=False):
     """
     Create config based on /etc/ddsclient.conf and ~/.ddsclient.conf($DDSCLIENT_CONF)
+    :param allow_insecure_config_file: bool: when true we will not check ~/.ddsclient permissions.
     :return: Config with the configuration to use for DDSClient.
     """
     config = Config()
@@ -34,7 +35,8 @@ def create_config():
     user_config_filename = os.environ.get(LOCAL_CONFIG_ENV)
     if not user_config_filename:
         user_config_filename = LOCAL_CONFIG_FILENAME
-        verify_file_private(user_config_filename)
+        if not allow_insecure_config_file:
+            verify_file_private(user_config_filename)
     config.add_properties(user_config_filename)
     return config
 

--- a/ddsc/config.py
+++ b/ddsc/config.py
@@ -31,7 +31,9 @@ def create_config():
     """
     config = Config()
     config.add_properties(GLOBAL_CONFIG_FILENAME)
-    config.add_properties(os.environ.get(LOCAL_CONFIG_ENV, LOCAL_CONFIG_FILENAME))
+    user_config_filename = os.environ.get(LOCAL_CONFIG_ENV, LOCAL_CONFIG_FILENAME)
+    verify_file_private(user_config_filename)
+    config.add_properties(user_config_filename)
     return config
 
 
@@ -68,7 +70,6 @@ class Config(object):
         """
         filename = os.path.expanduser(filename)
         if os.path.exists(filename):
-            verify_file_private(filename)
             with open(filename, 'r') as yaml_file:
                 self.update_properties(yaml.load(yaml_file))
 

--- a/ddsc/config.py
+++ b/ddsc/config.py
@@ -4,6 +4,8 @@ import re
 import math
 import yaml
 import multiprocessing
+from ddsc.core.util import verify_file_private
+
 try:
     from urllib.parse import urlparse
 except ImportError:
@@ -66,6 +68,7 @@ class Config(object):
         """
         filename = os.path.expanduser(filename)
         if os.path.exists(filename):
+            verify_file_private(filename)
             with open(filename, 'r') as yaml_file:
                 self.update_properties(yaml.load(yaml_file))
 

--- a/ddsc/config.py
+++ b/ddsc/config.py
@@ -31,8 +31,10 @@ def create_config():
     """
     config = Config()
     config.add_properties(GLOBAL_CONFIG_FILENAME)
-    user_config_filename = os.environ.get(LOCAL_CONFIG_ENV, LOCAL_CONFIG_FILENAME)
-    verify_file_private(user_config_filename)
+    user_config_filename = os.environ.get(LOCAL_CONFIG_ENV)
+    if not user_config_filename:
+        user_config_filename = LOCAL_CONFIG_FILENAME
+        verify_file_private(user_config_filename)
     config.add_properties(user_config_filename)
     return config
 

--- a/ddsc/core/util.py
+++ b/ddsc/core/util.py
@@ -257,9 +257,11 @@ def verify_file_private(filename):
     On windows this never raises due to the implementation of stat.
     """
     if platform.system().upper() != 'WINDOWS':
-        file_stat = os.stat(filename)
-        if mode_allows_group_or_other(file_stat.st_mode):
-            raise ValueError(CONFIG_FILE_PERMISSIONS_ERROR)
+        filename = os.path.expanduser(filename)
+        if os.path.exists(filename):
+            file_stat = os.stat(filename)
+            if mode_allows_group_or_other(file_stat.st_mode):
+                raise ValueError(CONFIG_FILE_PERMISSIONS_ERROR)
 
 
 def mode_allows_group_or_other(st_mode):

--- a/ddsc/core/util.py
+++ b/ddsc/core/util.py
@@ -1,10 +1,21 @@
 import sys
+import os
+import platform
+import stat
 
 TERMINAL_ENCODING_NOT_UTF_ERROR = """
 ERROR: DukeDSClient requires UTF terminal encoding.
 
 Follow this guide for adjusting your terminal encoding:
   https://github.com/Duke-GCB/DukeDSClient/blob/master/docs/UnicodeTerminalSetup.md
+
+"""
+
+CONFIG_FILE_PERMISSIONS_ERROR = """
+ERROR: Your config file ~/.ddsclient permissions are open and can allow other users to see your secret key.
+Please disable group and other permissions for your DukeDSClient configuration file.
+You may be able to fix this by running:
+chmod 600 ~/.ddsclient
 
 """
 
@@ -238,3 +249,23 @@ def verify_terminal_encoding(encoding):
     encoding = encoding or ''
     if not ("UTF" in encoding):
         raise ValueError(TERMINAL_ENCODING_NOT_UTF_ERROR)
+
+
+def verify_file_private(filename):
+    """
+    Raises ValueError the file permissions allow group/other
+    On windows this never raises due to the implementation of stat.
+    """
+    if platform.system().upper() != 'WINDOWS':
+        file_stat = os.stat(filename)
+        if mode_allows_group_or_other(file_stat.st_mode):
+            raise ValueError(CONFIG_FILE_PERMISSIONS_ERROR)
+
+
+def mode_allows_group_or_other(st_mode):
+    """
+    Returns True if st_mode bitset has group or other permissions
+    :param st_mode: int: bit set from a file
+    :return: bool: true when group or other has some permissions
+    """
+    return (st_mode & stat.S_IRWXO or st_mode & stat.S_IRWXG) != 0

--- a/ddsc/ddsclient.py
+++ b/ddsc/ddsclient.py
@@ -13,6 +13,7 @@ from ddsc.core.download import ProjectDownload
 from ddsc.core.util import ProjectFilenameList, verify_terminal_encoding
 from ddsc.core.pathfilter import PathFilter
 from ddsc.versioncheck import check_version, VersionException
+from ddsc.config import create_config
 
 NO_PROJECTS_FOUND_MESSAGE = 'No projects found.'
 TWO_SECONDS = 2
@@ -22,12 +23,8 @@ class DDSClient(object):
     """
     Runs various commands based on arguments.
     """
-    def __init__(self, config):
-        """
-        Pass in the configuration for the data service.
-        :param config: ddsc.config.Config configuration object to be used with the DataServiceApi.
-        """
-        self.config = config
+    def __init__(self):
+        self.show_error_stack_trace = False
 
     def run_command(self, args):
         """
@@ -82,7 +79,9 @@ class DDSClient(object):
         """
         verify_terminal_encoding(sys.stdout.encoding)
         self._check_pypi_version()
-        command = command_constructor(self.config)
+        config = create_config(allow_insecure_config_file=args.allow_insecure_config_file)
+        self.show_error_stack_trace = config.debug_mode
+        command = command_constructor(config)
         command.run(args)
 
 

--- a/ddsc/tests/test_config.py
+++ b/ddsc/tests/test_config.py
@@ -4,6 +4,7 @@ import ddsc.config
 import multiprocessing
 from mock.mock import patch
 
+
 class TestConfig(TestCase):
     def test_empty_config(self):
         config = ddsc.config.Config()
@@ -111,7 +112,7 @@ class TestConfig(TestCase):
         mock_os.path.expanduser.return_value = '/never/gonna/happen.file'
         mock_os.path.exists.return_value = False
         mock_os.environ.get.return_value = None
-        config = ddsc.config.create_config()
+        ddsc.config.create_config()
         mock_verify_file_private.assert_called()
 
     @patch('ddsc.config.os')
@@ -120,5 +121,5 @@ class TestConfig(TestCase):
         mock_os.path.expanduser.return_value = '/never/gonna/happen.file'
         mock_os.path.exists.return_value = False
         mock_os.environ.get.return_value = "/shared/ddsclient.config"
-        config = ddsc.config.create_config()
+        ddsc.config.create_config()
         mock_verify_file_private.assert_not_called()

--- a/ddsc/tests/test_config.py
+++ b/ddsc/tests/test_config.py
@@ -2,7 +2,7 @@ from unittest import TestCase
 import math
 import ddsc.config
 import multiprocessing
-
+from mock.mock import patch
 
 class TestConfig(TestCase):
     def test_empty_config(self):
@@ -104,3 +104,21 @@ class TestConfig(TestCase):
         ddsc.config.MAX_DEFAULT_WORKERS = 1
         self.assertEqual(1, ddsc.config.default_num_workers())
         ddsc.config.MAX_DEFAULT_WORKERS = orig_max_default_workers
+
+    @patch('ddsc.config.os')
+    @patch('ddsc.config.verify_file_private')
+    def test_create_config_no_env_set(self, mock_verify_file_private, mock_os):
+        mock_os.path.expanduser.return_value = '/never/gonna/happen.file'
+        mock_os.path.exists.return_value = False
+        mock_os.environ.get.return_value = None
+        config = ddsc.config.create_config()
+        mock_verify_file_private.assert_called()
+
+    @patch('ddsc.config.os')
+    @patch('ddsc.config.verify_file_private')
+    def test_create_config_with_env_set(self, mock_verify_file_private, mock_os):
+        mock_os.path.expanduser.return_value = '/never/gonna/happen.file'
+        mock_os.path.exists.return_value = False
+        mock_os.environ.get.return_value = "/shared/ddsclient.config"
+        config = ddsc.config.create_config()
+        mock_verify_file_private.assert_not_called()

--- a/ddsc/tests/test_util.py
+++ b/ddsc/tests/test_util.py
@@ -75,3 +75,9 @@ class TestUtil(TestCase):
         verify_file_private(tempfilename)
         set_file_perm(tempfilename, '0500')
         verify_file_private(tempfilename)
+
+    @patch("ddsc.core.util.platform")
+    def test_non_existant_file_no_raises(self, mock_platform):
+        mock_platform.system.return_value = 'Linux'
+        tempfilename = './file.never.gonna.exist'
+        verify_file_private(tempfilename)

--- a/ddsc/tests/test_util.py
+++ b/ddsc/tests/test_util.py
@@ -1,21 +1,77 @@
 from unittest import TestCase
-from ddsc.core.util import verify_terminal_encoding
+import subprocess
+import os
+import tempfile
+from ddsc.core.util import mode_allows_group_or_other, verify_file_private, CONFIG_FILE_PERMISSIONS_ERROR
+from mock import patch
 
 
-class TestVerifyEncoding(TestCase):
-    def test_verify_encoding(self):
-        bad_values = [
-            'ASCII',
-            None,
-            'US-ASCII',
-            '',
+def make_temp_filename():
+    tempfilename = tempfile.mktemp()
+    with open(tempfilename, 'w') as outfile:
+        pass
+    return tempfilename
+
+
+def set_file_perm(filename, mode):
+    subprocess.call(['chmod', mode, filename])
+
+
+class TestUtil(TestCase):
+    def test_mode_allows_group_or_other_true(self):
+        tempfilename = make_temp_filename()
+        modes = [
+            '0777',
+            '0666',
+            '0555',
+            '0770',
+            '0707',
+            '0660',
+            '0606',
+            '0010',
+            '0001',
         ]
-        good_values = [
-            'dataUTFdata'
-            'UTF-8',
+        for mode in modes:
+            set_file_perm(tempfilename, mode)
+            st_mode = os.stat(tempfilename).st_mode
+            self.assertEqual(True, mode_allows_group_or_other(st_mode))
+        os.unlink(tempfilename)
+
+    def test_mode_allows_group_or_other_false(self):
+        tempfilename = make_temp_filename()
+        modes = [
+            '0700',
+            '0600',
+            '0500',
         ]
-        for bad_value in bad_values:
-            with self.assertRaises(ValueError):
-                verify_terminal_encoding(bad_value)
-        for good_value in good_values:
-            verify_terminal_encoding(good_value)
+        for mode in modes:
+            set_file_perm(tempfilename, mode)
+            st_mode = os.stat(tempfilename).st_mode
+            self.assertEqual(False, mode_allows_group_or_other(st_mode))
+        os.unlink(tempfilename)
+
+    @patch("ddsc.core.util.platform")
+    def test_verify_file_private_on_windows_no_raise(self, mock_platform):
+        mock_platform.system.return_value = 'Windows'
+        tempfilename = make_temp_filename()
+        set_file_perm(tempfilename, '0777')
+        verify_file_private(tempfilename)
+
+    @patch("ddsc.core.util.platform")
+    def test_verify_file_private_not_windows_raises_when_bad(self, mock_platform):
+        mock_platform.system.return_value = 'Linux'
+        tempfilename = make_temp_filename()
+        set_file_perm(tempfilename, '0777')
+        with self.assertRaises(ValueError) as err:
+            verify_file_private(tempfilename)
+
+    @patch("ddsc.core.util.platform")
+    def test_verify_file_private_not_windows_ok(self, mock_platform):
+        mock_platform.system.return_value = 'Linux'
+        tempfilename = make_temp_filename()
+        set_file_perm(tempfilename, '0700')
+        verify_file_private(tempfilename)
+        set_file_perm(tempfilename, '0600')
+        verify_file_private(tempfilename)
+        set_file_perm(tempfilename, '0500')
+        verify_file_private(tempfilename)

--- a/ddsc/tests/test_util.py
+++ b/ddsc/tests/test_util.py
@@ -2,13 +2,13 @@ from unittest import TestCase
 import subprocess
 import os
 import tempfile
-from ddsc.core.util import mode_allows_group_or_other, verify_file_private, CONFIG_FILE_PERMISSIONS_ERROR
+from ddsc.core.util import mode_allows_group_or_other, verify_file_private
 from mock import patch
 
 
 def make_temp_filename():
     tempfilename = tempfile.mktemp()
-    with open(tempfilename, 'w') as outfile:
+    with open(tempfilename, 'w'):
         pass
     return tempfilename
 
@@ -62,7 +62,7 @@ class TestUtil(TestCase):
         mock_platform.system.return_value = 'Linux'
         tempfilename = make_temp_filename()
         set_file_perm(tempfilename, '0777')
-        with self.assertRaises(ValueError) as err:
+        with self.assertRaises(ValueError):
             verify_file_private(tempfilename)
 
     @patch("ddsc.core.util.platform")


### PR DESCRIPTION
Check ~/.ddsclient config file permissions and make sure it isn't readable by other users.
This is similar to how ssh tries to keep your keys safe.
Fixes #111