### PR TITLE
deliver/share with message

### DIFF
--- a/ddsc/cmdparser.py
+++ b/ddsc/cmdparser.py
@@ -237,6 +237,17 @@ def _skip_config_file_permission_check(arg_parser):
                             default=False)
 
 
+def _add_message_file(arg_parser, help_text):
+    """
+    Add mesage file argument with help_text to arg_parser.
+    :param arg_parser: ArgumentParser parser to add this argument to.
+    :param help_text: str: help text for this argument
+    """
+    arg_parser.add_argument('--msg-file',
+                            type=argparse.FileType('r'),
+                            help=help_text)
+
+
 class CommandParser(object):
     """
     Root command line parser. Supports the following commands: upload and add_user.
@@ -320,6 +331,8 @@ class CommandParser(object):
         add_email_arg(user_or_email)
         _add_auth_role_arg(share_parser, default_permissions='file_downloader')
         _add_resend_arg(share_parser, "Resend share")
+        _add_message_file(share_parser, "Filename containing a message to be sent with the share. "
+                                        "Pass - to read from stdin.")
         share_parser.set_defaults(func=share_func)
 
     def register_deliver_command(self, deliver_func):
@@ -340,6 +353,8 @@ class CommandParser(object):
         include_or_exclude = deliver_parser.add_mutually_exclusive_group(required=False)
         _add_include_arg(include_or_exclude)
         _add_exclude_arg(include_or_exclude)
+        _add_message_file(deliver_parser, "Filename containing a message to be sent with the delivery. "
+                                          "Pass - to read from stdin.")
         deliver_parser.set_defaults(func=deliver_func)
 
     def register_list_command(self, list_func):

--- a/ddsc/core/d4s2.py
+++ b/ddsc/core/d4s2.py
@@ -85,6 +85,7 @@ class D4S2Api(object):
             'from_user_id': item.from_user_id,
             'to_user_id': item.to_user_id,
             'role': item.auth_role,
+            'user_message': item.user_message
         })
         resp = requests.post(self.make_url(item.destination), headers=self.json_headers, data=data)
         self.check_response(resp)
@@ -121,7 +122,7 @@ class D4S2Item(object):
     """
     Contains data for processing either share or deliver.
     """
-    def __init__(self, destination, from_user_id, to_user_id, project_id, project_name, auth_role):
+    def __init__(self, destination, from_user_id, to_user_id, project_id, project_name, auth_role, user_message):
         """
         Save data for use with send method.
         :param destination: str type of message we are sending(SHARE_DESTINATION or DELIVER_DESTINATION)
@@ -130,6 +131,7 @@ class D4S2Item(object):
         :param project_id: str uuid(duke-data-service) of project we are sharing
         :param project_name: str name of the project (sent for debugging purposes)
         :param auth_role: str authorization role to given to the user (determines which email to send)
+        :param user_message: str user message to send with the share/delivery
         """
         self.destination = destination
         self.from_user_id = from_user_id
@@ -137,6 +139,7 @@ class D4S2Item(object):
         self.project_id = project_id
         self.project_name = project_name
         self.auth_role = auth_role
+        self.user_message = user_message
 
     def send(self, api, force_send):
         """
@@ -200,17 +203,18 @@ class D4S2Project(object):
         self.remote_store = remote_store
         self.print_func = print_func
 
-    def share(self, project_name, to_user, force_send, auth_role):
+    def share(self, project_name, to_user, force_send, auth_role, user_message):
         """
         Send mail and give user specified access to the project.
         :param project_name: str name of the project to share
         :param to_user: RemoteUser user to receive email/access
         :param auth_role: str project role eg 'project_admin' to give to the user
+        :param user_message: str message to be sent with the share
         :return: str email we share the project with
         """
         project = self.fetch_remote_project(project_name, must_exist=True)
         self.set_user_project_permission(project, to_user, auth_role)
