### PR TITLE
Recreate session before retrying external PUT

### DIFF
--- a/ddsc/core/fileuploader.py
+++ b/ddsc/core/fileuploader.py
@@ -144,10 +144,21 @@ class FileUploadOperations(object):
             except requests.exceptions.ConnectionError:
                 count += 1
                 if count < retry_times:
+                    if count == 1:  # Only show a warning the first time we fail to send a chunk
+                        self._show_retry_warning(host)
                     time.sleep(SEND_EXTERNAL_RETRY_SECONDS)
                     self.data_service.recreate_requests_session()
                 else:
                     raise
+
+    @staticmethod
+    def _show_retry_warning(host):
+        """
+        Displays a message on stderr that we lost connection to a host and will retry.
+        :param host: str: name of the host we are trying to communicate with
+        """
+        sys.stderr.write("\nConnection to {} failed. Retrying.\n".format(host))
+        sys.stderr.flush()
 
     def finish_upload(self, upload_id, hash_data, parent_data, remote_file_id):
         """

--- a/ddsc/core/fileuploader.py
+++ b/ddsc/core/fileuploader.py
@@ -12,8 +12,8 @@ from ddsc.core.localstore import HashData
 import traceback
 import sys
 
-SEND_EXTERNAL_PUT_RETRY_TIMES = 3
-SEND_EXTERNAL_RETRY_SECONDS = 0.5
+SEND_EXTERNAL_PUT_RETRY_TIMES = 5
+SEND_EXTERNAL_RETRY_SECONDS = 1
 
 
 class FileUploader(object):
@@ -145,6 +145,7 @@ class FileUploadOperations(object):
                 count += 1
                 if count < retry_times:
                     time.sleep(SEND_EXTERNAL_RETRY_SECONDS)
+                    self.data_service.recreate_requests_session()
                 else:
                     raise
 

--- a/ddsc/core/projectuploader.py
+++ b/ddsc/core/projectuploader.py
@@ -4,8 +4,6 @@ from ddsc.core.ddsapi import DataServiceAuth, DataServiceApi
 from ddsc.core.fileuploader import FileUploader, FileUploadOperations, ParentData
 from ddsc.core.parallel import TaskExecutor, TaskRunner
 
-requests_session = requests.Session()
-
 
 class UploadSettings(object):
     """
