### PR TITLE
Retry inconsistent downloads

### DIFF
--- a/ddsc/core/ddsapi.py
+++ b/ddsc/core/ddsapi.py
@@ -968,6 +968,6 @@ def retry_until_resource_is_consistent(func, monitor):
             return resp
         except DSResourceNotConsistentError:
             if not waiting and monitor:
-                monitor.started_waiting()
+                monitor.start_waiting()
                 waiting = True
             time.sleep(RESOURCE_NOT_CONSISTENT_RETRY_SECONDS)

--- a/ddsc/core/ddsapi.py
+++ b/ddsc/core/ddsapi.py
@@ -8,6 +8,7 @@ from ddsc.versioncheck import APP_NAME, get_internal_version_str
 AUTH_TOKEN_CLOCK_SKEW_MAX = 5 * 60  # 5 minutes
 SETUP_GUIDE_URL = "https://github.com/Duke-GCB/DukeDSClient/blob/master/docs/GettingAgentAndUserKeys.md"
 DEFAULT_RESULTS_PER_PAGE = 100
+RESOURCE_NOT_CONSISTENT_RETRY_SECONDS = 2
 
 
 def get_user_agent_str():
@@ -948,3 +949,25 @@ Try upgrading ddsclient: pip install --upgrade DukeDSClient
 
     def __init__(self):
         super(UnexpectedPagingReceivedError, self).__init__(self.MESSAGE)
+
+
+def retry_until_resource_is_consistent(func, monitor):
+    """
+    Runs func, if func raises DSResourceNotConsistentError will retry func indefinitely.
+    Notifies monitor if we have to wait(only happens if DukeDS API raises DSResourceNotConsistentError.
+    :param func: func(): function to run
+    :param monitor: object: has start_waiting() and done_waiting() methods when waiting for non-consistent resource
+    :return: whatever func returns
+    """
+    waiting = False
+    while True:
+        try:
+            resp = func()
+            if waiting and monitor:
+                monitor.done_waiting()
+            return resp
+        except DSResourceNotConsistentError:
+            if not waiting and monitor:
+                monitor.started_waiting()
+                waiting = True
+            time.sleep(RESOURCE_NOT_CONSISTENT_RETRY_SECONDS)

--- a/ddsc/core/download.py
+++ b/ddsc/core/download.py
@@ -42,7 +42,7 @@ class ProjectDownload(object):
         path_filtered_project.run(project)  # calls visit_project, visit_folder, visit_file in RemoteContentCounter
 
         self.watcher = ProgressPrinter(counter.count, msg_verb='downloading')
-        path_filtered_project = PathFilteredProject(self.path_filter, self.watcher)
+        path_filtered_project = PathFilteredProject(self.path_filter, self)
         path_filtered_project.run(project)  # calls visit_project, visit_folder, visit_file below
         self.watcher.finished()
         warnings = self.check_warnings()

--- a/ddsc/core/download.py
+++ b/ddsc/core/download.py
@@ -24,7 +24,6 @@ class ProjectDownload(object):
         self.path_filter = path_filter
         self.file_download_pre_processor = file_download_pre_processor
         self.watcher = None
-        self.project_status_monitor = None
 
     def run(self):
         """
@@ -87,7 +86,7 @@ class ProjectDownload(object):
             self.file_download_pre_processor.run(self.remote_store.data_service, item)
         path = os.path.join(self.dest_directory, item.remote_path)
         get_file_url = GetFileUrl(self.remote_store.data_service, item)
-        url_json = retry_until_resource_is_consistent(get_file_url.run, self.project_status_monitor)
+        url_json = retry_until_resource_is_consistent(get_file_url.run, self.watcher)
         downloader = FileDownloader(self.remote_store.config, item, url_json, path, self.watcher)
         downloader.run()
         ProjectDownload.check_file_size(item, path)

--- a/ddsc/core/download.py
+++ b/ddsc/core/download.py
@@ -1,5 +1,5 @@
 import os
-from ddsc.core.util import ProgressPrinter, ProjectStatusMonitor
+from ddsc.core.util import ProgressPrinter
 from ddsc.core.filedownloader import FileDownloader
 from ddsc.core.pathfilter import PathFilteredProject
 from ddsc.core.ddsapi import retry_until_resource_is_consistent
@@ -43,8 +43,7 @@ class ProjectDownload(object):
         path_filtered_project.run(project)  # calls visit_project, visit_folder, visit_file in RemoteContentCounter
 
         self.watcher = ProgressPrinter(counter.count, msg_verb='downloading')
-        self.project_status_monitor = ProjectStatusMonitor(self.watcher, action_name='downloading')
-        path_filtered_project = PathFilteredProject(self.path_filter, self)
+        path_filtered_project = PathFilteredProject(self.path_filter, self.watcher)
         path_filtered_project.run(project)  # calls visit_project, visit_folder, visit_file below
         self.watcher.finished()
         warnings = self.check_warnings()

--- a/ddsc/core/fileuploader.py
+++ b/ddsc/core/fileuploader.py
@@ -7,7 +7,7 @@ import time
 import requests
 from multiprocessing import Process, Queue
 from ddsc.core.ddsapi import DataServiceAuth, DataServiceApi, retry_until_resource_is_consistent
-from ddsc.core.util import ProgressQueue, wait_for_processes, ProjectStatusMonitor
+from ddsc.core.util import ProgressQueue, wait_for_processes
 from ddsc.core.localstore import HashData
 import traceback
 import sys
@@ -37,8 +37,7 @@ class FileUploader(object):
         """
         self.config = config
         self.data_service = data_service
