### PR TITLE
Allow empty/none for terminal encoding

### DIFF
--- a/ddsc/core/tests/test_util.py
+++ b/ddsc/core/tests/test_util.py
@@ -16,13 +16,11 @@ class TestUtil(TestCase):
         with self.assertRaises(ValueError):
             verify_terminal_encoding('ascii')
 
-    def test_verify_terminal_encoding_empty_raises(self):
-        with self.assertRaises(ValueError):
-            verify_terminal_encoding('')
+    def test_verify_terminal_encoding_empty_is_ok(self):
+        verify_terminal_encoding('')
 
-    def test_verify_terminal_encoding_none_raises(self):
-        with self.assertRaises(ValueError):
-            verify_terminal_encoding(None)
+    def test_verify_terminal_encoding_none_is_ok(self):
+        verify_terminal_encoding(None)
 
 
 class TestProgressBar(TestCase):

--- a/ddsc/core/util.py
+++ b/ddsc/core/util.py
@@ -301,8 +301,7 @@ def verify_terminal_encoding(encoding):
     Raises ValueError with error message when terminal encoding is not Unicode(contains UTF ignoring case).
     :param encoding: str: encoding we want to check
     """
-    encoding = encoding or ''
-    if not ("UTF" in encoding.upper()) and encoding:
+    if encoding and not ("UTF" in encoding.upper()):
         raise ValueError(TERMINAL_ENCODING_NOT_UTF_ERROR)
 
 

--- a/ddsc/core/util.py
+++ b/ddsc/core/util.py
@@ -302,7 +302,7 @@ def verify_terminal_encoding(encoding):
     :param encoding: str: encoding we want to check
     """
     encoding = encoding or ''
-    if not ("UTF" in encoding.upper()):
+    if not ("UTF" in encoding.upper()) and encoding:
         raise ValueError(TERMINAL_ENCODING_NOT_UTF_ERROR)
 
 


### PR DESCRIPTION
When ddsclient output was piped or redirected to a file
the terminal encoding error was raised. We will now allow
None as an encoding value.
Fixes #154 