### PR TITLE
Eventual consistency

### DIFF
--- a/ddsc/core/fileuploader.py
+++ b/ddsc/core/fileuploader.py
@@ -107,7 +107,7 @@ class FileUploadOperations(object):
         size = path_data.size()
 
         def func():
-            self.data_service.create_upload(project_id, name, mime_type, size, hash_data.value, hash_data.alg)
+            return self.data_service.create_upload(project_id, name, mime_type, size, hash_data.value, hash_data.alg)
 
         monitor = ResourceNotConsistentMonitor(os.path.basename(name))
         resp = retry_until_resource_is_consistent(func, monitor)

--- a/ddsc/core/fileuploader.py
+++ b/ddsc/core/fileuploader.py
@@ -105,8 +105,10 @@ class FileUploadOperations(object):
         name = path_data.name()
         mime_type = path_data.mime_type()
         size = path_data.size()
-        func = lambda: self.data_service.create_upload(project_id, name, mime_type, size, hash_data.value,
-                                                       hash_data.alg)
+
+        def func():
+            self.data_service.create_upload(project_id, name, mime_type, size, hash_data.value, hash_data.alg)
+
         monitor = ResourceNotConsistentMonitor(os.path.basename(name))
         resp = retry_until_resource_is_consistent(func, monitor)
         return resp.json()['id']

--- a/ddsc/core/fileuploader.py
+++ b/ddsc/core/fileuploader.py
@@ -109,7 +109,7 @@ class FileUploadOperations(object):
         def func():
             return self.data_service.create_upload(project_id, name, mime_type, size, hash_data.value, hash_data.alg)
 
-        monitor = ResourceNotConsistentMonitor(os.path.basename(name))
+        monitor = ResourceNotConsistentMonitor('{} storage'.format(os.path.basename(name)))
         resp = retry_until_resource_is_consistent(func, monitor)
         return resp.json()['id']
 
@@ -355,10 +355,10 @@ class ResourceNotConsistentMonitor(object):
         self.description = description
 
     def started_waiting(self):
-        print("\nWaiting for {} to become ready.\n".format(self.description))
+        print("Waiting for {} to become ready.".format(self.description))
 
     def done_waiting(self):
-        print("\nResource {} is now ready.\n".format(self.description))
+        print("{} is now ready.".format(self.description))
 
 
 def retry_until_resource_is_consistent(func, monitor):

--- a/ddsc/core/tests/test_ddsapi.py
+++ b/ddsc/core/tests/test_ddsapi.py
@@ -1,8 +1,9 @@
 from __future__ import absolute_import
 from unittest import TestCase
 import requests
-from ddsc.core.ddsapi import MultiJSONResponse, DataServiceApi, ContentType, UNEXPECTED_PAGING_DATA_RECEIVED
-from mock import MagicMock
+from ddsc.core.ddsapi import MultiJSONResponse, DataServiceApi, ContentType, UNEXPECTED_PAGING_DATA_RECEIVED, \
+    DataServiceError, DSResourceNotConsistentError
+from mock import MagicMock, Mock
 
 
 def fake_response_with_pages(status_code, json_return_value, num_pages=1):
@@ -346,3 +347,39 @@ class TestDataServiceApi(TestCase):
         api = DataServiceApi(auth=None, url="something.com/v1/", http=None)
         self.assertIsNotNone(api.http)
         self.assertEqual(type(api.http), requests.sessions.Session)
+
+    def test_check_err_with_good_response(self):
+        resp = Mock(headers={}, status_code=202)
+        url_suffix = ""
+        data = None
+        DataServiceApi._check_err(resp, url_suffix, data, allow_pagination=False)
+
+    def test_check_err_with_500(self):
+        resp = Mock(headers={}, status_code=500)
+        url_suffix = ""
+        data = None
+        with self.assertRaises(DataServiceError):
+            DataServiceApi._check_err(resp, url_suffix, data, allow_pagination=False)
+
+    def test_check_err_with_400(self):
+        resp = Mock(headers={}, status_code=400)
+        url_suffix = ""
+        data = None
+        with self.assertRaises(DataServiceError):
+            DataServiceApi._check_err(resp, url_suffix, data, allow_pagination=False)
+
+    def test_check_err_with_404(self):
+        resp = Mock(headers={}, status_code=404)
+        resp.json.return_value = {"code": "not_found"}
+        url_suffix = ""
+        data = None
+        with self.assertRaises(DataServiceError):
+            DataServiceApi._check_err(resp, url_suffix, data, allow_pagination=False)
+
+    def test_check_err_with_404_with_flag(self):
+        resp = Mock(headers={}, status_code=404)
+        resp.json.return_value = {"code": "resource_not_consistent"}
+        url_suffix = ""
+        data = None
+        with self.assertRaises(DSResourceNotConsistentError):
+            DataServiceApi._check_err(resp, url_suffix, data, allow_pagination=False)


### PR DESCRIPTION
DukeDS API has introduced [eventual_consistency_status](https://github.com/Duke-Translational-Bioinformatics/duke-data-service/blob/develop/api_design/DDS-872-eventual_consistency_status.md). 

This results in new failures cases for the following DukeDS api endpoints:
- __POST /projects/{id}/uploads__ - creates an upload so we can upload chunks of a file
   - returns 404 with JSON data containing "code": "resource_not_consistent"
- __GET /files/{id}/url__ - get a url so we can download a file
  - returns 400 - "reason": "reported chunk hash/size does not match that computed by StorageProvider"
- __GET /file_versions/{id)/url__ - get a url of a file version so we can download a file
  - returns 400 - "reason": "reported chunk hash/size does not match that computed by 

There isn't anything we can do for the two GET endpoint failure cases.
For the __POST /projects/{id}/uploads__ we will sleep/display a message to the user while we are waiting.