-        return self._share_project(D4S2Api.SHARE_DESTINATION, project, to_user, force_send, auth_role)
+        return self._share_project(D4S2Api.SHARE_DESTINATION, project, to_user, force_send, auth_role, user_message)
 
     def fetch_remote_project(self, project_name, must_exist=False):
         """
@@ -230,7 +234,7 @@ class D4S2Project(object):
         """
         self.remote_store.set_user_project_permission(project, user, auth_role)
 
-    def deliver(self, project_name, new_project_name, to_user, force_send, path_filter):
+    def deliver(self, project_name, new_project_name, to_user, force_send, path_filter, user_message):
         """
         Remove access to project_name for to_user, copy to new_project_name if not None,
         send message to service to email user so they can have access.
@@ -239,13 +243,14 @@ class D4S2Project(object):
         :param to_user: RemoteUser user we are handing over the project to
         :param force_send: boolean enables resending of email for existing projects
         :param path_filter: PathFilter: filters what files are shared
+        :param user_message: str message to be sent with the share
         :return: str email we sent deliver to
         """
         project = self.fetch_remote_project(project_name, must_exist=True)
         self.remove_user_permission(project, to_user)
         if new_project_name:
             project = self._copy_project(project_name, new_project_name, path_filter)
-        return self._share_project(D4S2Api.DELIVER_DESTINATION, project, to_user, force_send)
+        return self._share_project(D4S2Api.DELIVER_DESTINATION, project, to_user, force_send, user_message=user_message)
 
     def remove_user_permission(self, project, user):
         """
@@ -255,13 +260,14 @@ class D4S2Project(object):
         """
         self.remote_store.revoke_user_project_permission(project, user)
 
-    def _share_project(self, destination, project, to_user, force_send, auth_role=''):
+    def _share_project(self, destination, project, to_user, force_send, auth_role='', user_message=''):
         """
         Send message to remove service to email/share project with to_user.
         :param destination: str which type of sharing we are doing (SHARE_DESTINATION or DELIVER_DESTINATION)
         :param project: RemoteProject project we are sharing
         :param to_user: RemoteUser user we are sharing with
         :param auth_role: str project role eg 'project_admin' email is customized based on this setting.
+        :param user_message: str message to be sent with the share
         :return: the email the user should receive a message on soon
         """
         from_user = self.remote_store.get_current_user()
@@ -270,7 +276,8 @@ class D4S2Project(object):
                         to_user_id=to_user.id,
                         project_id=project.id,
                         project_name=project.name,
-                        auth_role=auth_role)
+                        auth_role=auth_role,
+                        user_message=user_message)
         item.send(self.api, force_send)
         return to_user.email
 

--- a/ddsc/core/d4s2.py
+++ b/ddsc/core/d4s2.py
@@ -115,7 +115,8 @@ class D4S2Api(object):
         if response.status_code == 401:
             raise D4S2Error(UNAUTHORIZED_MESSAGE)
         if not 200 <= response.status_code < 300:
-            raise D4S2Error("Request to {} failed with {}.".format(response.url, response.status_code))
+            raise D4S2Error("Request to {} failed with {}:\n{}.".format(response.url, response.status_code,
+                                                                        response.text))
 
 
 class D4S2Item(object):

