### PR TITLE
Show actual config filename in errors

### DIFF
--- a/ddsc/config.py
+++ b/ddsc/config.py
@@ -24,6 +24,14 @@ FILE_EXCLUDE_REGEX_DEFAULT = '^\.DS_Store$|^\.ddsclient$|^\.\_'
 MAX_DEFAULT_WORKERS = 8
 
 
+def get_user_config_filename():
+    user_config_filename = os.environ.get(LOCAL_CONFIG_ENV)
+    if user_config_filename:
+        return user_config_filename
+    else:
+        return LOCAL_CONFIG_FILENAME
+
+
 def create_config(allow_insecure_config_file=False):
     """
     Create config based on /etc/ddsclient.conf and ~/.ddsclient.conf($DDSCLIENT_CONF)
@@ -32,11 +40,9 @@ def create_config(allow_insecure_config_file=False):
     """
     config = Config()
     config.add_properties(GLOBAL_CONFIG_FILENAME)
-    user_config_filename = os.environ.get(LOCAL_CONFIG_ENV)
-    if not user_config_filename:
-        user_config_filename = LOCAL_CONFIG_FILENAME
-        if not allow_insecure_config_file:
-            verify_file_private(user_config_filename)
+    user_config_filename = get_user_config_filename()
+    if user_config_filename == LOCAL_CONFIG_FILENAME and not allow_insecure_config_file:
+        verify_file_private(user_config_filename)
     config.add_properties(user_config_filename)
     return config
 

--- a/ddsc/core/tests/test_ddsapi.py
+++ b/ddsc/core/tests/test_ddsapi.py
@@ -461,11 +461,11 @@ class TestDataServiceAuth(TestCase):
         config = Mock(url='', user_key='', agent_key='abc')
         mock_requests.post.return_value = Mock(status_code=500, text='service down')
         auth = DataServiceAuth(config)
-        with self.assertRaises(AuthTokenCreationError) as raised_exception:
+        with self.assertRaises(AuthTokenCreationError) as err:
             auth.claim_new_token()
-        error_msg = str(raised_exception.exception)
-        self.assertIn('500', error_msg)
-        self.assertIn('service down', error_msg)
+        error_message = str(err.exception)
+        self.assertIn('500', error_message)
+        self.assertIn('service down', error_message)
 
 
 class TestMissingInitialSetupError(TestCase):
@@ -474,9 +474,10 @@ class TestMissingInitialSetupError(TestCase):
         mock_get_user_config_filename.return_value = '/tmp/ddsc.config'
         with self.assertRaises(MissingInitialSetupError) as err:
             raise MissingInitialSetupError()
-        self.assertIn('Missing initial setup', err.exception.message)
-        self.assertIn('/tmp/ddsc.config', err.exception.message)
-        self.assertIn(SETUP_GUIDE_URL, err.exception.message)
+        error_message = str(err.exception)
+        self.assertIn('Missing initial setup', error_message)
+        self.assertIn('/tmp/ddsc.config', error_message)
+        self.assertIn(SETUP_GUIDE_URL, error_message)
 
 
 class TestSoftwareAgentNotFoundError(TestCase):
@@ -485,15 +486,17 @@ class TestSoftwareAgentNotFoundError(TestCase):
         mock_get_user_config_filename.return_value = '/tmp/ddsc_other.config'
         with self.assertRaises(SoftwareAgentNotFoundError) as err:
             raise SoftwareAgentNotFoundError()
-        self.assertIn('Your software agent was not found', err.exception.message)
-        self.assertIn('/tmp/ddsc_other.config', err.exception.message)
+        error_message = str(err.exception)
+        self.assertIn('Your software agent was not found', error_message)
+        self.assertIn('/tmp/ddsc_other.config', error_message)
 
 
 class TestUnexpectedPagingReceivedError(TestCase):
     def test_constructor(self):
         with self.assertRaises(UnexpectedPagingReceivedError) as err:
             raise UnexpectedPagingReceivedError()
-        self.assertIn('Received unexpected paging data', err.exception.message)
+        error_message = str(err.exception)
+        self.assertIn('Received unexpected paging data', error_message)
 
 
 class TestAuthTokenCreationError(TestCase):
@@ -501,6 +504,7 @@ class TestAuthTokenCreationError(TestCase):
         request = Mock(status_code=400, text='Bad data')
         with self.assertRaises(AuthTokenCreationError) as err:
             raise AuthTokenCreationError(request)
-        self.assertIn('Failed to create auth token', err.exception.message)
-        self.assertIn('400', err.exception.message)
-        self.assertIn('Bad data', err.exception.message)
+        error_message = str(err.exception)
+        self.assertIn('Failed to create auth token', error_message)
+        self.assertIn('400', error_message)
+        self.assertIn('Bad data', error_message)

