### PR TITLE
Remove legacy options from help

### DIFF
--- a/ddsc/cmdparser.py
+++ b/ddsc/cmdparser.py
@@ -271,7 +271,6 @@ class CommandParser(object):
         """
         description = "Gives user permission to access a remote project."
         add_user_parser = self.subparsers.add_parser('add-user', description=description)
-        self.subparsers.choices['add_user'] = add_user_parser
         add_project_name_arg(add_user_parser, help_text="Name of the project to add a user to.")
         user_or_email = add_user_parser.add_mutually_exclusive_group(required=True)
         add_user_arg(user_or_email)
@@ -286,7 +285,6 @@ class CommandParser(object):
         """
         description = "Removes user permission to access a remote project."
         remove_user_parser = self.subparsers.add_parser('remove-user', description=description)
-        self.subparsers.choices['remove_user'] = remove_user_parser
         add_project_name_arg(remove_user_parser, help_text="Name of the project to remove a user from.")
         user_or_email = remove_user_parser.add_mutually_exclusive_group(required=True)
         add_user_arg(user_or_email)

--- a/ddsc/tests/test_cmdparser.py
+++ b/ddsc/tests/test_cmdparser.py
@@ -3,18 +3,17 @@ from unittest import TestCase
 from ddsc.cmdparser import CommandParser
 
 
+def no_op():
+    pass
+
+
 class TestCommandParser(TestCase):
     def test_register_add_user_command(self):
         command_parser = CommandParser()
-        def call_func():
-            pass
-        command_parser.register_add_user_command(call_func)
+        command_parser.register_add_user_command(no_op)
         self.assertEqual(['add-user'], command_parser.subparsers.choices.keys())
 
     def test_register_remove_user_command(self):
         command_parser = CommandParser()
-        def call_func():
-            pass
-        command_parser.register_remove_user_command(call_func)
+        command_parser.register_remove_user_command(no_op)
         self.assertEqual(['remove-user'], command_parser.subparsers.choices.keys())
-

--- a/ddsc/tests/test_cmdparser.py
+++ b/ddsc/tests/test_cmdparser.py
@@ -11,9 +11,9 @@ class TestCommandParser(TestCase):
     def test_register_add_user_command(self):
         command_parser = CommandParser()
         command_parser.register_add_user_command(no_op)
-        self.assertEqual(['add-user'], command_parser.subparsers.choices.keys())
+        self.assertEqual(['add-user'], list(command_parser.subparsers.choices.keys()))
 
     def test_register_remove_user_command(self):
         command_parser = CommandParser()
         command_parser.register_remove_user_command(no_op)
-        self.assertEqual(['remove-user'], command_parser.subparsers.choices.keys())
+        self.assertEqual(['remove-user'], list(command_parser.subparsers.choices.keys()))

--- a/ddsc/tests/test_cmdparser.py
+++ b/ddsc/tests/test_cmdparser.py
@@ -1,0 +1,20 @@
+from __future__ import absolute_import
+from unittest import TestCase
+from ddsc.cmdparser import CommandParser
+
+
+class TestCommandParser(TestCase):
+    def test_register_add_user_command(self):
+        command_parser = CommandParser()
+        def call_func():
+            pass
+        command_parser.register_add_user_command(call_func)
+        self.assertEqual(['add-user'], command_parser.subparsers.choices.keys())
+
+    def test_register_remove_user_command(self):
+        command_parser = CommandParser()
+        def call_func():
+            pass
+        command_parser.register_remove_user_command(call_func)
+        self.assertEqual(['remove-user'], command_parser.subparsers.choices.keys())
+


### PR DESCRIPTION
Remove `add_user` and `remove_user` from help screens.
Fixes #123