--- a/ddsc/core/tests/test_d4s2.py
+++ b/ddsc/core/tests/test_d4s2.py
@@ -1,0 +1,42 @@
+from __future__ import absolute_import
+from unittest import TestCase
+from ddsc.core.d4s2 import D4S2Project
+from mock import patch, MagicMock, Mock
+
+
+class TestD4S2Project(TestCase):
+    @patch('ddsc.core.d4s2.D4S2Api')
+    @patch('ddsc.core.d4s2.requests')
+    def test_share(self, mock_requests, mock_d4s2api):
+        mock_d4s2api().get_existing_item.return_value = Mock(json=Mock(return_value=[]))
+        project = D4S2Project(config=MagicMock(), remote_store=MagicMock(), print_func=MagicMock())
+        project.share(project_name='mouserna',
+                      to_user=MagicMock(id='123'),
+                      force_send=False,
+                      auth_role='project_viewer',
+                      user_message='This is a test.')
+        args, kwargs = mock_d4s2api().create_item.call_args
+        item = args[0]
+        self.assertEqual(mock_d4s2api.SHARE_DESTINATION, item.destination)
+        self.assertEqual('123', item.to_user_id)
+        self.assertEqual('project_viewer', item.auth_role)
+        self.assertEqual('This is a test.', item.user_message)
+        mock_d4s2api().send_item.assert_called()
+
+    @patch('ddsc.core.d4s2.D4S2Api')
+    @patch('ddsc.core.d4s2.requests')
+    def test_deliver(self, mock_requests, mock_d4s2api):
+        mock_d4s2api().get_existing_item.return_value = Mock(json=Mock(return_value=[]))
+        project = D4S2Project(config=MagicMock(), remote_store=MagicMock(), print_func=MagicMock())
+        project.deliver(project_name='mouserna',
+                        new_project_name=None,
+                        to_user=MagicMock(id='456'),
+                        force_send=False,
+                        path_filter='',
+                        user_message='Yet Another Message.')
+        args, kwargs = mock_d4s2api().create_item.call_args
+        item = args[0]
+        self.assertEqual(mock_d4s2api.DELIVER_DESTINATION, item.destination)
+        self.assertEqual('456', item.to_user_id)
+        self.assertEqual('Yet Another Message.', item.user_message)
+        mock_d4s2api().send_item.assert_called()

--- a/ddsc/tests/test_cmdparser.py
+++ b/ddsc/tests/test_cmdparser.py
@@ -8,7 +8,13 @@ def no_op():
 
 
 class TestCommandParser(TestCase):
-    def test_register_add_user_command(self):
+    def setUp(self):
+        self.parsed_args = None
+
+    def set_parsed_args(self, args):
+        self.parsed_args = args
+
+    def test_register_add_user_command_no_msg(self):
         command_parser = CommandParser()
         command_parser.register_add_user_command(no_op)
         self.assertEqual(['add-user'], list(command_parser.subparsers.choices.keys()))
@@ -17,3 +23,31 @@ class TestCommandParser(TestCase):
         command_parser = CommandParser()
         command_parser.register_remove_user_command(no_op)
         self.assertEqual(['remove-user'], list(command_parser.subparsers.choices.keys()))
+
+    def test_deliver_no_msg(self):
+        command_parser = CommandParser()
+        command_parser.register_deliver_command(self.set_parsed_args)
+        self.assertEqual(['deliver'], list(command_parser.subparsers.choices.keys()))
+        command_parser.run_command(['deliver', '-p', 'someproject', '--user', 'joe123'])
+        self.assertEqual(None, self.parsed_args.msg_file)
+
+    def test_deliver_with_msg(self):
+        command_parser = CommandParser()
+        command_parser.register_deliver_command(self.set_parsed_args)
+        self.assertEqual(['deliver'], list(command_parser.subparsers.choices.keys()))
+        command_parser.run_command(['deliver', '-p', 'someproject', '--user', 'joe123', '--msg-file', 'setup.py'])
+        self.assertIn('setup(', self.parsed_args.msg_file.read())
+
+    def test_share_no_msg(self):
+        command_parser = CommandParser()
+        command_parser.register_share_command(self.set_parsed_args)
+        self.assertEqual(['share'], list(command_parser.subparsers.choices.keys()))
+        command_parser.run_command(['share', '-p', 'someproject', '--user', 'joe123'])
+        self.assertEqual(None, self.parsed_args.msg_file)
+
+    def test_share_with_msg(self):
+        command_parser = CommandParser()
+        command_parser.register_share_command(self.set_parsed_args)
+        self.assertEqual(['share'], list(command_parser.subparsers.choices.keys()))
+        command_parser.run_command(['share', '-p', 'someproject', '--user', 'joe123', '--msg-file', 'setup.py'])
+        self.assertIn('setup(', self.parsed_args.msg_file.read())

