### PR TITLE
Project id flag

### DIFF
--- a/ddsc/cmdparser.py
+++ b/ddsc/cmdparser.py
@@ -44,6 +44,33 @@ def add_project_name_arg(arg_parser, required=True, help_text="Name of the remot
                             required=required)
 
 
+def add_project_id_arg(arg_parser, required=True, help_text="Name of the remote project to manage."):
+    """
+    Adds project_name parameter to a parser.
+    :param arg_parser: ArgumentParser parser to add this argument to.
+    :param help_text: str label displayed in usage
+    """
+    arg_parser.add_argument("-i",
+                            metavar='ProjectUUID',
+                            type=to_unicode,
+                            dest='project_id',
+                            help=help_text,
+                            required=required)
+
+
+def add_project_name_or_id_arg(arg_parser, required=True, help_text="ID of the remote project to manage."):
+    """
+    Adds project name or project id argument. These two are mutually exclusive.
+    :param arg_parser:
+    :param required:
+    :param help_text:
+    :return:
+    """
+    project_name_or_id = arg_parser.add_mutually_exclusive_group(required=required)
+    add_project_name_arg(project_name_or_id, required=False, help_text=help_text)
+    add_project_id_arg(project_name_or_id, required=False, help_text=help_text)
+
+
 def _paths_must_exists(path):
     """
     Raises error if path doesn't exist.
@@ -298,7 +325,7 @@ class CommandParser(object):
         upload_parser = self.subparsers.add_parser('upload', description=description)
         _add_dry_run(upload_parser, help_text="Instead of uploading displays a list of folders/files that "
                                               "need to be uploaded.")
-        add_project_name_arg(upload_parser, help_text="Name of the project to upload files/folders to.")
+        add_project_name_or_id_arg(upload_parser, help_text="Name of the project to upload files/folders to.")
         _add_folders_positional_arg(upload_parser)
         _add_follow_symlinks_arg(upload_parser)
         upload_parser.set_defaults(func=upload_func)
@@ -311,7 +338,7 @@ class CommandParser(object):
         """
         description = "Gives user permission to access a remote project."
         add_user_parser = self.subparsers.add_parser('add-user', description=description)
-        add_project_name_arg(add_user_parser, help_text="Name of the project to add a user to.")
+        add_project_name_or_id_arg(add_user_parser, help_text="Name of the project to add a user to.")
         user_or_email = add_user_parser.add_mutually_exclusive_group(required=True)
         add_user_arg(user_or_email)
         add_email_arg(user_or_email)
@@ -325,7 +352,7 @@ class CommandParser(object):
         """
         description = "Removes user permission to access a remote project."
         remove_user_parser = self.subparsers.add_parser('remove-user', description=description)
-        add_project_name_arg(remove_user_parser, help_text="Name of the project to remove a user from.")
+        add_project_name_or_id_arg(remove_user_parser, help_text="Name of the project to remove a user from.")
         user_or_email = remove_user_parser.add_mutually_exclusive_group(required=True)
         add_user_arg(user_or_email)
         add_email_arg(user_or_email)
@@ -338,7 +365,7 @@ class CommandParser(object):
         """
         description = "Download the contents of a remote remote project to a local folder."
         download_parser = self.subparsers.add_parser('download', description=description)
-        add_project_name_arg(download_parser, help_text="Name of the project to download.")
+        add_project_name_or_id_arg(download_parser, help_text="Name of the project to download.")
         _add_folder_positional_arg(download_parser)
         include_or_exclude = download_parser.add_mutually_exclusive_group(required=False)
         _add_include_arg(include_or_exclude)
@@ -354,7 +381,7 @@ class CommandParser(object):
                       "Sends the other user an email message via D4S2 service. " \
                       "If not specified this command gives user download permissions."
         share_parser = self.subparsers.add_parser('share', description=description)
-        add_project_name_arg(share_parser)
+        add_project_name_or_id_arg(share_parser)
         user_or_email = share_parser.add_mutually_exclusive_group(required=True)
         add_user_arg(user_or_email)
         add_email_arg(user_or_email)
@@ -373,7 +400,7 @@ class CommandParser(object):
                       "Makes a copy of the project. Send message to D4S2 service to send email and allow " \
                       "access to the copy of the project once user acknowledges receiving the data."
         deliver_parser = self.subparsers.add_parser('deliver', description=description)
-        add_project_name_arg(deliver_parser)
+        add_project_name_or_id_arg(deliver_parser)
         user_or_email = deliver_parser.add_mutually_exclusive_group(required=True)
         add_user_arg(user_or_email)
         add_email_arg(user_or_email)
@@ -395,7 +422,7 @@ class CommandParser(object):
         list_parser = self.subparsers.add_parser('list', description=description)
         project_name_or_auth_role = list_parser.add_mutually_exclusive_group(required=False)
         _add_project_filter_auth_role_arg(project_name_or_auth_role)
-        add_project_name_arg(project_name_or_auth_role, required=False, help_text="Name of the project to show details for.")
+        add_project_name_or_id_arg(project_name_or_auth_role, required=False, help_text="Name of the project to show details for.")
         list_parser.set_defaults(func=list_func)
 
     def register_delete_command(self, delete_func):
@@ -405,7 +432,7 @@ class CommandParser(object):
         """
         description = "Permanently delete a project."
         delete_parser = self.subparsers.add_parser('delete', description=description)
-        add_project_name_arg(delete_parser, help_text="Name of the project to delete.")
+        add_project_name_or_id_arg(delete_parser, help_text="Name of the project to delete.")
         _add_force_arg(delete_parser, "Do not prompt before deleting.")
         delete_parser.set_defaults(func=delete_func)
 

--- a/ddsc/cmdparser.py
+++ b/ddsc/cmdparser.py
@@ -30,13 +30,13 @@ def to_unicode(s):
     return s if six.PY3 else str(s, 'utf-8')
 
 
-def add_project_name_arg(arg_parser, required=True, help_text="Name of the remote project to manage."):
+def add_project_name_arg(arg_parser, required, help_text):
     """
     Adds project_name parameter to a parser.
     :param arg_parser: ArgumentParser parser to add this argument to.
     :param help_text: str label displayed in usage
     """
-    arg_parser.add_argument("-p",
+    arg_parser.add_argument("-p", '--project-name',
                             metavar='ProjectName',
                             type=to_unicode,
                             dest='project_name',
@@ -44,13 +44,13 @@ def add_project_name_arg(arg_parser, required=True, help_text="Name of the remot
                             required=required)
 
 
-def add_project_id_arg(arg_parser, required=True, help_text="Name of the remote project to manage."):
+def add_project_id_arg(arg_parser, required, help_text):
     """
     Adds project_name parameter to a parser.
     :param arg_parser: ArgumentParser parser to add this argument to.
     :param help_text: str label displayed in usage
     """
-    arg_parser.add_argument("-i",
+    arg_parser.add_argument("-i", '--project-id',
                             metavar='ProjectUUID',
                             type=to_unicode,
                             dest='project_id',
@@ -58,7 +58,7 @@ def add_project_id_arg(arg_parser, required=True, help_text="Name of the remote 
                             required=required)
 
 
-def add_project_name_or_id_arg(arg_parser, required=True, help_text="ID of the remote project to manage."):
+def add_project_name_or_id_arg(arg_parser, required=True, help_text_suffix="manage"):
     """
     Adds project name or project id argument. These two are mutually exclusive.
     :param arg_parser:
