### PR TITLE
Project upload eventual consistency changes

### DIFF
--- a/ddsc/__main__.py
+++ b/ddsc/__main__.py
@@ -13,7 +13,8 @@ def main(args=None):
         if client.show_error_stack_trace:
             raise
         else:
-            sys.stderr.write(str(ex))
+            error_message = '\n{}\n'.format(str(ex))
+            sys.stderr.write(error_message)
             sys.exit(2)
 
 

--- a/ddsc/core/ddsapi.py
+++ b/ddsc/core/ddsapi.py
@@ -144,7 +144,7 @@ class DataServiceError(Exception):
         if response.status_code == 500:
             if resp_json and not resp_json.get('reason'):
                 resp_json = {'reason': 'Internal Server Error', 'suggestion': 'Contact DDS support.'}
-        Exception.__init__(self, '\nError {} on {}\nReason:{}\nSuggestion:{}\n'.format(
+        Exception.__init__(self, 'Error {} on {}\nReason:{}\nSuggestion:{}'.format(
             response.status_code, url_suffix, resp_json.get('reason', resp_json.get('error', '')),
             resp_json.get('suggestion', '')
         ))

--- a/ddsc/core/ddsapi.py
+++ b/ddsc/core/ddsapi.py
@@ -144,7 +144,7 @@ class DataServiceError(Exception):
         if response.status_code == 500:
             if resp_json and not resp_json.get('reason'):
                 resp_json = {'reason': 'Internal Server Error', 'suggestion': 'Contact DDS support.'}
-        Exception.__init__(self, 'Error {} on {} Reason:{} Suggestion:{}'.format(
+        Exception.__init__(self, '\nError {} on {}\nReason:{}\nSuggestion:{}\n'.format(
             response.status_code, url_suffix, resp_json.get('reason', resp_json.get('error', '')),
             resp_json.get('suggestion', '')
         ))

--- a/ddsc/core/fileuploader.py
+++ b/ddsc/core/fileuploader.py
@@ -107,7 +107,7 @@ class FileUploadOperations(object):
         size = path_data.size()
 
         def func():
-            self.data_service.create_upload(project_id, name, mime_type, size, hash_data.value, hash_data.alg)
+            return self.data_service.create_upload(project_id, name, mime_type, size, hash_data.value, hash_data.alg)
 
         monitor = ResourceNotConsistentMonitor(os.path.basename(name))
         resp = retry_until_resource_is_consistent(func, monitor)

--- a/ddsc/core/fileuploader.py
+++ b/ddsc/core/fileuploader.py
@@ -105,8 +105,10 @@ class FileUploadOperations(object):
         name = path_data.name()
         mime_type = path_data.mime_type()
         size = path_data.size()
-        func = lambda: self.data_service.create_upload(project_id, name, mime_type, size, hash_data.value,
-                                                       hash_data.alg)
+
+        def func():
+            self.data_service.create_upload(project_id, name, mime_type, size, hash_data.value, hash_data.alg)
+
         monitor = ResourceNotConsistentMonitor(os.path.basename(name))
         resp = retry_until_resource_is_consistent(func, monitor)
         return resp.json()['id']

--- a/ddsc/core/fileuploader.py
+++ b/ddsc/core/fileuploader.py
@@ -381,7 +381,7 @@ class ProjectStatusMonitor(object):
 
     def started_waiting(self):
         if not self.waiting:
-            self.watcher.start_waiting("Waiting for project to become ready for uploading.")
+            self.watcher.start_waiting("Waiting for project to become ready for uploading")
             self.waiting = True
 
     def done_waiting(self):

--- a/ddsc/core/fileuploader.py
+++ b/ddsc/core/fileuploader.py
@@ -109,7 +109,7 @@ class FileUploadOperations(object):
         def func():
             return self.data_service.create_upload(project_id, name, mime_type, size, hash_data.value, hash_data.alg)
 
-        monitor = ResourceNotConsistentMonitor(os.path.basename(name))
+        monitor = ResourceNotConsistentMonitor('{} storage'.format(os.path.basename(name)))
         resp = retry_until_resource_is_consistent(func, monitor)
         return resp.json()['id']
 
@@ -355,10 +355,10 @@ class ResourceNotConsistentMonitor(object):
         self.description = description
 
     def started_waiting(self):
-        print("\nWaiting for {} to become ready.\n".format(self.description))
+        print("Waiting for {} to become ready.".format(self.description))
 
     def done_waiting(self):
-        print("\nResource {} is now ready.\n".format(self.description))
+        print("{} is now ready.".format(self.description))
 
 
 def retry_until_resource_is_consistent(func, monitor):

--- a/ddsc/core/parallel.py
+++ b/ddsc/core/parallel.py
@@ -199,7 +199,7 @@ class TaskExecutor(object):
             if self.is_done():
                 break
             self.start_tasks()
-            self.read_message_queue()
+            self.process_all_messages_in_queue()
             finished_tasks_and_results = self.get_finished_results()
         return finished_tasks_and_results
 
@@ -222,14 +222,27 @@ class TaskExecutor(object):
         pending_result = self.pool.apply_async(execute_task_async, (task.func, task.id, context))
         self.pending_results.append(pending_result)
 
-    def read_message_queue(self):
+    def process_all_messages_in_queue(self):
+        """
+        Process all messages in the queue coming from tasks.
+        """
+        keep_checking = True
+        while keep_checking:
+            keep_checking = self.process_single_message_from_queue()
+
+    def process_single_message_from_queue(self):
+        """
+        Tries to read a single message from the queue and let the associated task process it.
+        :return: bool: True if we processed a message, otherwise False
+        """
         try:
             message = self.message_queue.get_nowait()
             task_id, data = message
             task = self.task_id_to_task[task_id]
             task.on_message(data)
+            return True
         except queue.Empty:
-            pass
+            return False
 
     def get_finished_results(self):
         """
@@ -242,6 +255,8 @@ class TaskExecutor(object):
                 ret = pending_result.get()
                 task_id, result = ret
                 task = self.task_id_to_task[task_id]
+                # process any pending messages for this task (will also process other tasks messages)
+                self.process_all_messages_in_queue()
                 task.after_run(result)
                 task_and_results.append((task, result))
                 self.pending_results.remove(pending_result)

--- a/ddsc/core/tests/test_ddsapi.py
+++ b/ddsc/core/tests/test_ddsapi.py
@@ -1,8 +1,9 @@
 from __future__ import absolute_import
 from unittest import TestCase
 import requests
-from ddsc.core.ddsapi import MultiJSONResponse, DataServiceApi, ContentType, UNEXPECTED_PAGING_DATA_RECEIVED
-from mock import MagicMock
+from ddsc.core.ddsapi import MultiJSONResponse, DataServiceApi, ContentType, UNEXPECTED_PAGING_DATA_RECEIVED, \
+    DataServiceError, DSResourceNotConsistentError
+from mock import MagicMock, Mock
 
 
 def fake_response_with_pages(status_code, json_return_value, num_pages=1):
@@ -346,3 +347,39 @@ class TestDataServiceApi(TestCase):
         api = DataServiceApi(auth=None, url="something.com/v1/", http=None)
         self.assertIsNotNone(api.http)
         self.assertEqual(type(api.http), requests.sessions.Session)
+
+    def test_check_err_with_good_response(self):
+        resp = Mock(headers={}, status_code=202)
+        url_suffix = ""
+        data = None
+        DataServiceApi._check_err(resp, url_suffix, data, allow_pagination=False)
+
+    def test_check_err_with_500(self):
+        resp = Mock(headers={}, status_code=500)
+        url_suffix = ""
+        data = None
+        with self.assertRaises(DataServiceError):
+            DataServiceApi._check_err(resp, url_suffix, data, allow_pagination=False)
+
+    def test_check_err_with_400(self):
+        resp = Mock(headers={}, status_code=400)
+        url_suffix = ""
+        data = None
+        with self.assertRaises(DataServiceError):
+            DataServiceApi._check_err(resp, url_suffix, data, allow_pagination=False)
+
+    def test_check_err_with_404(self):
+        resp = Mock(headers={}, status_code=404)
+        resp.json.return_value = {"code": "not_found"}
+        url_suffix = ""
+        data = None
+        with self.assertRaises(DataServiceError):
+            DataServiceApi._check_err(resp, url_suffix, data, allow_pagination=False)
+
+    def test_check_err_with_404_with_flag(self):
+        resp = Mock(headers={}, status_code=404)
+        resp.json.return_value = {"code": "resource_not_consistent"}
+        url_suffix = ""
+        data = None
+        with self.assertRaises(DSResourceNotConsistentError):
+            DataServiceApi._check_err(resp, url_suffix, data, allow_pagination=False)

--- a/ddsc/core/tests/test_ddsapi.py
+++ b/ddsc/core/tests/test_ddsapi.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 from unittest import TestCase
 import requests
-from ddsc.core.ddsapi import MultiJSONResponse, DataServiceApi, ContentType, UNEXPECTED_PAGING_DATA_RECEIVED, \
+from ddsc.core.ddsapi import MultiJSONResponse, DataServiceApi, UNEXPECTED_PAGING_DATA_RECEIVED, \
     DataServiceError, DSResourceNotConsistentError
 from mock import MagicMock, Mock
 

--- a/ddsc/core/tests/test_fileuploader.py
+++ b/ddsc/core/tests/test_fileuploader.py
@@ -209,13 +209,13 @@ class TestProjectStatusMonitor(TestCase):
         monitor.started_waiting()
         self.assertEqual(1, watcher.start_waiting.call_count)
         watcher.start_waiting.assert_has_calls([
-            call('Waiting for project to become ready for uploading.')
+            call('Waiting for project to become ready for uploading')
         ])
         monitor.started_waiting()
         monitor.started_waiting()
         self.assertEqual(1, watcher.start_waiting.call_count)
         watcher.start_waiting.assert_has_calls([
-            call('Waiting for project to become ready for uploading.')
+            call('Waiting for project to become ready for uploading')
         ])
 
     def test_done_waiting(self):
@@ -225,6 +225,6 @@ class TestProjectStatusMonitor(TestCase):
         monitor.done_waiting()
         self.assertEqual(1, watcher.start_waiting.call_count)
         watcher.start_waiting.assert_has_calls([
-            call('Waiting for project to become ready for uploading.'),
+            call('Waiting for project to become ready for uploading'),
         ])
         self.assertEqual(1, watcher.done_waiting.call_count)

--- a/ddsc/core/tests/test_fileuploader.py
+++ b/ddsc/core/tests/test_fileuploader.py
@@ -228,4 +228,3 @@ class TestProjectStatusMonitor(TestCase):
             call('Waiting for project to become ready for uploading.'),
         ])
         self.assertEqual(1, watcher.done_waiting.call_count)
-

--- a/ddsc/core/tests/test_projectuploader.py
+++ b/ddsc/core/tests/test_projectuploader.py
@@ -1,5 +1,6 @@
 from unittest import TestCase
 import pickle
+import multiprocessing
 from ddsc.core.projectuploader import UploadSettings, UploadContext, ProjectUploadDryRun
 from ddsc.core.util import KindType
 from mock import MagicMock
@@ -20,7 +21,7 @@ class TestUploadContext(TestCase):
         """Make sure we can pickle context since it must be passed to another process."""
         settings = UploadSettings(None, FakeDataServiceApi(), None, None, None)
         params = ('one', 'two', 'three')
-        context = UploadContext(settings, params)
+        context = UploadContext(settings, params, multiprocessing.Manager().Queue(), 12)
         pickle.dumps(context)
 
 

--- a/ddsc/core/tests/test_util.py
+++ b/ddsc/core/tests/test_util.py
@@ -1,6 +1,7 @@
 from unittest import TestCase
 
-from ddsc.core.util import verify_terminal_encoding
+from ddsc.core.util import verify_terminal_encoding, ProgressBar, ProgressPrinter, KindType
+from mock import patch, Mock
 
 
 class TestUtil(TestCase):
@@ -22,3 +23,114 @@ class TestUtil(TestCase):
     def test_verify_terminal_encoding_none_raises(self):
         with self.assertRaises(ValueError):
             verify_terminal_encoding(None)
+
+
+class TestProgressBar(TestCase):
+    @patch('ddsc.core.util.sys.stdout')
+    def test_show_no_waiting(self, mock_stdout):
+        progress_bar = ProgressBar()
+
+        # replace line with our progress
+        progress_bar.update(percent_done=0, details='sending really_long_filename.txt')
+        progress_bar.show()
+        expected = '\rProgress: 0% - sending really_long_filename.txt'
+        mock_stdout.write.assert_called_with(expected)
+
+        # replace line with our progress (make sure it is long enough to blank out previous line)
+        progress_bar.update(percent_done=10, details='sending short.txt')
+        progress_bar.show()
+        expected = '\rProgress: 10% - sending short.txt              '
+        mock_stdout.write.assert_called_with(expected)
+
+        progress_bar.update(percent_done=15, details='sending short.txt')
+        progress_bar.show()
+        expected = '\rProgress: 15% - sending short.txt              '
+        mock_stdout.write.assert_called_with(expected)
+
+        # we finish uploading(go to newline)
+        progress_bar.set_state(ProgressBar.STATE_DONE)
+        progress_bar.show()
+        expected = '\rDone: 100%                                     \n'
+        mock_stdout.write.assert_called_with(expected)
+
+    @patch('ddsc.core.util.sys.stdout')
+    def test_show_with_waiting(self, mock_stdout):
+        progress_bar = ProgressBar()
+
+        # we make some progress
+        progress_bar.update(percent_done=10, details='sending short.txt')
+        progress_bar.show()
+        expected = '\rProgress: 10% - sending short.txt'
+        mock_stdout.write.assert_called_with(expected)
+
+        # we get stuck waiting
+        progress_bar.wait_msg = "Waiting for project"
+        progress_bar.set_state(ProgressBar.STATE_WAITING)
+        progress_bar.show()
+        expected = '\rProgress: 10% - Waiting for project'
+        mock_stdout.write.assert_called_with(expected)
+
+        # waiting takes priority over progress updates
+        # (we may be able to upload some folders while waiting to upload files)
+        progress_bar.update(percent_done=15, details='sending short.txt')
+        progress_bar.show()
+        expected = '\rProgress: 15% - Waiting for project'
+        mock_stdout.write.assert_called_with(expected)
+
+        # we are not longer waiting
+        progress_bar.set_state(ProgressBar.STATE_RUNNING)
+        progress_bar.show()
+        expected = '\rProgress: 15% - sending short.txt  '
+        mock_stdout.write.assert_called_with(expected)
+
+        # we finish uploading(go to newline)
+        progress_bar.set_state(ProgressBar.STATE_DONE)
+        progress_bar.show()
+        expected = '\rDone: 100%                         \n'
+        mock_stdout.write.assert_called_with(expected)
+
+
+class TestProgressPrinter(TestCase):
+    @patch('ddsc.core.util.ProgressBar')
+    def test_stuff(self, mock_progress_bar):
+        progress_printer = ProgressPrinter(total=10, msg_verb='sending')
+
+        # pretend we just created a project
+        mock_project = Mock(kind=KindType.project_str,path='')
+        progress_printer.transferring_item(item=mock_project, increment_amt=1)
+        mock_progress_bar.return_value.update.assert_called_with(10, 'sending project')
+        mock_progress_bar.return_value.show.assert_called()
+        mock_progress_bar.reset_mock()
+
+        # pretend we just created a folder
+        mock_project = Mock(kind=KindType.folder_str,path='/data')
+        progress_printer.transferring_item(item=mock_project, increment_amt=2)
+        mock_progress_bar.return_value.update.assert_called_with(30, 'sending data')
+        mock_progress_bar.return_value.show.assert_called()
+        mock_progress_bar.reset_mock()
+
+        # pretend we get stuck waiting for project uploads to be ready
+        progress_printer.start_waiting('Waiting for project uploads')
+        self.assertEqual(progress_printer.progress_bar.wait_msg, 'Waiting for project uploads')
+        mock_progress_bar.return_value.set_state.assert_called_with(mock_progress_bar.STATE_WAITING)
+        mock_progress_bar.return_value.show.assert_called()
+        mock_progress_bar.reset_mock()
+
+        # pretend project uploads are ready
+        progress_printer.done_waiting()
+        mock_progress_bar.return_value.set_state.assert_called_with(mock_progress_bar.STATE_RUNNING)
+        mock_progress_bar.return_value.show.assert_called()
+        mock_progress_bar.reset_mock()
+
+        # pretend we uploaded a file
+        mock_project = Mock(kind=KindType.file_str,path='/data/log.txt')
+        progress_printer.transferring_item(item=mock_project, increment_amt=2)
+        mock_progress_bar.return_value.update.assert_called_with(50, 'sending log.txt')
+        mock_progress_bar.return_value.show.assert_called()
+        mock_progress_bar.reset_mock()
+
+        # pretend we are finished uploading
+        progress_printer.finished()
+        mock_progress_bar.return_value.set_state.assert_called_with(mock_progress_bar.STATE_DONE)
+        mock_progress_bar.return_value.show.assert_called()
+        mock_progress_bar.reset_mock()

--- a/ddsc/core/tests/test_util.py
+++ b/ddsc/core/tests/test_util.py
@@ -96,14 +96,14 @@ class TestProgressPrinter(TestCase):
         progress_printer = ProgressPrinter(total=10, msg_verb='sending')
 
         # pretend we just created a project
-        mock_project = Mock(kind=KindType.project_str,path='')
+        mock_project = Mock(kind=KindType.project_str, path='')
         progress_printer.transferring_item(item=mock_project, increment_amt=1)
         mock_progress_bar.return_value.update.assert_called_with(10, 'sending project')
         mock_progress_bar.return_value.show.assert_called()
         mock_progress_bar.reset_mock()
 
         # pretend we just created a folder
-        mock_project = Mock(kind=KindType.folder_str,path='/data')
+        mock_project = Mock(kind=KindType.folder_str, path='/data')
         progress_printer.transferring_item(item=mock_project, increment_amt=2)
         mock_progress_bar.return_value.update.assert_called_with(30, 'sending data')
         mock_progress_bar.return_value.show.assert_called()
@@ -123,7 +123,7 @@ class TestProgressPrinter(TestCase):
         mock_progress_bar.reset_mock()
 
         # pretend we uploaded a file
-        mock_project = Mock(kind=KindType.file_str,path='/data/log.txt')
+        mock_project = Mock(kind=KindType.file_str, path='/data/log.txt')
         progress_printer.transferring_item(item=mock_project, increment_amt=2)
         mock_progress_bar.return_value.update.assert_called_with(50, 'sending log.txt')
         mock_progress_bar.return_value.show.assert_called()


### PR DESCRIPTION
There are forth-coming changes to DukeDS related to [eventual consistency](https://github.com/Duke-Translational-Bioinformatics/duke-data-service/blob/develop/api_design/DDS-872-eventual_consistency_status.md).

DukeDS endpoints with new failures cases:
- __POST /projects/{id}/uploads__ - creates an upload so we can upload chunks of a file
   - returns 404 with JSON data containing "code": "resource_not_consistent"
- __GET /files/{id}/url__ - get a url so we can download a file
  - returns 400 - "reason": "reported chunk hash/size does not match that computed by StorageProvider"
- __GET /file_versions/{id)/url__ - get a url of a file version so we can download a file
  - returns 400 - "reason": "reported chunk hash/size does not match that computed by 

There isn't anything we can do for the two GET endpoint failure cases.
For the __POST /projects/{id}/uploads__ we will sleep/display a message to the user while we are waiting.

- `ddsapi.DataServiceApi` will now raise `DSResourceNotConsistentError` when we encounter a 404 with the special code value of `resource_not_consistent`.