-        project_status_monitor = ProjectStatusMonitor(watcher, action_name='uploading')
-        self.upload_operations = FileUploadOperations(self.data_service, project_status_monitor)
+        self.upload_operations = FileUploadOperations(self.data_service, watcher)
         self.file_upload_post_processor = file_upload_post_processor
         self.local_file = local_file
         self.upload_id = None

--- a/ddsc/core/projectuploader.py
+++ b/ddsc/core/projectuploader.py
@@ -1,6 +1,6 @@
-from ddsc.core.util import ProjectWalker, KindType
+from ddsc.core.util import ProjectWalker, KindType, ProjectStatusMonitor
 from ddsc.core.ddsapi import DataServiceAuth, DataServiceApi
-from ddsc.core.fileuploader import FileUploader, FileUploadOperations, ParentData, ProjectStatusMonitor
+from ddsc.core.fileuploader import FileUploader, FileUploadOperations, ParentData
 from ddsc.core.parallel import TaskExecutor, TaskRunner
 
 
@@ -22,7 +22,7 @@ class UploadSettings(object):
         self.project_name = project_name
         self.project_id = None
         self.file_upload_post_processor = file_upload_post_processor
-        self.project_status_monitor = ProjectStatusMonitor(watcher)
+        self.project_status_monitor = ProjectStatusMonitor(watcher, action_name='uploading')
 
     def get_data_service_auth_data(self):
         """

--- a/ddsc/core/projectuploader.py
+++ b/ddsc/core/projectuploader.py
@@ -1,4 +1,4 @@
-from ddsc.core.util import ProjectWalker, KindType, ProjectStatusMonitor
+from ddsc.core.util import ProjectWalker, KindType
 from ddsc.core.ddsapi import DataServiceAuth, DataServiceApi
 from ddsc.core.fileuploader import FileUploader, FileUploadOperations, ParentData
 from ddsc.core.parallel import TaskExecutor, TaskRunner
@@ -22,7 +22,6 @@ class UploadSettings(object):
         self.project_name = project_name
         self.project_id = None
         self.file_upload_post_processor = file_upload_post_processor
-        self.project_status_monitor = ProjectStatusMonitor(watcher, action_name='uploading')
 
     def get_data_service_auth_data(self):
         """
@@ -384,11 +383,11 @@ class CreateSmallFileCommand(object):
         Receives started_waiting boolean from create_small_file method and notifies project_status_monitor in settings.
         :param started_waiting: boolean: True when we start waiting, False when done
         """
-        project_status_monitor = self.settings.project_status_monitor
+        watcher = self.settings.watcher
         if started_waiting:
-            project_status_monitor.started_waiting()
+            watcher.start_waiting()
         else:
-            project_status_monitor.done_waiting()
+            watcher.done_waiting()
 
 
 def create_small_file(upload_context):

--- a/ddsc/core/tests/test_fileuploader.py
+++ b/ddsc/core/tests/test_fileuploader.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 from ddsc.core.fileuploader import ParallelChunkProcessor, upload_async, FileUploadOperations, \
-    RESOURCE_NOT_CONSISTENT_RETRY_SECONDS, ProjectStatusMonitor
+    RESOURCE_NOT_CONSISTENT_RETRY_SECONDS
 from ddsc.core.ddsapi import DSResourceNotConsistentError, DataServiceError
 import requests
 from mock import MagicMock, Mock, patch, call
@@ -200,31 +200,3 @@ class TestFileUploadOperations(TestCase):
         fop = FileUploadOperations(data_service, MagicMock())
         with self.assertRaises(DataServiceError):
             fop.create_upload(project_id='12', path_data=path_data, hash_data=MagicMock())
-
-
-class TestProjectStatusMonitor(TestCase):
-    def test_started_waiting_debounces(self):
-        watcher = MagicMock()
-        monitor = ProjectStatusMonitor(watcher)
-        monitor.started_waiting()
-        self.assertEqual(1, watcher.start_waiting.call_count)
-        watcher.start_waiting.assert_has_calls([
-            call('Waiting for project to become ready for uploading')
-        ])
-        monitor.started_waiting()
-        monitor.started_waiting()
-        self.assertEqual(1, watcher.start_waiting.call_count)
-        watcher.start_waiting.assert_has_calls([
-            call('Waiting for project to become ready for uploading')
-        ])
-
-    def test_done_waiting(self):
-        watcher = MagicMock()
-        monitor = ProjectStatusMonitor(watcher)
-        monitor.started_waiting()
-        monitor.done_waiting()
-        self.assertEqual(1, watcher.start_waiting.call_count)
-        watcher.start_waiting.assert_has_calls([
-            call('Waiting for project to become ready for uploading'),
-        ])
-        self.assertEqual(1, watcher.done_waiting.call_count)

--- a/ddsc/core/tests/test_util.py
+++ b/ddsc/core/tests/test_util.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
 
 from ddsc.core.util import verify_terminal_encoding, ProgressBar, ProgressPrinter, KindType
-from mock import patch, Mock, MagicMock, call
+from mock import patch, Mock
 
 
 class TestUtil(TestCase):

--- a/ddsc/core/util.py
+++ b/ddsc/core/util.py
@@ -145,6 +145,31 @@ class ProgressBar(object):
         return formatted_line
 
 
+class ProjectStatusMonitor(object):
+    """
+    Displays messages to user while we are waiting for a project that isn't ready for file uploading.
+    De-bounces messages so we don't spam the user.
+    """
+    def __init__(self, watcher, action_name):
+        """
+        :param watcher: object with show_warning(str) method
+        :param action_name: str: type of activity we are performing that may be interrupted (eg. 'uploading')
+        """
+        self.watcher = watcher
+        self.action_name = action_name
+        self.waiting = False
+
+    def started_waiting(self):
+        if not self.waiting:
+            self.watcher.start_waiting("Waiting for project to become ready for {}".format(self.action_name))
+            self.waiting = True
+
+    def done_waiting(self):
+        if self.waiting:
+            self.watcher.done_waiting()
+            self.waiting = False
+
+
 class ProjectWalker(object):
     """
     Generic tool for visiting all the nodes in a project.

