### PR TITLE
Cleanup processes on error in parallel chunk uploading

### DIFF
--- a/ddsc/core/fileuploader.py
+++ b/ddsc/core/fileuploader.py
@@ -7,6 +7,8 @@ from multiprocessing import Process, Queue
 from ddsc.core.ddsapi import DataServiceAuth, DataServiceApi
 from ddsc.core.util import ProgressQueue, wait_for_processes
 from ddsc.core.localstore import HashData
+import traceback
+import sys
 
 
 class FileUploader(object):
@@ -234,7 +236,11 @@ def upload_async(data_service_auth_data, config, upload_id,
     data_service = DataServiceApi(auth, config.url)
     sender = ChunkSender(data_service, upload_id, filename, config.upload_bytes_per_chunk, index, num_chunks_to_send,
                          progress_queue)
-    return sender.send()
+    try:
+        sender.send()
+    except:
+        error_msg = "".join(traceback.format_exception(*sys.exc_info()))
+        progress_queue.error(error_msg)
 
 
 class ChunkSender(object):

--- a/ddsc/core/fileuploader.py
+++ b/ddsc/core/fileuploader.py
@@ -296,8 +296,7 @@ class ChunkSender(object):
 
     def send(self):
         """
-        For each chunk we need to send, create upload url and send bytes.
-        :return None when everything is ok otherwise returns a string error message.
+        For each chunk we need to send, create upload url and send bytes. Raises exception on error.
         """
         sent_chunks = 0
         chunk_num = self.index
@@ -309,7 +308,6 @@ class ChunkSender(object):
                 self.progress_queue.processed(1)
                 chunk_num += 1
                 sent_chunks += 1
-        return None
 
     def _send_chunk(self, chunk, chunk_num):
         """

--- a/ddsc/core/tests/test_fileuploader.py
+++ b/ddsc/core/tests/test_fileuploader.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 from ddsc.core.fileuploader import ParallelChunkProcessor, upload_async
-from mock import MagicMock, Mock, patch
+from mock import MagicMock, patch
 
 
 class FakeConfig(object):


### PR DESCRIPTION
This is a fix to the upload_async method uploads chunks of a file in a background process.

When this method has an exception it will now send the error message back to the main process.
The main process already has code to cleanup processes and notify the user when this happens.

This is just to cleanup processes when an error occurs when talking to DukeDS-API or the Swift store. Before this change the user would have to hit Ctrl-C to terminate the process.

Also adds a sleep and retry on connection error when uploading a chunk via PUT.