--- a/ddsc/core/tests/test_ddsapi.py
+++ b/ddsc/core/tests/test_ddsapi.py
@@ -1,9 +1,10 @@
 from __future__ import absolute_import
 from unittest import TestCase
 import requests
-from ddsc.core.ddsapi import MultiJSONResponse, DataServiceApi, UNEXPECTED_PAGING_DATA_RECEIVED, \
-    DataServiceError, DSResourceNotConsistentError
-from mock import MagicMock, Mock
+from ddsc.core.ddsapi import MultiJSONResponse, DataServiceApi, DataServiceAuth, SETUP_GUIDE_URL
+from ddsc.core.ddsapi import MissingInitialSetupError, SoftwareAgentNotFoundError, AuthTokenCreationError, \
+    UnexpectedPagingReceivedError, DataServiceError, DSResourceNotConsistentError
+from mock import MagicMock, Mock, patch
 
 
 def fake_response_with_pages(status_code, json_return_value, num_pages=1):
@@ -157,9 +158,8 @@ class TestDataServiceApi(TestCase):
             fake_response_with_pages(status_code=200, json_return_value={}, num_pages=3)
         ]
         api = DataServiceApi(auth=None, url="something.com/v1/", http=mock_requests)
-        with self.assertRaises(ValueError) as er:
+        with self.assertRaises(UnexpectedPagingReceivedError):
             api._put(url_suffix='stuff', data={})
-        self.assertEqual(UNEXPECTED_PAGING_DATA_RECEIVED, str(er.exception))
 
     def test_post_raises_error_on_paging_response(self):
         mock_requests = MagicMock()
@@ -167,9 +167,8 @@ class TestDataServiceApi(TestCase):
             fake_response_with_pages(status_code=200, json_return_value={}, num_pages=3)
         ]
         api = DataServiceApi(auth=None, url="something.com/v1/", http=mock_requests)
-        with self.assertRaises(ValueError) as er:
+        with self.assertRaises(UnexpectedPagingReceivedError):
             api._post(url_suffix='stuff', data={})
-        self.assertEqual(UNEXPECTED_PAGING_DATA_RECEIVED, str(er.exception))
 
     def test_delete_raises_error_on_paging_response(self):
         mock_requests = MagicMock()
@@ -177,9 +176,8 @@ class TestDataServiceApi(TestCase):
             fake_response_with_pages(status_code=200, json_return_value={}, num_pages=3)
         ]
         api = DataServiceApi(auth=None, url="something.com/v1/", http=mock_requests)
-        with self.assertRaises(ValueError) as er:
+        with self.assertRaises(UnexpectedPagingReceivedError):
             api._delete(url_suffix='stuff', data={})
-        self.assertEqual(UNEXPECTED_PAGING_DATA_RECEIVED, str(er.exception))
 
     def test_get_single_item_raises_error_on_paging_response(self):
         mock_requests = MagicMock()
@@ -187,9 +185,8 @@ class TestDataServiceApi(TestCase):
             fake_response_with_pages(status_code=200, json_return_value={}, num_pages=3)
         ]
         api = DataServiceApi(auth=None, url="something.com/v1/", http=mock_requests)
-        with self.assertRaises(ValueError) as er:
+        with self.assertRaises(UnexpectedPagingReceivedError):
             api._get_single_item(url_suffix='stuff', data={})
-        self.assertEqual(UNEXPECTED_PAGING_DATA_RECEIVED, str(er.exception))
 
     def test_get_single_page_works_on_paging_response(self):
         mock_requests = MagicMock()
@@ -421,3 +418,89 @@ class TestDataServiceApi(TestCase):
         second_call_second_arg = mock_requests.get.call_args_list[0][1]
         self.assertEqual(100, second_call_second_arg['params']['per_page'])
         self.assertEqual(1, second_call_second_arg['params']['page'])
