### PR TITLE
Reset session and incremental waiting

### DIFF
--- a/ddsc/core/ddsapi.py
+++ b/ddsc/core/ddsapi.py
@@ -160,7 +160,7 @@ class DataServiceApi(object):
     Sends json messages and receives responses back from Duke Data Service api.
     See https://github.com/Duke-Translational-Bioinformatics/duke-data-service.
     """
-    def __init__(self, auth, url, http=requests):
+    def __init__(self, auth, url, http=requests_session):
         """
         Setup for REST api.
         :param auth: str auth token to be send via Authorization header
@@ -171,6 +171,12 @@ class DataServiceApi(object):
         self.base_url = url
         self.http = http
         self.user_agent_str = get_user_agent_str()
+
+    def reset_persistent_session(self):
+        """
+        Recreates the internal http session.
+        """
+        self.http = requests.Session()
 
     def _url_parts(self, url_suffix, data, content_type):
         """
@@ -489,9 +495,9 @@ class DataServiceApi(object):
         :return: requests.Response containing the successful result
         """
         if http_verb == 'PUT':
-            return requests_session.put(host + url, data=chunk, headers=http_headers)
+            return self.http.put(host + url, data=chunk, headers=http_headers)
         elif http_verb == 'POST':
-            return requests_session.post(host + url, data=chunk, headers=http_headers)
+            return self.http.post(host + url, data=chunk, headers=http_headers)
         else:
             raise ValueError("Unsupported http_verb:" + http_verb)
 
@@ -505,7 +511,7 @@ class DataServiceApi(object):
         :return: requests.Response containing the successful result
         """
         if http_verb == 'GET':
-            return requests_session.get(host + url, headers=http_headers, stream=True)
+            return self.http.get(host + url, headers=http_headers, stream=True)
         else:
             raise ValueError("Unsupported http_verb:" + http_verb)
 

--- a/ddsc/core/fileuploader.py
+++ b/ddsc/core/fileuploader.py
@@ -12,8 +12,8 @@ from ddsc.core.localstore import HashData
 import traceback
 import sys
 
-SEND_EXTERNAL_PUT_RETRY_TIMES = 3
-SEND_EXTERNAL_RETRY_SECONDS = 0.5
+SEND_EXTERNAL_PUT_RETRY_TIMES = 5
+SEND_EXTERNAL_RETRY_SECONDS = 1
 
 
 class FileUploader(object):
@@ -144,7 +144,8 @@ class FileUploadOperations(object):
             except requests.exceptions.ConnectionError:
                 count += 1
                 if count < retry_times:
-                    time.sleep(SEND_EXTERNAL_RETRY_SECONDS)
+                    time.sleep(SEND_EXTERNAL_RETRY_SECONDS * count)
+                    self.data_service.reset_persistent_session()
                 else:
                     raise
 

--- a/ddsc/core/tests/test_fileuploader.py
+++ b/ddsc/core/tests/test_fileuploader.py
@@ -92,10 +92,14 @@ class TestFileUploadOperations(TestCase):
         fop.send_file_external(url_json, chunk='DATADATADATA')
         self.assertEqual(2, data_service.send_external.call_count)
 
-    def test_send_file_external_retry_put_fail_after_3_times(self):
+    def test_send_file_external_retry_put_fail_after_5_times(self):
         data_service = MagicMock()
         connection_err = requests.exceptions.ConnectionError
-        data_service.send_external.side_effect = [connection_err, connection_err, connection_err, connection_err]
+        data_service.send_external.side_effect = [connection_err,
+                                                  connection_err,
+                                                  connection_err,
+                                                  connection_err,
+                                                  connection_err]
         fop = FileUploadOperations(data_service)
         url_json = {
             'http_verb': 'PUT',
@@ -105,12 +109,16 @@ class TestFileUploadOperations(TestCase):
         }
         with self.assertRaises(requests.exceptions.ConnectionError):
             fop.send_file_external(url_json, chunk='DATADATADATA')
-        self.assertEqual(3, data_service.send_external.call_count)
+        self.assertEqual(5, data_service.send_external.call_count)
 
-    def test_send_file_external_succeeds_3rd_time(self):
+    def test_send_file_external_succeeds_5th_time(self):
         data_service = MagicMock()
         connection_err = requests.exceptions.ConnectionError
-        data_service.send_external.side_effect = [connection_err, connection_err, Mock(status_code=201)]
+        data_service.send_external.side_effect = [connection_err,
+                                                  connection_err,
+                                                  connection_err,
+                                                  connection_err,
+                                                  Mock(status_code=201)]
         fop = FileUploadOperations(data_service)
         url_json = {
             'http_verb': 'PUT',
@@ -119,7 +127,7 @@ class TestFileUploadOperations(TestCase):
             'http_headers': [],
         }
         fop.send_file_external(url_json, chunk='DATADATADATA')
-        self.assertEqual(3, data_service.send_external.call_count)
+        self.assertEqual(5, data_service.send_external.call_count)
 
     def test_send_file_external_no_retry_post(self):
         data_service = MagicMock()


### PR DESCRIPTION
Recreating the persistent requests session after a connection error.
Waiting longer between retries. 
Waits up to 5 times with increasing sleep times: 1 second ... 5 seconds.