### PR TITLE
travis commit env module to helmod repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,13 @@ before_script:
 - flake8 --ignore E501 ddsc/
 after_success: coveralls
 deploy:
-  provider: pypi
-  user: jbradley
-  password:
-    secure: asDgRbV5BsiRA/WK0ZNBrB0NfoI6d90ugZd6pZmm8yofJVoDM6qqWWvSWi9tu6QWrmkjOY60swIHYtGiRyD2cc5O7FEL5L85bZb352GNjjgAq2odj4rpLuMi8T+CpiY/FoQBDWHpy4O5nFaIGWm5VM0kDRpzUmntTnqyj29kbka4RflM2JSo9KgUBIM1yOjz1Qy+5whEl/qY6OGSmfHmDny7AaAvPJrtcjvJbfiBLhh61nILggTzOmt0+eXzUydAZ26J5iLzEZslvAU4ZYGmnPb65rYOtiXQNxzxhYtg4unKbRemeI69nWlzNq9ptBgl7OZhUAXuHXj4Fxv9b5/HnWBXwlfioGJXsWTK4RQm/pnikYCUJv0zt1KTdR8wz8x8Izal35kXLK/g+XP3ghYKPeHHtGRra7c+Xha70UwYcbLedTtR6mvVBTBUehO6mnYpgd0w8wQAEn+3GwClB2Xrw/irolaqbPgeNlqaArjk8DILc/IQ1jsbUhsDGg/FEajSyJOkXXboBRkvY6scGmIEV5HGfCInCucmjT+Wc/+XEKUAKHXQuaBeP1Hl13MICnU5vBIyvOJkrshURH3o4Pzw27sWkjfNPhJW2iQv0bFp4Opcwr5utmTW2eklKEJ/31iLMf2BiffGN5U0pSHKJtc8Fwj8gIfSuQ1oZLY4PP3ehDY=
-  on:
-    tags: true
+  - provider: pypi
+    user: jbradley
+    password:
+      secure: asDgRbV5BsiRA/WK0ZNBrB0NfoI6d90ugZd6pZmm8yofJVoDM6qqWWvSWi9tu6QWrmkjOY60swIHYtGiRyD2cc5O7FEL5L85bZb352GNjjgAq2odj4rpLuMi8T+CpiY/FoQBDWHpy4O5nFaIGWm5VM0kDRpzUmntTnqyj29kbka4RflM2JSo9KgUBIM1yOjz1Qy+5whEl/qY6OGSmfHmDny7AaAvPJrtcjvJbfiBLhh61nILggTzOmt0+eXzUydAZ26J5iLzEZslvAU4ZYGmnPb65rYOtiXQNxzxhYtg4unKbRemeI69nWlzNq9ptBgl7OZhUAXuHXj4Fxv9b5/HnWBXwlfioGJXsWTK4RQm/pnikYCUJv0zt1KTdR8wz8x8Izal35kXLK/g+XP3ghYKPeHHtGRra7c+Xha70UwYcbLedTtR6mvVBTBUehO6mnYpgd0w8wQAEn+3GwClB2Xrw/irolaqbPgeNlqaArjk8DILc/IQ1jsbUhsDGg/FEajSyJOkXXboBRkvY6scGmIEV5HGfCInCucmjT+Wc/+XEKUAKHXQuaBeP1Hl13MICnU5vBIyvOJkrshURH3o4Pzw27sWkjfNPhJW2iQv0bFp4Opcwr5utmTW2eklKEJ/31iLMf2BiffGN5U0pSHKJtc8Fwj8gIfSuQ1oZLY4PP3ehDY=
+    on:
+      tags: true
+  - provider: script
+    script: ./deploy/onpublish.sh
+    on:
+      tags: true

