### PR TITLE
Prevent duplicate deploys

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,9 @@ deploy:
       secure: asDgRbV5BsiRA/WK0ZNBrB0NfoI6d90ugZd6pZmm8yofJVoDM6qqWWvSWi9tu6QWrmkjOY60swIHYtGiRyD2cc5O7FEL5L85bZb352GNjjgAq2odj4rpLuMi8T+CpiY/FoQBDWHpy4O5nFaIGWm5VM0kDRpzUmntTnqyj29kbka4RflM2JSo9KgUBIM1yOjz1Qy+5whEl/qY6OGSmfHmDny7AaAvPJrtcjvJbfiBLhh61nILggTzOmt0+eXzUydAZ26J5iLzEZslvAU4ZYGmnPb65rYOtiXQNxzxhYtg4unKbRemeI69nWlzNq9ptBgl7OZhUAXuHXj4Fxv9b5/HnWBXwlfioGJXsWTK4RQm/pnikYCUJv0zt1KTdR8wz8x8Izal35kXLK/g+XP3ghYKPeHHtGRra7c+Xha70UwYcbLedTtR6mvVBTBUehO6mnYpgd0w8wQAEn+3GwClB2Xrw/irolaqbPgeNlqaArjk8DILc/IQ1jsbUhsDGg/FEajSyJOkXXboBRkvY6scGmIEV5HGfCInCucmjT+Wc/+XEKUAKHXQuaBeP1Hl13MICnU5vBIyvOJkrshURH3o4Pzw27sWkjfNPhJW2iQv0bFp4Opcwr5utmTW2eklKEJ/31iLMf2BiffGN5U0pSHKJtc8Fwj8gIfSuQ1oZLY4PP3ehDY=
     on:
       tags: true
+      python: '3.5'
   - provider: script
     script: ./deploy/onpublish.sh
     on:
       tags: true
+      python: '3.5'

--- a/deploy/onpublish.py
+++ b/deploy/onpublish.py
@@ -21,12 +21,12 @@ resp = requests.get(url, headers=headers)
 if resp.status_code == 404:
     print("Creating spec file {}.".format(target_filename))
     with open(source_filename, 'r') as infile:
-        base64_content = base64.b64encode(infile.read())
+        base64_content = base64.b64encode(infile.read().encode('utf-8'))
     data = {
       "path": "rpmbuild/SPECS/{}".format(target_filename),
       "message": commit_msg,
       "committer": {"name": commit_user, "email": commit_email},
-      "content": base64_content,
+      "content": str(base64_content),
       "branch": commit_branch
     }
     resp = requests.put(url, headers=headers, json=data)


### PR DESCRIPTION
By default travis deploys once for every python version.
Changes here only deploy using the 3.5 deploy.
The pypi deploy seems ok with being run twice.
This caused deploying to the Duke-GCB/helmod repo twice.
Also fixed the helmod deploy script to be python 3.5 compatible.