--- a/ddsc/core/util.py
+++ b/ddsc/core/util.py
@@ -54,6 +54,7 @@ class ProgressPrinter(object):
         self.total = total
         self.cnt = 0
         self.max_width = 0
+        self.waiting = False
         self.msg_verb = msg_verb
         self.progress_bar = ProgressBar()
 
@@ -86,21 +87,23 @@ class ProgressPrinter(object):
         """
         print(message)
 
-    def start_waiting(self, wait_msg):
+    def start_waiting(self):
         """
-        Show waiting progress bar until done_waiting is called
-        :param wait_msg: str: message describing what we are waiting for
+        Show waiting progress bar until done_waiting is called.
+        Only has an effect if we are in waiting state.
         """
-        self.progress_bar.wait_msg = wait_msg
-        self.progress_bar.set_state(ProgressBar.STATE_WAITING)
-        self.progress_bar.show()
+        if not self.waiting:
+            self.waiting = True
+            wait_msg = "Waiting for project to become ready for {}".format(self.msg_verb)
+            self.progress_bar.show_waiting(wait_msg)
 
     def done_waiting(self):
         """
-        Show running progress bar
+        Show running progress bar (only has an effect if we are in waiting state).
         """
-        self.progress_bar.set_state(ProgressBar.STATE_RUNNING)
-        self.progress_bar.show()
+        if self.waiting:
+            self.waiting = False
+            self.progress_bar.show_running()
 
 
 class ProgressBar(object):
@@ -144,30 +147,22 @@ class ProgressBar(object):
             formatted_line += '\n'
         return formatted_line
 
-
-class ProjectStatusMonitor(object):
-    """
-    Displays messages to user while we are waiting for a project that isn't ready for file uploading.
-    De-bounces messages so we don't spam the user.
-    """
-    def __init__(self, watcher, action_name):
+    def show_running(self):
         """
-        :param watcher: object with show_warning(str) method
-        :param action_name: str: type of activity we are performing that may be interrupted (eg. 'uploading')
+        Show running progress bar
         """
-        self.watcher = watcher
-        self.action_name = action_name
-        self.waiting = False
+        self.set_state(ProgressBar.STATE_RUNNING)
+        self.show()
 
-    def started_waiting(self):
-        if not self.waiting:
-            self.watcher.start_waiting("Waiting for project to become ready for {}".format(self.action_name))
-            self.waiting = True
-
-    def done_waiting(self):
-        if self.waiting:
-            self.watcher.done_waiting()
-            self.waiting = False
+    def show_waiting(self, wait_msg):
+        """
+        Show waiting progress bar until done_waiting is called.
+        Only has an effect if we are in waiting state.
+        :param wait_msg: str: message describing what we are waiting for
+        """
+        self.wait_msg = wait_msg
+        self.set_state(ProgressBar.STATE_WAITING)
+        self.show()
 
 
 class ProjectWalker(object):


### PR DESCRIPTION
When downloading a file there is a special 404 that has a `resource_not_consistent` value in `code`. This occurs when the file url is not currently ready. A background DukeDS process should finish up with the file and we can try again.  Similar to what we did with uploads waiting for the project to get ready we will pause and retry. The user will see a message that we are waiting.
Fixes #152