--- a/deploy/ddsclient-generic-gcb01.spec
+++ b/deploy/ddsclient-generic-gcb01.spec
@@ -1,0 +1,328 @@
+#------------------- package info ----------------------------------------------
+#
+#
+# enter the simple app name, e.g. myapp
+#
+Name: %{getenv:NAME}
+#
+# enter the app version, e.g. 0.0.1
+#
+Version: %{getenv:VERSION}
+#
+# enter the release; start with fasrc01 (or some other convention for your 
+# organization) and increment in subsequent releases
+#
+# the actual "Release", %%{release_full}, is constructed dynamically; for Comp 
+# and MPI apps, it will include the name/version/release of the apps used to 
+# build it and will therefore be very long
+#
+%define release_short %{getenv:RELEASE}
+#
+# enter your FIRST LAST <EMAIL>
+#
+Packager: %{getenv:FASRCSW_AUTHOR}
+#
+# enter a succinct one-line summary (%%{summary} gets changed when the debuginfo 
+# rpm gets created, so this stores it separately for later re-use); do not 
+# surround this string with quotes
+#
+%define summary_static The DukeDSCLient (ddsclient) is a command line python tool facilitating upload and download of data from the Duke Data Service, as well as modifications to file ownershop and access.
+Summary: %{summary_static}
+#
+# enter the url from where you got the source; change the archive suffix if 
+# applicable
+#
+# no source needed since this spec file uses pip install. url provided below for information - pip fetches appropriate version based on %{version} variable derived from spec file name.
+#
+URL: https://github.com/Duke-GCB/DukeDSClient
+#Source: %{name}-%{version}.tar.gz
+#
+# there should be no need to change the following
+#
+#these fields are required by RPM
+Group: fasrcsw
+License: see COPYING file or upstream packaging
+#this comes here since it uses Name and Version but dynamically computes Release, Prefix, etc.
+%include fasrcsw_defines.rpmmacros
+Release: %{release_full}
+Prefix: %{_prefix}
+#
+# Macros for setting app data 
+# The first set can probably be left as is
+# the nil construct should be used for empty values
+#
+%define modulename %{name}-%{version}-%{release_short}
+%define appname %(test %{getenv:APPNAME} && echo "%{getenv:APPNAME}" || echo "%{name}")
+%define appversion %(test %{getenv:APPVERSION} && echo "%{getenv:APPVERSION}" || echo "%{version}")
+%define appdescription %{summary_static}
+%define type %{getenv:TYPE}
+%define specauthor %{getenv:FASRCSW_AUTHOR}
+%define builddate %(date)
+%define buildhost %(hostname)
+%define buildhostversion 1
+%define compiler %( if [[ %{getenv:TYPE} == "Comp" || %{getenv:TYPE} == "MPI" ]]; then if [[ -n "%{getenv:FASRCSW_COMPS}" ]]; then echo "%{getenv:FASRCSW_COMPS}"; fi; else echo "system"; fi)
+%define mpi %(if [[ %{getenv:TYPE} == "MPI" ]]; then if [[ -n "%{getenv:FASRCSW_MPIS}" ]]; then echo "%{getenv:FASRCSW_MPIS}"; fi; else echo ""; fi)
+%define builddependencies python/2.7.11-fasrc01 
+%define rundependencies %{builddependencies}
+%define buildcomments %{nil}
+%define requestor %{nil}
+%define requestref %{nil}
+# apptags
+# For aci-ref database use aci-ref-app-category and aci-ref-app-tag namespaces and separate tags with a semi-colon
+# aci-ref-app-category:Programming Tools; aci-ref-app-tag:Compiler
+%define apptags %{nil} 
+%define apppublication %{nil}
+#
+# enter a description, often a paragraph; unless you prefix lines with spaces, 
+# rpm will format it, so no need to worry about the wrapping
+#
+# NOTE! INDICATE IF THERE ARE CHANGES FROM THE NORM TO THE BUILD!
+#
+%description
+#------------------- %%prep (~ tar xvf) ---------------------------------------
+%prep
+#
+# FIXME
+#
+# unpack the sources here.  The default below is for standard, GNU-toolchain 
+# style things -- hopefully it'll just work as-is.
+#
+umask 022
+cd "$FASRCSW_DEV"/rpmbuild/BUILD 
+rm -rf %{name}-%{version}
+mkdir %{name}-%{version}
+cd %{name}-%{version}
+chmod -Rf a+rX,u+w,g-w,o-w .
+#------------------- %%build (~ configure && make) ----------------------------
+%build
+#(leave this here)
+%include fasrcsw_module_loads.rpmmacros
+#
+#
+# configure and make the software here.  The default below is for standard 
+# GNU-toolchain style things -- hopefully it'll just work as-is.
+# 
+##prerequisite apps (uncomment and tweak if necessary).  If you add any here, 
+##make sure to add them to modulefile.lua below, too!
+#module load NAME/VERSION-RELEASE
+umask 022
+cd "$FASRCSW_DEV"/rpmbuild/BUILD/%{name}-%{version}
+#if you are okay with disordered output, add %%{?_smp_mflags} (with only one 
+#percent sign) to build in parallel
+#make
+#------------------- %%install (~ make install + create modulefile) -----------
+%install
+#(leave this here)
+%include fasrcsw_module_loads.rpmmacros
+#
+# make install here.  The default below is for standard GNU-toolchain style 
+# things -- hopefully it'll just work as-is.
+#
+# Note that DESTDIR != %{prefix} -- this is not the final installation.  
+# Rpmbuild does a temporary installation in the %{buildroot} and then 
+# constructs an rpm out of those files.  See the following hack if your app 
+# does not support this:
+#
+# https://github.com/fasrc/fasrcsw/blob/master/doc/FAQ.md#how-do-i-handle-apps-that-insist-on-writing-directly-to-the-production-location
+#
+# %%{buildroot} is usually ~/rpmbuild/BUILDROOT/%{name}-%{version}-%{release}.%{arch}.
+# (A spec file cannot change it, thus it is not inside $FASRCSW_DEV.)
+#
+umask 022
+cd "$FASRCSW_DEV"/rpmbuild/BUILD/%{name}-%{version}
+echo %{buildroot} | grep -q %{name}-%{version} && rm -rf %{buildroot}
+mkdir -p %{buildroot}/%{_prefix}
+mkdir -p %{buildroot}/%{_prefix}/lib/python2.7/site-packages
+export PYTHONPATH=%{buildroot}/%{_prefix}/lib/python2.7/site-packages
+PYTHONUSERBASE=%{buildroot}/%{_prefix} pip install --user --upgrade PyYAML requests DukeDSClient==%{version}
+#(this should not need to be changed)
+#these files are nice to have; %%doc is not as prefix-friendly as I would like
+#if there are other files not installed by make install, add them here
+for f in COPYING AUTHORS README INSTALL ChangeLog NEWS THANKS TODO BUGS; do
+	test -e "$f" && ! test -e '%{buildroot}/%{_prefix}/'"$f" && cp -a "$f" '%{buildroot}/%{_prefix}/'
+done
+#(this should not need to be changed)
+#this is the part that allows for inspecting the build output without fully creating the rpm
+%if %{defined trial}
+	set +x
+	
+	echo
+	echo
+	echo "*************** fasrcsw -- STOPPING due to %%define trial yes ******************"
+	echo 
+	echo "Look at the tree output below to decide how to finish off the spec file.  (\`Bad"
+	echo "exit status' is expected in this case, it's just a way to stop NOW.)"
+	echo
+	echo
+	
+	tree '%{buildroot}/%{_prefix}'
+
+	echo
+	echo
+	echo "Some suggestions of what to use in the modulefile:"
+	echo
+	echo
+
+	generate_setup.sh --action echo --format lmod --prefix '%%{_prefix}'  '%{buildroot}/%{_prefix}'
+
+	echo
+	echo
+	echo "******************************************************************************"
+	echo
+	echo
+	
+	#make the build stop
+	false
+
+	set -x
+%endif
+
+# 
+# FIXME (but the above is enough for a "trial" build)
+#
+# This is the part that builds the modulefile.  However, stop now and run 
+# `make trial'.  The output from that will suggest what to add below.
+#
+# - uncomment any applicable prepend_path things (`--' is a comment in lua)
+#
+# - do any other customizing of the module, e.g. load dependencies -- make sure 
+#   any dependency loading is in sync with the %%build section above!
+#
+# - in the help message, link to website docs rather than write anything 
+#   lengthy here
+#
+# references on writing modules:
+#   http://www.tacc.utexas.edu/tacc-projects/lmod/advanced-user-guide/writing-module-files
+#   http://www.tacc.utexas.edu/tacc-projects/lmod/system-administrator-guide/initial-setup-of-modules
+#   http://www.tacc.utexas.edu/tacc-projects/lmod/system-administrator-guide/module-commands-tutorial
+#
+
+mkdir -p %{buildroot}/%{_prefix}
+cat > %{buildroot}/%{_prefix}/modulefile.lua <<EOF
+local helpstr = [[
+%{name}-%{version}-%{release_short}
+%{summary_static}
+%{buildcomments}
+]]
+help(helpstr,"\n")
+
+whatis("Name: %{name}")
+whatis("Version: %{version}-%{release_short}")
+whatis("Description: %{summary_static}")
+
+---- prerequisite apps (uncomment and tweak if necessary)
+for i in string.gmatch("%{rundependencies}","%%S+") do 
+    if mode()=="load" then
+        a = string.match(i,"^[^/]+")
+        if not isloaded(a) then
+            load(i)
+        end
+    end
+end
+
+
+---- environment changes (uncomment what is relevant)
+--setenv("TEMPLATE_HOME",       "%{_prefix}")
+
+prepend_path("PATH",                "%{_prefix}/bin")
+--prepend_path("CPATH",               "%{_prefix}/include")
+--prepend_path("FPATH",               "%{_prefix}/include")
+--prepend_path("INFOPATH",            "%{_prefix}/info")
+prepend_path("LD_LIBRARY_PATH",     "%{_prefix}/lib")
+prepend_path("LIBRARY_PATH",        "%{_prefix}/lib")
+--prepend_path("LD_LIBRARY_PATH",     "%{_prefix}/lib64")
+--prepend_path("LIBRARY_PATH",        "%{_prefix}/lib64")
+--prepend_path("MANPATH",             "%{_prefix}/man")
+--prepend_path("PKG_CONFIG_PATH",     "%{_prefix}/pkgconfig")
+--prepend_path("PATH",                "%{_prefix}/sbin")
+--prepend_path("INFOPATH",            "%{_prefix}/share/info")
+--prepend_path("MANPATH",             "%{_prefix}/share/man")
+prepend_path("PYTHONPATH",          "%{_prefix}/lib/python2.7/site-packages")
+EOF
+
+#------------------- App data file
+cat > $FASRCSW_DEV/appdata/%{modulename}.%{type}.dat <<EOF
+appname             : %{appname}
+appversion          : %{appversion}
+description         : %{appdescription}
+tags                : %{apptags}
+publication         : %{apppublication}
+modulename          : %{modulename}
+type                : %{type}
+compiler            : %{compiler}
+mpi                 : %{mpi}
+specauthor          : %{specauthor}
+builddate           : %{builddate}
+buildhost           : %{buildhost}
+buildhostversion    : %{buildhostversion}
+builddependencies   : %{builddependencies}
+rundependencies     : %{rundependencies}
+buildcomments       : %{buildcomments}
+requestor           : %{requestor}
+requestref          : %{requestref}
+EOF
+
+
+#------------------- %%files (there should be no need to change this ) --------
+
+%files
+
+%defattr(-,root,root,-)
+
+%{_prefix}/*
+
+
+
+#------------------- scripts (there should be no need to change these) --------
+
+
+%pre
+#
+# everything in fasrcsw is installed in an app hierarchy in which some 
+# components may need creating, but no single rpm should own them, since parts 
+# are shared; only do this if it looks like an app-specific prefix is indeed 
+# being used (that's the fasrcsw default)
+#
+echo '%{_prefix}' | grep -q '%{name}.%{version}' && mkdir -p '%{_prefix}'
+#
+
+%post
+#
+# symlink to the modulefile installed along with the app; we want all rpms to 
+# be relocatable, hence why this is not a proper %%file; as with the app itself, 
+# modulefiles are in an app hierarchy in which some components may need 
+# creating
+#
+mkdir -p %{modulefile_dir}
+ln -s %{_prefix}/modulefile.lua %{modulefile}
+#
+
+
+%preun
+#
+# undo the module file symlink done in the %%post; do not rmdir 
+# %%{modulefile_dir}, though, since that is shared by multiple apps (yes, 
+# orphans will be left over after the last package in the app family 
+# is removed)
+#
+test -L '%{modulefile}' && rm '%{modulefile}'
+#
+
+%postun
+#
+# undo the last component of the mkdir done in the %%pre (yes, orphans will be 
+# left over after the last package in the app family is removed); also put a 
+# little protection so this does not cause problems if a non-default prefix 
+# (e.g. one shared with other packages) is used
+#
+test -d '%{_prefix}' && echo '%{_prefix}' | grep -q '%{name}.%{version}' && rmdir '%{_prefix}'
+#
+
+
+%clean
+#
+# wipe out the buildroot, but put some protection to make sure it isn't 
+# accidentally / or something -- we always have "rpmbuild" in the name
+#
+echo '%{buildroot}' | grep -q 'rpmbuild' && rm -rf '%{buildroot}'
+#

--- a/deploy/onpublish.sh
+++ b/deploy/onpublish.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Travis build trigger should have environment variables COMMIT_USER, COMMIT_EMAIL and COMMIT_TOKEN setup.
+
+SOURCEFILENAME=".deploy/ddsclient-generic-gcb01.spec"
+TARGETFILENAME="ddsclient-$TRAVIS_TAG-gcb01.spec"
+COMMITMSG="DukeDSClient module update $TRAVIS_TAG"
+COMMITBRANCH="master"
+
+# Encode the spec file as base64
+BASE64CONTENT=`base64 $SOURCEFILENAME`
+
+# Upload file to helmod repo
+curl -i -X PUT -H "Authorization: token $COMMIT_TOKEN" \
+   -d "{ \"path\": \"rpmbuild/SPECS/$TARGETFILENAME\", \
+        \"message\": \"$COMMITMSG\", \
+        \"committer\": {\"name\": \"$COMMIT_USER\", \"email\": \"$COMMIT_EMAIL\"}, \
+        \"content\": \"$BASE64CONTENT\", \
+        \"branch\": \"$COMMITBRANCH\"}" \
+    https://api.github.com/repos/Duke-GCB/helmod/contents/rpmbuild/SPECS/$TARGETFILENAME


### PR DESCRIPTION
In the deployment step (tagged commit/release) after we send the code to pypi
it will create a new spec file in the github.com/Duke-GCB/helmod repo.
This will help automate building of the environment module.

When run in production need to check that travis doesn't accidentally log COMMIT_TOKEN.