### PR TITLE
Fix list_auth_roles and get_project_transfers

### DIFF
--- a/ddsc/core/ddsapi.py
+++ b/ddsc/core/ddsapi.py
@@ -613,7 +613,7 @@ class DataServiceApi(object):
         :param context: str which roles do we want 'project' or 'system'
         :return: requests.Response containing the successful result
         """
-        return self._get_all_pages("/auth_roles", {"context": context}, content_type=ContentType.form)
+        return self._get_collection("/auth_roles", {"context": context}, content_type=ContentType.form)
 
     def get_project_transfers(self, project_id):
         """
@@ -621,7 +621,7 @@ class DataServiceApi(object):
         :param project_id: str uuid of the project
         :return: requests.Response containing the successful result
         """
-        return self._get_all_pages("/projects/" + project_id + "/transfers", {})
+        return self._get_collection("/projects/" + project_id + "/transfers", {})
 
     def create_project_transfer(self, project_id, to_user_ids):
         """

--- a/ddsc/core/tests/test_ddsapi.py
+++ b/ddsc/core/tests/test_ddsapi.py
@@ -233,3 +233,38 @@ class TestDataServiceApi(TestCase):
         self.assertEqual(user, result.json())
         expected_url = 'something.com/v1/auth_providers/123/affiliates/joe/dds_user/'
         self.assertEqual(expected_url, mock_requests.post.call_args_list[0][0][0])
+
+    def test_list_auth_roles(self):
+        return_value = {
+            "results": [
+                {
+                    "id": "project_admin",
+                    "name": "Project Admin",
+                }
+            ]
+        }
+        mock_requests = MagicMock()
+        mock_requests.get.side_effect = [
+            fake_response_with_pages(status_code=200, json_return_value=return_value, num_pages=1)
+        ]
+        api = DataServiceApi(auth=None, url="something.com/v1/", http=mock_requests)
+        resp = api.get_auth_roles(context='')
+        self.assertEqual(1, len(resp.json()['results']))
+        self.assertEqual("Project Admin", resp.json()['results'][0]['name'])
+
+    def test_get_project_transfers(self):
+        return_value = {
+            "results": [
+                {
+                    "id": "1234"
+                }
+            ]
+        }
+        mock_requests = MagicMock()
+        mock_requests.get.side_effect = [
+            fake_response_with_pages(status_code=200, json_return_value=return_value, num_pages=1)
+        ]
+        api = DataServiceApi(auth=None, url="something.com/v1/", http=mock_requests)
+        resp = api.get_project_transfers(project_id='4521')
+        self.assertEqual(1, len(resp.json()['results']))
+        self.assertEqual("1234", resp.json()['results'][0]['id'])


### PR DESCRIPTION
I think this was the result of a merge that worked but didn't make sense.
These two methods were using the older _get_all_pages method instead of _get_collection.