--- a/ddsc/tests/test_ddsclient.py
+++ b/ddsc/tests/test_ddsclient.py
@@ -1,0 +1,81 @@
+from __future__ import absolute_import
+from unittest import TestCase
+from ddsc.ddsclient import ShareCommand, DeliverCommand, read_argument_file_contents
+from mock import patch, MagicMock, Mock
+
+
+class TestShareCommand(TestCase):
+    @patch('ddsc.ddsclient.RemoteStore')
+    @patch('ddsc.ddsclient.D4S2Project')
+    def test_run_no_message(self, mock_d4s2_project, mock_remote_store):
+        cmd = ShareCommand(MagicMock())
+        myargs = Mock(project_name='mouse', email=None, username='joe123', force_send=False,
+                      auth_role='project_viewer', msg_file=None)
+        cmd.run(myargs)
+        args, kwargs = mock_d4s2_project().share.call_args
+        project_name, to_user, force_send, auth_role, message = args
+        self.assertEqual('mouse', project_name)
+        self.assertEqual('project_viewer', auth_role)
+        self.assertEqual('', message)
+
+    @patch('ddsc.ddsclient.RemoteStore')
+    @patch('ddsc.ddsclient.D4S2Project')
+    def test_run_message(self, mock_d4s2_project, mock_remote_store):
+        with open('setup.py') as message_infile:
+            cmd = ShareCommand(MagicMock())
+            myargs = Mock(project_name='mouse', email=None, username='joe123', force_send=False,
+                          auth_role='project_viewer', msg_file=message_infile)
+            cmd.run(myargs)
+            args, kwargs = mock_d4s2_project().share.call_args
+            project_name, to_user, force_send, auth_role, message = args
+            self.assertEqual('mouse', project_name)
+            self.assertEqual('project_viewer', auth_role)
+            self.assertIn('setup(', message)
+
+
+class TestDeliverCommand(TestCase):
+    @patch('ddsc.ddsclient.RemoteStore')
+    @patch('ddsc.ddsclient.D4S2Project')
+    def test_run_no_message(self, mock_d4s2_project, mock_remote_store):
+        cmd = DeliverCommand(MagicMock())
+        myargs = Mock(project_name='mouse',
+                      email=None,
+                      resend=False,
+                      username='joe123',
+                      skip_copy_project=True,
+                      include_paths=None,
+                      exclude_paths=None,
+                      msg_file=None)
+        cmd.run(myargs)
+        args, kwargs = mock_d4s2_project().deliver.call_args
+        project_name, new_project_name, to_user, force_send, path_filter, message = args
+        self.assertEqual('mouse', project_name)
+        self.assertEqual(False, force_send)
+        self.assertEqual('', message)
+
+    @patch('ddsc.ddsclient.RemoteStore')
+    @patch('ddsc.ddsclient.D4S2Project')
+    def test_run_message(self, mock_d4s2_project, mock_remote_store):
+        with open('setup.py') as message_infile:
+            cmd = DeliverCommand(MagicMock())
+            myargs = Mock(project_name='mouse',
+                          resend=False,
+                          email=None,
+                          username='joe123',
+                          skip_copy_project=True,
+                          include_paths=None,
+                          exclude_paths=None,
+                          msg_file=message_infile)
+            cmd.run(myargs)
+            args, kwargs = mock_d4s2_project().deliver.call_args
+            project_name, new_project_name, to_user, force_send, path_filter, message = args
+            self.assertEqual('mouse', project_name)
+            self.assertEqual(False, force_send)
+            self.assertIn('setup(', message)
+
+
+class TestDDSClient(TestCase):
+    def test_read_argument_file_contents(self):
+        self.assertEqual('', read_argument_file_contents(None))
+        with open("setup.py") as infile:
+            self.assertIn("setup(", read_argument_file_contents(infile))


### PR DESCRIPTION
Adds filename parameter to share and delivery: `--msg-file <filename>`
By default argparse supports passing '-' to this argument to read from stdin.
This value or empty string (if not specified) is passed to d4s2 in the item user_message field.
Fixes #121.