@@ -41,7 +39,7 @@ class UploadSettings(object):
         """
         auth = DataServiceAuth(config)
         auth.set_auth_data(data_service_auth_data)
-        return DataServiceApi(auth, config.url, requests_session)
+        return DataServiceApi(auth, config.url)
 
 
 class UploadContext(object):

--- a/ddsc/core/projectuploader.py
+++ b/ddsc/core/projectuploader.py
@@ -1,4 +1,3 @@
-import requests
 from ddsc.core.util import ProjectWalker, KindType
 from ddsc.core.ddsapi import DataServiceAuth, DataServiceApi
 from ddsc.core.fileuploader import FileUploader, FileUploadOperations, ParentData

--- a/ddsc/core/tests/test_ddsapi.py
+++ b/ddsc/core/tests/test_ddsapi.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 from unittest import TestCase
+import requests
 from ddsc.core.ddsapi import MultiJSONResponse, DataServiceApi, ContentType, UNEXPECTED_PAGING_DATA_RECEIVED
 from mock import MagicMock
 
@@ -268,3 +269,8 @@ class TestDataServiceApi(TestCase):
         resp = api.get_project_transfers(project_id='4521')
         self.assertEqual(1, len(resp.json()['results']))
         self.assertEqual("1234", resp.json()['results'][0]['id'])
+
+    def test_constructor_creates_session_when_passed_none(self):
+        api = DataServiceApi(auth=None, url="something.com/v1/", http=None)
+        self.assertIsNotNone(api.http)
+        self.assertEqual(type(api.http), requests.sessions.Session)

--- a/ddsc/core/tests/test_fileuploader.py
+++ b/ddsc/core/tests/test_fileuploader.py
@@ -92,7 +92,8 @@ class TestFileUploadOperations(TestCase):
         fop.send_file_external(url_json, chunk='DATADATADATA')
         self.assertEqual(2, data_service.send_external.call_count)
 
-    def test_send_file_external_retry_put_fail_after_5_times(self):
+    @patch('ddsc.core.fileuploader.time')
+    def test_send_file_external_retry_put_fail_after_5_times(self, mock_time):
         data_service = MagicMock()
         connection_err = requests.exceptions.ConnectionError
         data_service.send_external.side_effect = [connection_err, connection_err, connection_err, connection_err,
@@ -109,7 +110,8 @@ class TestFileUploadOperations(TestCase):
         self.assertEqual(5, data_service.send_external.call_count)
         self.assertEqual(4, data_service.recreate_requests_session.call_count)
 
-    def test_send_file_external_succeeds_3rd_time(self):
+    @patch('ddsc.core.fileuploader.time')
+    def test_send_file_external_succeeds_3rd_time(self, mock_time):
         data_service = MagicMock()
         connection_err = requests.exceptions.ConnectionError
         data_service.send_external.side_effect = [connection_err, connection_err, Mock(status_code=201)]

--- a/ddsc/core/tests/test_fileuploader.py
+++ b/ddsc/core/tests/test_fileuploader.py
@@ -124,7 +124,6 @@ class TestFileUploadOperations(TestCase):
         self.assertEqual(3, data_service.send_external.call_count)
         self.assertEqual(2, data_service.recreate_requests_session.call_count)
 
-
     def test_send_file_external_no_retry_post(self):
         data_service = MagicMock()
         data_service.send_external.side_effect = [requests.exceptions.ConnectionError]

--- a/ddsc/core/tests/test_fileuploader.py
+++ b/ddsc/core/tests/test_fileuploader.py
@@ -92,10 +92,11 @@ class TestFileUploadOperations(TestCase):
         fop.send_file_external(url_json, chunk='DATADATADATA')
         self.assertEqual(2, data_service.send_external.call_count)
 
-    def test_send_file_external_retry_put_fail_after_3_times(self):
+    def test_send_file_external_retry_put_fail_after_5_times(self):
         data_service = MagicMock()
         connection_err = requests.exceptions.ConnectionError
-        data_service.send_external.side_effect = [connection_err, connection_err, connection_err, connection_err]
+        data_service.send_external.side_effect = [connection_err, connection_err, connection_err, connection_err,
+                                                  connection_err, connection_err]
         fop = FileUploadOperations(data_service)
         url_json = {
             'http_verb': 'PUT',
@@ -105,7 +106,7 @@ class TestFileUploadOperations(TestCase):
         }
         with self.assertRaises(requests.exceptions.ConnectionError):
             fop.send_file_external(url_json, chunk='DATADATADATA')
-        self.assertEqual(3, data_service.send_external.call_count)
+        self.assertEqual(5, data_service.send_external.call_count)
 
     def test_send_file_external_succeeds_3rd_time(self):
         data_service = MagicMock()

--- a/ddsc/core/tests/test_fileuploader.py
+++ b/ddsc/core/tests/test_fileuploader.py
@@ -107,6 +107,7 @@ class TestFileUploadOperations(TestCase):
         with self.assertRaises(requests.exceptions.ConnectionError):
             fop.send_file_external(url_json, chunk='DATADATADATA')
         self.assertEqual(5, data_service.send_external.call_count)
+        self.assertEqual(4, data_service.recreate_requests_session.call_count)
 
     def test_send_file_external_succeeds_3rd_time(self):
         data_service = MagicMock()
@@ -121,6 +122,8 @@ class TestFileUploadOperations(TestCase):
         }
         fop.send_file_external(url_json, chunk='DATADATADATA')
         self.assertEqual(3, data_service.send_external.call_count)
+        self.assertEqual(2, data_service.recreate_requests_session.call_count)
+
 
     def test_send_file_external_no_retry_post(self):
         data_service = MagicMock()

--- a/integration_test.sh
+++ b/integration_test.sh
@@ -23,20 +23,20 @@ python3 setup.py -q test
 export PROJ="python$PROJECT_PREFIX"
 echo "test upload $PROJ"
 python -m ddsc upload -p $PROJ ddsc/
-python -m ddsc add_user -p $PROJ --email $USER_EMAIL
+python -m ddsc add-user -p $PROJ --email $USER_EMAIL
 
 echo "test download $PROJ"
-rm -rf /tmp/$PROJ
 # test filename conversion
 python -m ddsc download -p $PROJ
 echo "differences:"
 diff --brief -r ddsc/ $PROJ/ddsc/
+rm -rf $PROJ
 
 export PROJ2="python3$PROJECT_PREFIX"
 echo "test upload $PROJ2"
 python3 -m ddsc upload -p $PROJ2 ddsc/
-python3 -m ddsc add_user -p $PROJ2 --user $USERNAME
-python3 -m ddsc remove_user -p $PROJ2 --user $USERNAME
+python3 -m ddsc add-user -p $PROJ2 --user $USERNAME
+python3 -m ddsc remove-user -p $PROJ2 --user $USERNAME
 
 echo "test download $PROJ2"
 rm -rf /tmp/$PROJ2


### PR DESCRIPTION
Recreate requests session when we are retrying to send a chunk to the external host(swift currently). Also retries 5 times and waits 1 second between each retry.

Also fixes a bug in the integration_test script.