@@ -67,8 +67,10 @@ def add_project_name_or_id_arg(arg_parser, required=True, help_text="ID of the r
     :return:
     """
     project_name_or_id = arg_parser.add_mutually_exclusive_group(required=required)
-    add_project_name_arg(project_name_or_id, required=False, help_text=help_text)
-    add_project_id_arg(project_name_or_id, required=False, help_text=help_text)
+    name_help_text = "Name of the project to {}.".format(help_text_suffix)
+    add_project_name_arg(project_name_or_id, required=False, help_text=name_help_text)
+    id_help_text = "ID of the project to {}.".format(help_text_suffix)
+    add_project_id_arg(project_name_or_id, required=False, help_text=id_help_text)
 
 
 def _paths_must_exists(path):
@@ -336,7 +338,7 @@ class CommandParser(object):
         upload_parser = self.subparsers.add_parser('upload', description=description)
         _add_dry_run(upload_parser, help_text="Instead of uploading displays a list of folders/files that "
                                               "need to be uploaded.")
-        add_project_name_or_id_arg(upload_parser, help_text="Name of the project to upload files/folders to.")
+        add_project_name_or_id_arg(upload_parser, help_text_suffix="upload files/folders to.")
         _add_folders_positional_arg(upload_parser)
         _add_follow_symlinks_arg(upload_parser)
         upload_parser.set_defaults(func=upload_func)
@@ -349,7 +351,7 @@ class CommandParser(object):
         """
         description = "Gives user permission to access a remote project."
         add_user_parser = self.subparsers.add_parser('add-user', description=description)
-        add_project_name_or_id_arg(add_user_parser, help_text="Name of the project to add a user to.")
+        add_project_name_or_id_arg(add_user_parser, help_text_suffix="add a user to")
         user_or_email = add_user_parser.add_mutually_exclusive_group(required=True)
         add_user_arg(user_or_email)
         add_email_arg(user_or_email)
@@ -363,7 +365,7 @@ class CommandParser(object):
         """
         description = "Removes user permission to access a remote project."
         remove_user_parser = self.subparsers.add_parser('remove-user', description=description)
-        add_project_name_or_id_arg(remove_user_parser, help_text="Name of the project to remove a user from.")
+        add_project_name_or_id_arg(remove_user_parser, help_text_suffix="remove a user from")
         user_or_email = remove_user_parser.add_mutually_exclusive_group(required=True)
         add_user_arg(user_or_email)
         add_email_arg(user_or_email)
@@ -376,7 +378,7 @@ class CommandParser(object):
         """
         description = "Download the contents of a remote remote project to a local folder."
         download_parser = self.subparsers.add_parser('download', description=description)
-        add_project_name_or_id_arg(download_parser, help_text="Name of the project to download.")
+        add_project_name_or_id_arg(download_parser, help_text_suffix="download")
         _add_folder_positional_arg(download_parser)
         include_or_exclude = download_parser.add_mutually_exclusive_group(required=False)
         _add_include_arg(include_or_exclude)
@@ -433,7 +435,8 @@ class CommandParser(object):
         list_parser = self.subparsers.add_parser('list', description=description)
         project_name_or_auth_role = list_parser.add_mutually_exclusive_group(required=False)
         _add_project_filter_auth_role_arg(project_name_or_auth_role)
-        add_project_name_or_id_arg(project_name_or_auth_role, required=False, help_text="Name of the project to show details for.")
+        add_project_name_or_id_arg(project_name_or_auth_role, required=False,
+                                   help_text_suffix="show details for")
         _add_long_format_option(list_parser, 'Display long format.')
         list_parser.set_defaults(func=list_func)
 
@@ -444,7 +447,7 @@ class CommandParser(object):
         """
         description = "Permanently delete a project."
         delete_parser = self.subparsers.add_parser('delete', description=description)
-        add_project_name_or_id_arg(delete_parser, help_text="Name of the project to delete.")
+        add_project_name_or_id_arg(delete_parser, help_text_suffix="delete")
         _add_force_arg(delete_parser, "Do not prompt before deleting.")
         delete_parser.set_defaults(func=delete_func)
 

--- a/ddsc/cmdparser.py
+++ b/ddsc/cmdparser.py
@@ -302,6 +302,17 @@ def _add_message_file(arg_parser, help_text):
                             help=help_text)
 
 
+def _add_long_format_option(arg_parser, help_text):
+    """
+    Adds optional follow_symlinks parameter to a parser.
+    :param arg_parser: ArgumentParser parser to add this argument to.
+    """
+    arg_parser.add_argument("-l",
+                            help=help_text,
+                            action='store_true',
+                            dest='long_format')
+
+
 class CommandParser(object):
     """
     Root command line parser. Supports the following commands: upload and add_user.
@@ -423,6 +434,7 @@ class CommandParser(object):
         project_name_or_auth_role = list_parser.add_mutually_exclusive_group(required=False)
         _add_project_filter_auth_role_arg(project_name_or_auth_role)
         add_project_name_or_id_arg(project_name_or_auth_role, required=False, help_text="Name of the project to show details for.")
+        _add_long_format_option(list_parser, 'Display long format.')
         list_parser.set_defaults(func=list_func)
 
     def register_delete_command(self, delete_func):

--- a/ddsc/core/download.py
+++ b/ddsc/core/download.py
@@ -9,17 +9,17 @@ class ProjectDownload(object):
     """
     Creates local version of remote content.
     """
-    def __init__(self, remote_store, project_name, dest_directory, path_filter, file_download_pre_processor=None):
+    def __init__(self, remote_store, project, dest_directory, path_filter, file_download_pre_processor=None):
         """
         Setup for downloading a remote project.
         :param remote_store: RemoteStore: which remote store to download the project from
-        :param project_name: str: name of the project to download
+        :param project: RemoteProject: project to download
         :param dest_directory: str: path to where we will save the project contents
         :param path_filter: PathFilter: determines which files will be downloaded
         :param file_download_pre_processor: object: has run(data_service, RemoteFile) method to run before downloading
         """
         self.remote_store = remote_store
-        self.project_name = project_name
+        self.project = project
         self.dest_directory = dest_directory
         self.path_filter = path_filter
         self.file_download_pre_processor = file_download_pre_processor
@@ -27,10 +27,9 @@ class ProjectDownload(object):
 
     def run(self):
         """
-        Download the contents of the specified project_name to dest_directory.
+        Download the contents of the specified project name or id to dest_directory.
         """
-        remote_project = self.remote_store.fetch_remote_project(self.project_name, must_exist=True)
-        self.walk_project(remote_project)
+        self.walk_project(self.project)
 
     def walk_project(self, project):
         """

--- a/ddsc/core/projectuploader.py
+++ b/ddsc/core/projectuploader.py
@@ -8,18 +8,18 @@ class UploadSettings(object):
     """
     Settings used to upload a project
     """
-    def __init__(self, config, data_service, watcher, project_name, file_upload_post_processor):
+    def __init__(self, config, data_service, watcher, project_name_or_id, file_upload_post_processor):
         """
         :param config: ddsc.config.Config user configuration settings from YAML file/environment
         :param data_service: DataServiceApi: where we will upload to
         :param watcher: ProgressPrinter we notify of our progress
-        :param project_name: str: name of the project so we can create it if necessary
+        :param project_name_or_id: ProjectNameOrId: name or id of the project so we can create it if necessary
         :param file_upload_post_processor: object: has run(data_service, file_response) method to run after download
         """
         self.config = config
         self.data_service = data_service
         self.watcher = watcher
-        self.project_name = project_name
+        self.project_name_or_id = project_name_or_id
         self.project_id = None
         self.file_upload_post_processor = file_upload_post_processor
 
@@ -58,7 +58,7 @@ class UploadContext(object):
         """
         self.data_service_auth_data = settings.get_data_service_auth_data()
         self.config = settings.config
-        self.project_name = settings.project_name
+        self.project_name_or_id = settings.project_name_or_id
         self.project_id = settings.project_id
         self.params = params
         self.message_queue = message_queue
@@ -240,7 +240,9 @@ class CreateProjectCommand(object):
         """
         self.settings = settings
         self.local_project = local_project
-        self.project_name = settings.project_name
+        if not settings.project_name_or_id.is_name:
+            raise ValueError('Programming Error: CreateProjectCommand called without project name.')
+        self.project_name = settings.project_name_or_id.get_name_or_raise()
         self.func = upload_project_run
 
     def before_run(self, parent_task_result):
@@ -273,7 +275,7 @@ def upload_project_run(upload_context):
     :param upload_context: UploadContext: contains data service setup and project name to create.
     """
     data_service = upload_context.make_data_service()
-    project_name = upload_context.project_name
+    project_name = upload_context.project_name_or_id.get_name_or_raise()
     result = data_service.create_project(project_name, project_name)
     return result.json()['id']
 

--- a/ddsc/core/projectuploader.py
+++ b/ddsc/core/projectuploader.py
@@ -242,7 +242,6 @@ class CreateProjectCommand(object):
         self.local_project = local_project
         if not settings.project_name_or_id.is_name:
             raise ValueError('Programming Error: CreateProjectCommand called without project name.')
-        self.project_name = settings.project_name_or_id.get_name_or_raise()
         self.func = upload_project_run
 
     def before_run(self, parent_task_result):

--- a/ddsc/core/remotestore.py
+++ b/ddsc/core/remotestore.py
@@ -255,6 +255,12 @@ class RemoteStore(object):
             names.append(project['name'])
         return names
 
+    def get_projects_details(self):
+        """
+        Return list of top level details for all projects
+        """
+        return self.data_service.get_projects().json()['results']
+
     def get_projects_with_auth_role(self, auth_role):
         """
         Return the list of projects that have the specified auth role from the list that the current user has access to.

--- a/ddsc/core/remotestore.py
+++ b/ddsc/core/remotestore.py
@@ -587,6 +587,11 @@ class ProjectNameOrId(object):
             return self.value
         raise ValueError("Programming Error: Cannot return name. value is project id.")
 
+    def get_id_or_raise(self):
+        if not self.is_name:
+            return self.value
+        raise ValueError("Programming Error: Cannot return id. value is project name.")
+
     @staticmethod
     def create_from_name(name):
         return ProjectNameOrId(value=name, is_name=True)

--- a/ddsc/core/remotestore.py
+++ b/ddsc/core/remotestore.py
@@ -566,6 +566,11 @@ class NotFoundError(Exception):
 
 
 class ProjectNameOrId(object):
+    """
+    Contains either a project name or a project id(uuid).
+    If it contains a project ID the project is assumed to already exist (only DukeDS makes up project uuid).
+    If it contains a project name they project may or may not exist.
+    """
     def __init__(self, value, is_name):
         self.value = value
         self.is_name = is_name

--- a/ddsc/core/tests/test_d4s2.py
+++ b/ddsc/core/tests/test_d4s2.py
@@ -69,7 +69,6 @@ class TestCopyActivity(TestCase):
     def test_constructor_and_finished(self):
         data_service = MagicMock()
         data_service.create_activity().json().__getitem__.return_value = '1'
-        project_name = "mouse"
         new_project_name = "mouse_copy"
 
         # Constructor should create activity

--- a/ddsc/core/tests/test_d4s2.py
+++ b/ddsc/core/tests/test_d4s2.py
@@ -12,7 +12,7 @@ class TestD4S2Project(TestCase):
     def test_share(self, mock_requests, mock_d4s2api):
         mock_d4s2api().get_existing_item.return_value = Mock(json=Mock(return_value=[]))
         project = D4S2Project(config=MagicMock(), remote_store=MagicMock(), print_func=MagicMock())
-        project.share(project_name='mouserna',
+        project.share(project=Mock(name='mouserna'),
                       to_user=MagicMock(id='123'),
                       force_send=False,
                       auth_role='project_viewer',
@@ -30,7 +30,7 @@ class TestD4S2Project(TestCase):
     def test_deliver(self, mock_requests, mock_d4s2api):
         mock_d4s2api().get_existing_item.return_value = Mock(json=Mock(return_value=[]))
         project = D4S2Project(config=MagicMock(), remote_store=MagicMock(), print_func=MagicMock())
-        project.deliver(project_name='mouserna',
+        project.deliver(project=Mock(name='mouserna'),
                         new_project_name=None,
                         to_user=MagicMock(id='456'),
                         force_send=False,
@@ -51,7 +51,7 @@ class TestD4S2Project(TestCase):
         remote_store.fetch_remote_project.return_value = None
         project = D4S2Project(config=MagicMock(), remote_store=remote_store, print_func=MagicMock())
         path_filter = PathFilter(include_paths=[], exclude_paths=[])
-        project._copy_project('mouse', 'new_mouse', path_filter)
+        project._copy_project(Mock(name='mouse'), 'new_mouse', path_filter)
         data_service.create_activity.assert_called()
 
         mock_project_download.assert_called()
@@ -73,7 +73,9 @@ class TestCopyActivity(TestCase):
         new_project_name = "mouse_copy"
 
         # Constructor should create activity
-        activity = CopyActivity(data_service, project_name, new_project_name)
+        project = Mock()
+        project.name = 'mouse'
+        activity = CopyActivity(data_service, project, new_project_name)
         self.assertEqual('1', activity.id)
         data_service.create_activity.assert_called()
         args, kwargs = data_service.create_activity.call_args
@@ -101,7 +103,7 @@ class TestDownloadedFileRelations(TestCase):
         data_service = MagicMock()
         data_service.create_activity().json().__getitem__.return_value = new_activity_id
         remote_file = Mock(remote_path=file_remote_path, file_version_id=file_version_id)
-        activity = CopyActivity(data_service, "mouse", "mouse_copy")
+        activity = CopyActivity(data_service, Mock(name='mouse'), "mouse_copy")
 
         downloaded_file_relations = DownloadedFileRelations(activity)
         downloaded_file_relations.run(data_service, remote_file)
@@ -141,7 +143,7 @@ class TestUploadedFileRelations(TestCase):
         }
         data_service = MagicMock()
         data_service.create_activity().json().__getitem__.return_value = new_activity_id
-        activity = CopyActivity(data_service, "mouse", "mouse_copy")
+        activity = CopyActivity(data_service, Mock(name="mouse"), "mouse_copy")
         activity.remote_path_to_file_version_id[file_remote_path] = download_file_version_id
 
         uploaded_file_relations = UploadedFileRelations(activity)

--- a/ddsc/core/tests/test_download.py
+++ b/ddsc/core/tests/test_download.py
@@ -9,7 +9,7 @@ class TestProjectDownload(TestCase):
     @patch('ddsc.core.download.ProjectDownload.check_file_size')
     def test_visit_file_download_pre_processor_off(self, mock_file_downloader, mock_check_file_size):
         project_download = ProjectDownload(remote_store=MagicMock(),
-                                           project_name='test',
+                                           project=Mock(name='test'),
                                            dest_directory='/tmp/fakedir',
                                            path_filter=MagicMock())
         project_download.visit_file(Mock(), None)
@@ -20,7 +20,7 @@ class TestProjectDownload(TestCase):
         pre_processor_run = MagicMock()
         pre_processor = Mock(run=pre_processor_run)
         project_download = ProjectDownload(remote_store=MagicMock(),
-                                           project_name='test',
+                                           project=Mock(name='test'),
                                            dest_directory='/tmp/fakedir',
                                            path_filter=MagicMock(),
                                            file_download_pre_processor=pre_processor)

--- a/ddsc/core/tests/test_upload.py
+++ b/ddsc/core/tests/test_upload.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 from unittest import TestCase
 from ddsc.core.upload import ProjectUpload, LocalOnlyCounter
 from ddsc.core.localstore import LocalFile
+from ddsc.core.remotestore import ProjectNameOrId
 from mock import MagicMock, patch
 
 
@@ -11,7 +12,8 @@ class TestUploadCommand(TestCase):
     @patch("ddsc.core.upload.ProjectUploadDryRun")
     def test_nothing_to_do(self, MockProjectUploadDryRun, MockProjectUpload, MockRemoteStore):
         MockProjectUploadDryRun().upload_items = []
-        project_upload = ProjectUpload(MagicMock(), "someProject", ["data"])
+        name_or_id = ProjectNameOrId.create_from_name("someProject")
+        project_upload = ProjectUpload(MagicMock(), name_or_id, ["data"])
         dry_run_report = project_upload.dry_run_report()
         self.assertIn("No changes found. Nothing needs to be uploaded.", dry_run_report)
 
@@ -20,7 +22,8 @@ class TestUploadCommand(TestCase):
     @patch("ddsc.core.upload.ProjectUploadDryRun")
     def test_two_files_to_upload(self, MockProjectUploadDryRun, MockProjectUpload, MockRemoteStore):
         MockProjectUploadDryRun().upload_items = ['data.txt', 'data2.txt']
-        project_upload = ProjectUpload(MagicMock(), "someProject", ["data"])
+        name_or_id = ProjectNameOrId.create_from_name("someProject")
+        project_upload = ProjectUpload(MagicMock(), name_or_id, ["data"])
         dry_run_report = project_upload.dry_run_report()
         self.assertIn("Files/Folders that need to be uploaded:", dry_run_report)
         self.assertIn("data.txt", dry_run_report)

--- a/ddsc/core/util.py
+++ b/ddsc/core/util.py
@@ -231,11 +231,12 @@ class FilteredProject(object):
             self.visitor.visit_file(item, parent)
 
 
-class ProjectFilenameList(object):
+class ProjectDetailsList(object):
     """
     Walks a project and saves the project name and filenames to [str] filenames property.
     """
-    def __init__(self):
+    def __init__(self, long_format):
+        self.long_format = long_format
         self.details = []
         self.id_to_path = {}
 
@@ -248,16 +249,25 @@ class ProjectFilenameList(object):
         ProjectWalker.walk_project(project, self)
 
     def visit_project(self, item):
-        self.details.append("Project {} Contents:".format(item.name))
+        if self.long_format:
+            self.details.append("{} - Project {} Contents:".format(item.id, item.name))
+        else:
+            self.details.append("Project {} Contents:".format(item.name))
 
     def visit_folder(self, item, parent):
         name = self.get_name(item, parent)
         self.id_to_path[item.id] = name
-        self.details.append(name)
+        if self.long_format:
+            self.details.append('{}\t{}'.format(item.id, item.name))
+        else:
+            self.details.append(name)
 
     def visit_file(self, item, parent):
         name = self.get_name(item, parent)
-        self.details.append(name)
+        if self.long_format:
+            self.details.append('{}\t{}'.format(item.id, item.name))
+        else:
+            self.details.append(name)
 
     def get_name(self, item, parent):
         if parent:

--- a/ddsc/core/util.py
+++ b/ddsc/core/util.py
@@ -258,14 +258,14 @@ class ProjectDetailsList(object):
         name = self.get_name(item, parent)
         self.id_to_path[item.id] = name
         if self.long_format:
-            self.details.append('{}\t{}'.format(item.id, item.name))
+            self.details.append('{}\t{}'.format(item.id, name))
         else:
             self.details.append(name)
 
     def visit_file(self, item, parent):
         name = self.get_name(item, parent)
         if self.long_format:
-            self.details.append('{}\t{}'.format(item.id, item.name))
+            self.details.append('{}\t{}'.format(item.id, name))
         else:
             self.details.append(name)
 

--- a/ddsc/ddsclient.py
+++ b/ddsc/ddsclient.py
@@ -3,7 +3,6 @@ from __future__ import print_function, unicode_literals
 from builtins import input
 import sys
 import datetime
-import pipes
 import time
 from ddsc.core.d4s2 import D4S2Project, D4S2Error
 from ddsc.core.remotestore import RemoteStore, RemoteAuthRole, ProjectNameOrId

--- a/ddsc/tests/test_cmdparser.py
+++ b/ddsc/tests/test_cmdparser.py
@@ -129,3 +129,18 @@ class TestCommandParser(TestCase):
         self.assertEqual(True, self.parsed_args.long_format)
         self.assertEqual(None, self.parsed_args.project_name)
         self.assertEqual('123', self.parsed_args.project_id)
+
+        command_parser.run_command(['list', '--project-id', '123', '-l'])
+        self.assertEqual(True, self.parsed_args.long_format)
+        self.assertEqual(None, self.parsed_args.project_name)
+        self.assertEqual('123', self.parsed_args.project_id)
+
+        command_parser.run_command(['list', '-p', 'mouse', '-l'])
+        self.assertEqual(True, self.parsed_args.long_format)
+        self.assertEqual('mouse', self.parsed_args.project_name)
+        self.assertEqual(None, self.parsed_args.project_id)
+
+        command_parser.run_command(['list', '--project-name', 'mouse', '-l'])
+        self.assertEqual(True, self.parsed_args.long_format)
+        self.assertEqual('mouse', self.parsed_args.project_name)
+        self.assertEqual(None, self.parsed_args.project_id)

--- a/ddsc/tests/test_cmdparser.py
+++ b/ddsc/tests/test_cmdparser.py
@@ -15,15 +15,37 @@ class TestCommandParser(TestCase):
     def set_parsed_args(self, args):
         self.parsed_args = args
 
-    def test_register_add_user_command_no_msg(self):
+    def test_register_add_user_command_project_name(self):
         command_parser = CommandParser()
-        command_parser.register_add_user_command(no_op)
+        command_parser.register_add_user_command(self.set_parsed_args)
         self.assertEqual(['add-user'], list(command_parser.subparsers.choices.keys()))
+        command_parser.run_command(['add-user', '-p', 'myproj', '--user', 'joe123'])
+        self.assertEqual('myproj', self.parsed_args.project_name)
+        self.assertEqual(None, self.parsed_args.project_id)
 
-    def test_register_remove_user_command(self):
+    def test_register_add_user_command_project_id(self):
         command_parser = CommandParser()
-        command_parser.register_remove_user_command(no_op)
+        command_parser.register_add_user_command(self.set_parsed_args)
+        self.assertEqual(['add-user'], list(command_parser.subparsers.choices.keys()))
+        command_parser.run_command(['add-user', '-i', '123', '--user', 'joe123'])
+        self.assertEqual(None, self.parsed_args.project_name)
+        self.assertEqual('123', self.parsed_args.project_id)
+
+    def test_register_remove_user_command_project_name(self):
+        command_parser = CommandParser()
+        command_parser.register_remove_user_command(self.set_parsed_args)
         self.assertEqual(['remove-user'], list(command_parser.subparsers.choices.keys()))
+        command_parser.run_command(['remove-user', '-p', 'myproj', '--user', 'joe123'])
+        self.assertEqual('myproj', self.parsed_args.project_name)
+        self.assertEqual(None, self.parsed_args.project_id)
+
+    def test_register_remove_user_command_project_id(self):
+        command_parser = CommandParser()
+        command_parser.register_remove_user_command(self.set_parsed_args)
+        self.assertEqual(['remove-user'], list(command_parser.subparsers.choices.keys()))
+        command_parser.run_command(['remove-user', '-i', '456', '--user', 'joe123'])
+        self.assertEqual(None, self.parsed_args.project_name)
+        self.assertEqual('456', self.parsed_args.project_id)
 
     def test_deliver_no_msg(self):
         command_parser = CommandParser()
@@ -31,27 +53,35 @@ class TestCommandParser(TestCase):
         self.assertEqual(['deliver'], list(command_parser.subparsers.choices.keys()))
         command_parser.run_command(['deliver', '-p', 'someproject', '--user', 'joe123'])
         self.assertEqual(None, self.parsed_args.msg_file)
+        self.assertEqual('someproject', self.parsed_args.project_name)
+        self.assertEqual(None, self.parsed_args.project_id)
 
     def test_deliver_with_msg(self):
         command_parser = CommandParser()
         command_parser.register_deliver_command(self.set_parsed_args)
         self.assertEqual(['deliver'], list(command_parser.subparsers.choices.keys()))
-        command_parser.run_command(['deliver', '-p', 'someproject', '--user', 'joe123', '--msg-file', 'setup.py'])
+        command_parser.run_command(['deliver', '-i', '123', '--user', 'joe123', '--msg-file', 'setup.py'])
         self.assertIn('setup(', self.parsed_args.msg_file.read())
+        self.assertEqual(None, self.parsed_args.project_name)
+        self.assertEqual('123', self.parsed_args.project_id)
 
     def test_share_no_msg(self):
         command_parser = CommandParser()
         command_parser.register_share_command(self.set_parsed_args)
         self.assertEqual(['share'], list(command_parser.subparsers.choices.keys()))
-        command_parser.run_command(['share', '-p', 'someproject', '--user', 'joe123'])
+        command_parser.run_command(['share', '-p', 'someproject2', '--user', 'joe123'])
         self.assertEqual(None, self.parsed_args.msg_file)
+        self.assertEqual('someproject2', self.parsed_args.project_name)
+        self.assertEqual(None, self.parsed_args.project_id)
 
     def test_share_with_msg(self):
         command_parser = CommandParser()
         command_parser.register_share_command(self.set_parsed_args)
         self.assertEqual(['share'], list(command_parser.subparsers.choices.keys()))
-        command_parser.run_command(['share', '-p', 'someproject', '--user', 'joe123', '--msg-file', 'setup.py'])
+        command_parser.run_command(['share', '-i', '456', '--user', 'joe123', '--msg-file', 'setup.py'])
         self.assertIn('setup(', self.parsed_args.msg_file.read())
+        self.assertEqual(None, self.parsed_args.project_name)
+        self.assertEqual('456', self.parsed_args.project_id)
 
     def test_list_command(self):
         func = Mock()
@@ -65,6 +95,7 @@ class TestCommandParser(TestCase):
         args, kwargs = func.call_args
         self.assertEqual(args[0].auth_role, None)
         self.assertEqual(args[0].project_name, None)
+        self.assertEqual(args[0].long_format, False)
         func.reset_mock()
 
         # Test simple listing single project
@@ -80,3 +111,21 @@ class TestCommandParser(TestCase):
         args, kwargs = func.call_args
         self.assertEqual(args[0].auth_role, 'project_admin')
         self.assertEqual(args[0].project_name, None)
+
+    def test_list_command_long(self):
+        command_parser = CommandParser()
+        command_parser.register_list_command(self.set_parsed_args)
+        command_parser.run_command(['list'])
+        self.assertEqual(False, self.parsed_args.long_format)
+        self.assertEqual(None, self.parsed_args.project_name)
+        self.assertEqual(None, self.parsed_args.project_id)
+
+        command_parser.run_command(['list', '-l'])
+        self.assertEqual(True, self.parsed_args.long_format)
+        self.assertEqual(None, self.parsed_args.project_name)
+        self.assertEqual(None, self.parsed_args.project_id)
+
+        command_parser.run_command(['list', '-i', '123', '-l'])
+        self.assertEqual(True, self.parsed_args.long_format)
+        self.assertEqual(None, self.parsed_args.project_name)
+        self.assertEqual('123', self.parsed_args.project_id)

--- a/ddsc/tests/test_ddsclient.py
+++ b/ddsc/tests/test_ddsclient.py
@@ -1,34 +1,116 @@
 from __future__ import absolute_import
 from unittest import TestCase
-from ddsc.ddsclient import UploadCommand, ListCommand
+from ddsc.ddsclient import BaseCommand, UploadCommand, ListCommand, DownloadCommand
 from ddsc.ddsclient import ShareCommand, DeliverCommand, read_argument_file_contents
 from mock import patch, MagicMock, Mock, call
 
 
+class TestBaseCommand(TestCase):
+    def setUp(self):
+        self.args_with_project_id = Mock(project_name=None, project_id='123')
+        self.args_with_project_name = Mock(project_name='mouse', project_id=None)
+
+    def test_project_name_or_id_from_args(self):
+        project_name_or_id = BaseCommand.create_project_name_or_id_from_args(self.args_with_project_id)
+        self.assertEqual('123', project_name_or_id.value)
+        self.assertEqual(False, project_name_or_id.is_name)
+
+        project_name_or_id = BaseCommand.create_project_name_or_id_from_args(self.args_with_project_name)
+        self.assertEqual('mouse', project_name_or_id.value)
+        self.assertEqual(True, project_name_or_id.is_name)
+
+    @patch('ddsc.ddsclient.RemoteStore')
+    def test_fetch_project(self, mock_remote_store):
+        mock_config = MagicMock()
+        base_cmd = BaseCommand(mock_config)
+        base_cmd.fetch_project(self.args_with_project_id, must_exist=True, include_children=False)
+        mock_remote_store.return_value.fetch_remote_project.assert_called()
+        args, kwargs = mock_remote_store.return_value.fetch_remote_project.call_args
+        project_name_or_id = args[0]
+        self.assertEqual('123', project_name_or_id.value)
+        self.assertEqual(False, project_name_or_id.is_name)
+        self.assertEqual(True, kwargs['must_exist'])
+        self.assertEqual(False, kwargs['include_children'])
+
+
 class TestUploadCommand(TestCase):
     @patch("ddsc.ddsclient.ProjectUpload")
-    def test_without_dry_run(self, FakeProjectUpload):
+    def test_without_dry_run(self, mock_project_upload):
         cmd = UploadCommand(MagicMock())
         args = Mock()
         args.project_name = "test"
+        args.project_id = None
         args.folders = ["data", "scripts"]
         args.follow_symlinks = False
         args.dry_run = False
         cmd.run(args)
-        self.assertFalse(FakeProjectUpload().dry_run_report.called)
-        self.assertTrue(FakeProjectUpload().get_upload_report.called)
+        args, kwargs = mock_project_upload.call_args
+        self.assertEqual('test', args[1].get_name_or_raise())
+        self.assertFalse(mock_project_upload.return_value.dry_run_report.called)
+        self.assertTrue(mock_project_upload.return_value.get_upload_report.called)
+
+    @patch("ddsc.ddsclient.ProjectUpload")
+    def test_without_dry_run_project_id(self, mock_project_upload):
+        cmd = UploadCommand(MagicMock())
+        args = Mock()
+        args.project_name = None
+        args.project_id = '123'
+        args.folders = ["data", "scripts"]
+        args.follow_symlinks = False
+        args.dry_run = False
+        cmd.run(args)
+        args, kwargs = mock_project_upload.call_args
+        self.assertEqual('123', args[1].get_id_or_raise())
+        self.assertFalse(mock_project_upload.return_value.dry_run_report.called)
+        self.assertTrue(mock_project_upload.return_value.get_upload_report.called)
 
     @patch("ddsc.ddsclient.ProjectUpload")
     def test_with_dry_run(self, FakeProjectUpload):
         cmd = UploadCommand(MagicMock())
         args = Mock()
         args.project_name = "test"
+        args.project_id = None
         args.folders = ["data", "scripts"]
         args.follow_symlinks = False
         args.dry_run = True
         cmd.run(args)
         self.assertTrue(FakeProjectUpload().dry_run_report.called)
         self.assertFalse(FakeProjectUpload().get_upload_report.called)
+
+
+class TestDownloadCommand(TestCase):
+    @patch('ddsc.ddsclient.RemoteStore')
+    @patch("ddsc.ddsclient.ProjectDownload")
+    def test_run_project_name(self, mock_project_download, mock_remote_store):
+        @patch('ddsc.ddsclient.RemoteStore')
+        @patch('ddsc.ddsclient.ProjectDownload')
+        def test_run_project_id(self, mock_project_download, mock_remote_store):
+            cmd = DownloadCommand(MagicMock())
+            args = Mock()
+            args.project_name = 'mouse'
+            args.project_id = None
+            args.include_paths = None
+            args.exclude_paths = None
+            cmd.run(args)
+            mock_remote_store.return_value.fetch_remote_project.assert_called()
+            args, kwargs = mock_remote_store.return_value.fetch_remote_project.call_args
+            self.assertEqual('mouse', args[0].get_name_or_raise())
+            mock_project_download.return_value.run.assert_called()
+
+    @patch('ddsc.ddsclient.RemoteStore')
+    @patch('ddsc.ddsclient.ProjectDownload')
+    def test_run_project_id(self, mock_project_download, mock_remote_store):
+        cmd = DownloadCommand(MagicMock())
+        args = Mock()
+        args.project_name = None
+        args.project_id = '123'
+        args.include_paths = None
+        args.exclude_paths = None
+        cmd.run(args)
+        mock_remote_store.return_value.fetch_remote_project.assert_called()
+        args, kwargs = mock_remote_store.return_value.fetch_remote_project.call_args
+        self.assertEqual('123', args[0].get_id_or_raise())
+        mock_project_download.return_value.run.assert_called()
 
 
 class TestShareCommand(TestCase):
@@ -44,13 +126,15 @@ class TestShareCommand(TestCase):
         self.assertEqual(project, mock_remote_store.return_value.fetch_remote_project.return_value)
         self.assertEqual('project_viewer', auth_role)
         self.assertEqual('', message)
+        args, kwargs = mock_remote_store.return_value.fetch_remote_project.call_args
+        self.assertEqual('mouse', args[0].get_name_or_raise())
 
     @patch('ddsc.ddsclient.RemoteStore')
     @patch('ddsc.ddsclient.D4S2Project')
     def test_run_message(self, mock_d4s2_project, mock_remote_store):
         with open('setup.py') as message_infile:
             cmd = ShareCommand(MagicMock())
-            myargs = Mock(project_name='mouse', email=None, username='joe123', force_send=False,
+            myargs = Mock(project_name=None, project_id='123', email=None, username='joe123', force_send=False,
                           auth_role='project_viewer', msg_file=message_infile)
             cmd.run(myargs)
             args, kwargs = mock_d4s2_project().share.call_args
@@ -58,6 +142,8 @@ class TestShareCommand(TestCase):
             self.assertEqual(project, mock_remote_store.return_value.fetch_remote_project.return_value)
             self.assertEqual('project_viewer', auth_role)
             self.assertIn('setup(', message)
+            args, kwargs = mock_remote_store.return_value.fetch_remote_project.call_args
+            self.assertEqual('123', args[0].get_id_or_raise())
 
 
 class TestDeliverCommand(TestCase):
@@ -66,6 +152,7 @@ class TestDeliverCommand(TestCase):
     def test_run_no_message(self, mock_d4s2_project, mock_remote_store):
         cmd = DeliverCommand(MagicMock())
         myargs = Mock(project_name='mouse',
+                      project_id=None,
                       email=None,
                       resend=False,
                       username='joe123',
@@ -79,13 +166,16 @@ class TestDeliverCommand(TestCase):
         self.assertEqual(project, mock_remote_store.return_value.fetch_remote_project.return_value)
         self.assertEqual(False, force_send)
         self.assertEqual('', message)
+        args, kwargs = mock_remote_store.return_value.fetch_remote_project.call_args
+        self.assertEqual('mouse', args[0].get_name_or_raise())
 
     @patch('ddsc.ddsclient.RemoteStore')
     @patch('ddsc.ddsclient.D4S2Project')
     def test_run_message(self, mock_d4s2_project, mock_remote_store):
         with open('setup.py') as message_infile:
             cmd = DeliverCommand(MagicMock())
-            myargs = Mock(project_name='mouse',
+            myargs = Mock(project_name=None,
+                          project_id='456',
                           resend=False,
                           email=None,
                           username='joe123',
@@ -99,6 +189,8 @@ class TestDeliverCommand(TestCase):
             self.assertEqual(project, mock_remote_store.return_value.fetch_remote_project.return_value)
             self.assertEqual(False, force_send)
             self.assertIn('setup(', message)
+            args, kwargs = mock_remote_store.return_value.fetch_remote_project.call_args
+            self.assertEqual('456', args[0].get_id_or_raise())
 
 
 class TestDDSClient(TestCase):
@@ -111,10 +203,14 @@ class TestDDSClient(TestCase):
 class TestListCommand(TestCase):
     @patch('sys.stdout.write')
     @patch('ddsc.ddsclient.RemoteStore')
-    def test_print_project_names_no_auth_role(self, mock_remote_store, mock_print):
-        mock_remote_store.return_value.get_project_names.return_value = ['one', 'two', 'three']
+    def test_print_project_list_details(self, mock_remote_store, mock_print):
+        mock_remote_store.return_value.get_projects_details.return_value = [
+            {'name': 'one', 'id': '123'},
+            {'name': 'two', 'id': '456'},
+            {'name': 'three', 'id': '456'},
+        ]
         cmd = ListCommand(MagicMock())
-        cmd.print_project_names(filter_auth_role=None)
+        cmd.print_project_list_details(filter_auth_role=None, long_format=False)
         expected_calls = [
             call("one"),
             call("\n"),
@@ -127,13 +223,33 @@ class TestListCommand(TestCase):
 
     @patch('sys.stdout.write')
     @patch('ddsc.ddsclient.RemoteStore')
-    def test_print_project_names_with_auth_role(self, mock_remote_store, mock_print):
-        mock_remote_store.return_value.get_projects_with_auth_role.return_value = [
-            {'name': 'mouse'},
-            {'name': 'ant'},
+    def test_print_project_list_details_long_format(self, mock_remote_store, mock_print):
+        mock_remote_store.return_value.get_projects_details.return_value = [
+            {'name': 'one', 'id': '123'},
+            {'name': 'two', 'id': '456'},
+            {'name': 'three', 'id': '789'},
         ]
         cmd = ListCommand(MagicMock())
-        cmd.print_project_names(filter_auth_role='project_admin')
+        cmd.print_project_list_details(filter_auth_role=None, long_format=True)
+        expected_calls = [
+            call("123\tone"),
+            call("\n"),
+            call("456\ttwo"),
+            call("\n"),
+            call("789\tthree"),
+            call("\n")
+        ]
+        self.assertEqual(expected_calls, mock_print.call_args_list)
+
+    @patch('sys.stdout.write')
+    @patch('ddsc.ddsclient.RemoteStore')
+    def test_pprint_project_list_details_with_auth_role(self, mock_remote_store, mock_print):
+        mock_remote_store.return_value.get_projects_with_auth_role.return_value = [
+            {'name': 'mouse', 'id': '123'},
+            {'name': 'ant', 'id': '456'},
+        ]
+        cmd = ListCommand(MagicMock())
+        cmd.print_project_list_details(filter_auth_role='project_admin', long_format=False)
         expected_calls = [
             call("mouse"),
             call("\n"),
@@ -141,3 +257,28 @@ class TestListCommand(TestCase):
             call("\n")
         ]
         self.assertEqual(expected_calls, mock_print.call_args_list)
+
+    @patch('sys.stdout.write')
+    @patch('ddsc.ddsclient.RemoteStore')
+    def test_print_project_list_details_with_auth_role_long_format(self, mock_remote_store, mock_print):
+        mock_remote_store.return_value.get_projects_with_auth_role.return_value = [
+            {'name': 'mouse', 'id': '123'},
+            {'name': 'ant', 'id': '456'},
+        ]
+        cmd = ListCommand(MagicMock())
+        cmd.print_project_list_details(filter_auth_role='project_admin', long_format=True)
+        expected_calls = [
+            call("123\tmouse"),
+            call("\n"),
+            call("456\tant"),
+            call("\n")
+        ]
+        self.assertEqual(expected_calls, mock_print.call_args_list)
+
+    def test_get_project_info_line(self):
+        project_dict = {
+            'id': '123',
+            'name': 'mouse'
+        }
+        self.assertEqual('mouse', ListCommand.get_project_info_line(project_dict, False))
+        self.assertEqual('123\tmouse', ListCommand.get_project_info_line(project_dict, True))

--- a/ddsc/tests/test_ddsclient.py
+++ b/ddsc/tests/test_ddsclient.py
@@ -40,8 +40,8 @@ class TestShareCommand(TestCase):
                       auth_role='project_viewer', msg_file=None)
         cmd.run(myargs)
         args, kwargs = mock_d4s2_project().share.call_args
-        project_name, to_user, force_send, auth_role, message = args
-        self.assertEqual('mouse', project_name)
+        project, to_user, force_send, auth_role, message = args
+        self.assertEqual(project, mock_remote_store.return_value.fetch_remote_project.return_value)
         self.assertEqual('project_viewer', auth_role)
         self.assertEqual('', message)
 
@@ -54,8 +54,8 @@ class TestShareCommand(TestCase):
                           auth_role='project_viewer', msg_file=message_infile)
             cmd.run(myargs)
             args, kwargs = mock_d4s2_project().share.call_args
-            project_name, to_user, force_send, auth_role, message = args
-            self.assertEqual('mouse', project_name)
+            project, to_user, force_send, auth_role, message = args
+            self.assertEqual(project, mock_remote_store.return_value.fetch_remote_project.return_value)
             self.assertEqual('project_viewer', auth_role)
             self.assertIn('setup(', message)
 
@@ -75,8 +75,8 @@ class TestDeliverCommand(TestCase):
                       msg_file=None)
         cmd.run(myargs)
         args, kwargs = mock_d4s2_project().deliver.call_args
-        project_name, new_project_name, to_user, force_send, path_filter, message = args
-        self.assertEqual('mouse', project_name)
+        project, new_project_name, to_user, force_send, path_filter, message = args
+        self.assertEqual(project, mock_remote_store.return_value.fetch_remote_project.return_value)
         self.assertEqual(False, force_send)
         self.assertEqual('', message)
 
@@ -95,8 +95,8 @@ class TestDeliverCommand(TestCase):
                           msg_file=message_infile)
             cmd.run(myargs)
             args, kwargs = mock_d4s2_project().deliver.call_args
-            project_name, new_project_name, to_user, force_send, path_filter, message = args
-            self.assertEqual('mouse', project_name)
+            project, new_project_name, to_user, force_send, path_filter, message = args
+            self.assertEqual(project, mock_remote_store.return_value.fetch_remote_project.return_value)
             self.assertEqual(False, force_send)
             self.assertIn('setup(', message)
 

--- a/ddsc/tests/test_util.py
+++ b/ddsc/tests/test_util.py
@@ -2,8 +2,8 @@ from unittest import TestCase
 import subprocess
 import os
 import tempfile
-from ddsc.core.util import mode_allows_group_or_other, verify_file_private
-from mock import patch
+from ddsc.core.util import mode_allows_group_or_other, verify_file_private, ProjectDetailsList
+from mock import patch, Mock
 
 
 def make_temp_filename():
@@ -81,3 +81,40 @@ class TestUtil(TestCase):
         mock_platform.system.return_value = 'Linux'
         tempfilename = './file.never.gonna.exist'
         verify_file_private(tempfilename)
+
+
+class TestProjectDetailsList(TestCase):
+    def setUp(self):
+        self.mock_project_item = Mock()
+        self.mock_project_item.id = '123'
+        self.mock_project_item.name = 'mouse'
+        self.mock_folder_item = Mock()
+        self.mock_folder_item.id = '456'
+        self.mock_folder_item.name = 'data'
+        self.mock_file_item = Mock()
+        self.mock_file_item.id = '789'
+        self.mock_file_item.name = 'results.csv'
+
+    def test_visit_methods_short_format(self):
+        project_details_list = ProjectDetailsList(long_format=False)
+        project_details_list.visit_project(self.mock_project_item)
+        project_details_list.visit_folder(self.mock_folder_item, self.mock_project_item)
+        project_details_list.visit_file(self.mock_file_item, self.mock_folder_item)
+        expected_details = [
+            'Project mouse Contents:',
+            'data',
+            'data/results.csv',
+        ]
+        self.assertEqual(expected_details, project_details_list.details)
+
+    def test_visit_methods_long_format(self):
+        project_details_list = ProjectDetailsList(long_format=True)
+        project_details_list.visit_project(self.mock_project_item)
+        project_details_list.visit_folder(self.mock_folder_item, self.mock_project_item)
+        project_details_list.visit_file(self.mock_file_item, self.mock_folder_item)
+        expected_details = [
+            '123 - Project mouse Contents:',
+            '456\tdata',
+            '789\tdata/results.csv',
+        ]
+        self.assertEqual(expected_details, project_details_list.details)


### PR DESCRIPTION
Changes to allow selecting project via `-i` argument flag. This option is mutually exclusive from the -p flag which selects project by project name. This also adds a long option(`-l`) to the list command to allow user to find the id's associated with projects.