+
+
+class TestDataServiceAuth(TestCase):
+    @patch('ddsc.core.ddsapi.get_user_agent_str')
+    @patch('ddsc.core.ddsapi.requests')
+    def test_claim_new_token(self, mock_requests, mock_get_user_agent_str):
+        mock_get_user_agent_str.return_value = ''
+        payload = {
+            'api_token': 'abc',
+            'expires_on': '123'
+        }
+        response = Mock(status_code=201)
+        response.json.return_value = payload
+        mock_requests.post.return_value = response
+        config = Mock(url='', user_key='', agent_key='')
+        auth = DataServiceAuth(config)
+        auth.claim_new_token()
+        self.assertEqual(auth.get_auth_data(), ('abc', '123'))
+
+    @patch('ddsc.core.ddsapi.get_user_agent_str')
+    @patch('ddsc.core.ddsapi.requests')
+    def test_claim_new_token_missing_setup(self, mock_requests, mock_get_user_agent_str):
+        config = Mock(url='', user_key='', agent_key='')
+        mock_requests.post.return_value = Mock(status_code=404)
+        auth = DataServiceAuth(config)
+        with self.assertRaises(MissingInitialSetupError):
+            auth.claim_new_token()
+
+    @patch('ddsc.core.ddsapi.get_user_agent_str')
+    @patch('ddsc.core.ddsapi.requests')
+    def test_claim_new_token_missing_agent(self, mock_requests, mock_get_user_agent_str):
+        config = Mock(url='', user_key='', agent_key='abc')
+        mock_requests.post.return_value = Mock(status_code=404)
+        auth = DataServiceAuth(config)
+        with self.assertRaises(SoftwareAgentNotFoundError):
+            auth.claim_new_token()
+
+    @patch('ddsc.core.ddsapi.get_user_agent_str')
+    @patch('ddsc.core.ddsapi.requests')
+    def test_claim_new_token_error(self, mock_requests, mock_get_user_agent_str):
+        config = Mock(url='', user_key='', agent_key='abc')
+        mock_requests.post.return_value = Mock(status_code=500, text='service down')
+        auth = DataServiceAuth(config)
+        with self.assertRaises(AuthTokenCreationError) as raised_exception:
+            auth.claim_new_token()
+        error_msg = str(raised_exception.exception)
+        self.assertIn('500', error_msg)
+        self.assertIn('service down', error_msg)
+
+
+class TestMissingInitialSetupError(TestCase):
+    @patch('ddsc.core.ddsapi.get_user_config_filename')
+    def test_constructor(self, mock_get_user_config_filename):
+        mock_get_user_config_filename.return_value = '/tmp/ddsc.config'
+        with self.assertRaises(MissingInitialSetupError) as err:
+            raise MissingInitialSetupError()
+        self.assertIn('Missing initial setup', err.exception.message)
+        self.assertIn('/tmp/ddsc.config', err.exception.message)
+        self.assertIn(SETUP_GUIDE_URL, err.exception.message)
+
+
+class TestSoftwareAgentNotFoundError(TestCase):
+    @patch('ddsc.core.ddsapi.get_user_config_filename')
+    def test_constructor(self, mock_get_user_config_filename):
+        mock_get_user_config_filename.return_value = '/tmp/ddsc_other.config'
+        with self.assertRaises(SoftwareAgentNotFoundError) as err:
+            raise SoftwareAgentNotFoundError()
+        self.assertIn('Your software agent was not found', err.exception.message)
+        self.assertIn('/tmp/ddsc_other.config', err.exception.message)
+
+
+class TestUnexpectedPagingReceivedError(TestCase):
+    def test_constructor(self):
+        with self.assertRaises(UnexpectedPagingReceivedError) as err:
+            raise UnexpectedPagingReceivedError()
+        self.assertIn('Received unexpected paging data', err.exception.message)
+
+
+class TestAuthTokenCreationError(TestCase):
+    def test_constructor(self):
+        request = Mock(status_code=400, text='Bad data')
+        with self.assertRaises(AuthTokenCreationError) as err:
+            raise AuthTokenCreationError(request)
+        self.assertIn('Failed to create auth token', err.exception.message)
+        self.assertIn('400', err.exception.message)
+        self.assertIn('Bad data', err.exception.message)

--- a/ddsc/tests/test_config.py
+++ b/ddsc/tests/test_config.py
@@ -123,3 +123,15 @@ class TestConfig(TestCase):
         mock_os.environ.get.return_value = "/shared/ddsclient.config"
         ddsc.config.create_config()
         mock_verify_file_private.assert_not_called()
+
+    @patch('ddsc.config.os')
+    def test_get_user_config_filename(self, mock_os):
+        # Pretend there is no LOCAL_CONFIG_ENV set
+        mock_os.environ.get.return_value = None
+        self.assertEqual(ddsc.config.LOCAL_CONFIG_FILENAME, ddsc.config.get_user_config_filename())
+        mock_os.environ.get.assert_called_with(ddsc.config.LOCAL_CONFIG_ENV)
+        mock_os.environ.get.reset_mock()
+        # Pretend LOCAL_CONFIG_ENV is set to /tmp/special.ddsclient.conf
+        mock_os.environ.get.return_value = '/tmp/special.ddsclient.conf'
+        self.assertEqual('/tmp/special.ddsclient.conf', ddsc.config.get_user_config_filename())
+        mock_os.environ.get.assert_called_with(ddsc.config.LOCAL_CONFIG_ENV)


### PR DESCRIPTION
Fixes #145
Changes error messages to determine the actual config filename used.
The config filename defaults to `~/.ddsclient` but is overridable via the `DDSCLIENT_CONF` environment variable: https://github.com/Duke-GCB/DukeDSClient/wiki/Configuration 