### PR TITLE
Fix for 401 error when downloading part of a file

### DIFF
--- a/ddsc/core/download.py
+++ b/ddsc/core/download.py
@@ -2,7 +2,6 @@ import os
 from ddsc.core.util import ProgressPrinter
 from ddsc.core.filedownloader import FileDownloader
 from ddsc.core.pathfilter import PathFilteredProject
-from ddsc.core.ddsapi import retry_until_resource_is_consistent
 
 
 class ProjectDownload(object):
@@ -85,9 +84,7 @@ class ProjectDownload(object):
         if self.file_download_pre_processor:
             self.file_download_pre_processor.run(self.remote_store.data_service, item)
         path = os.path.join(self.dest_directory, item.remote_path)
-        get_file_url = GetFileUrl(self.remote_store.data_service, item)
-        url_json = retry_until_resource_is_consistent(get_file_url.run, self.watcher)
-        downloader = FileDownloader(self.remote_store.config, item, url_json, path, self.watcher)
+        downloader = FileDownloader(self.remote_store.config, item, path, self.watcher)
         downloader.run()
         ProjectDownload.check_file_size(item, path)
 
@@ -139,12 +136,3 @@ class RemoteContentCounter(object):
         :return:
         """
         self.count += item.size
-
-
-class GetFileUrl(object):
-    def __init__(self, data_service, item):
-        self.data_service = data_service
-        self.item = item
-
-    def run(self):
-        return self.data_service.get_file_url(self.item.id).json()

--- a/ddsc/core/filedownloader.py
+++ b/ddsc/core/filedownloader.py
@@ -27,7 +27,7 @@ class FileDownloader(object):
         """
         Setup details on what to download and watcher to notify of progress.
         :param config: Config: configuration settings for download (number workers)
-        :param url_parts: dictionary of fields related to url ('http_verb','host','http_headers') received from duke_data_service
+        :param remote_file: RemoteFile: details about DukeDS file we will download
         :param path: str: path to where we will save the file
         :param watcher: ProgressPrinter: we notify of our progress
         """
@@ -116,6 +116,16 @@ class FileDownloader(object):
 def download_async(config, remote_file_id, range_headers, path, seek_amt, bytes_to_read, progress_queue):
     """
     Called in separate process to download a chunk of a file.
+    :param config: Config: configuration settings for download
+    :param remote_file_id: str: uuid of the file we will download
+    :param range_headers: dict: range request header to filter amount downloaded
+    :param path: str: path to where we should save our chunk we download
+    :param seek_amt: offset to seek before writing our chunk out to path
+    :param bytes_to_read: int: how many bytes of data we will receive from the url
+    :param progress_queue: ProgressQueue: queue of tuples we will add progress/errors to
+    """
+    """
+    Called in separate process to download a chunk of a file.
     :param url: str: url to file we should download
     :param headers: dict: header to use with url, should contain Range to limit what we download
     :param path: str: path to where we should save our chunk we download
@@ -147,6 +157,14 @@ def download_async(config, remote_file_id, range_headers, path, seek_amt, bytes_
 
 
 def get_file_chunk_url_and_headers(remote_store, remote_file_id, range_headers, progress_queue):
+    """
+    Return url and headers to use for downloading part of a file.
+    :param remote_store: RemoteStore: used to fetch url and default headers
+    :param remote_file_id: str: uuid of the file we will download
+    :param range_headers: dict: range request header to filter amount downloaded
+    :param progress_queue: ProgressQueue: queue of tuples we will add progress/errors to
+    :return: str, dict: url to download and headers to use (combines range_headers and those returned by DukeDS)
+    """
     get_file_url = GetFileUrl(remote_store.data_service, remote_file_id)
     url_json = retry_until_resource_is_consistent(get_file_url.run, progress_queue)
     url = url_json['host'] + url_json['url']

--- a/ddsc/core/tests/test_filedownloader.py
+++ b/ddsc/core/tests/test_filedownloader.py
@@ -14,6 +14,7 @@ class FakeConfig(object):
 class FakeFile(object):
     def __init__(self, size):
         self.size = size
+        self.id = '123'
 
 
 class FakeWatcher(object):
@@ -25,8 +26,8 @@ class FakeWatcher(object):
 
 
 class TestDownloader(FileDownloader):
-    def __init__(self, config, remote_file, url_parts, path, watcher):
-        super(TestDownloader, self).__init__(config, remote_file, url_parts, path, watcher)
+    def __init__(self, config, remote_file, path, watcher):
+        super(TestDownloader, self).__init__(config, remote_file, path, watcher)
 
     def make_big_empty_file(self):
         pass
@@ -84,20 +85,21 @@ class TestFileDownloader(TestCase):
 
     def assert_make_ranges(self, workers, file_size, expected):
         config = FakeConfig(workers)
-        downloader = FileDownloader(config, FakeFile(file_size), None, None, None)
+        downloader = FileDownloader(config, FakeFile(file_size), None, None)
         self.assertEqual(expected, downloader.make_ranges())
 
     def test_chunk_that_fails(self):
         file_size = 83833112
         config = FakeConfig(3)
         ddsc.core.filedownloader.download_async = self.chunk_download_fails
-        downloader = TestDownloader(config, FakeFile(file_size), sample_url_parts, None, None)
+        downloader = TestDownloader(config, FakeFile(file_size), None, None)
         try:
             downloader.run()
         except ValueError as err:
             self.assertEqual("oops", str(err))
 
-    def chunk_download_fails(self, url, headers, path, seek_amt, bytes_to_read, progress_queue):
+    def chunk_download_fails(self, config, remote_file_id, range_headers, path, seek_amt, bytes_to_read,
+                             progress_queue):
         progress_queue.error("oops")
 
     def test_download_whole_chunk(self):
@@ -105,12 +107,13 @@ class TestFileDownloader(TestCase):
         config = FakeConfig(3)
         watcher = FakeWatcher()
         ddsc.core.filedownloader.download_async = self.chunk_download_one_piece
-        downloader = TestDownloader(config, FakeFile(file_size), sample_url_parts, None, watcher)
+        downloader = TestDownloader(config, FakeFile(file_size), None, watcher)
         downloader.run()
         self.assertEqual(file_size, watcher.amt)
 
-    def chunk_download_one_piece(self, url, headers, path, seek_amt, bytes_to_read, progress_queue):
-        start, end = headers['Range'].replace("bytes=", "").split('-')
+    def chunk_download_one_piece(self, config, remote_file_id, range_headers, path, seek_amt, bytes_to_read,
+                                 progress_queue):
+        start, end = range_headers['Range'].replace("bytes=", "").split('-')
         total = (int(end) - int(start) + 1)
         progress_queue.processed(total)
 
@@ -119,12 +122,13 @@ class TestFileDownloader(TestCase):
         config = FakeConfig(3)
         watcher = FakeWatcher()
         ddsc.core.filedownloader.download_async = self.chunk_download_two_parts
-        downloader = TestDownloader(config, FakeFile(file_size), sample_url_parts, None, watcher)
+        downloader = TestDownloader(config, FakeFile(file_size), None, watcher)
         downloader.run()
         self.assertEqual(file_size, watcher.amt)
 
-    def chunk_download_two_parts(self, url, headers, path, seek_amt, bytes_to_read, progress_queue):
-        start, end = headers['Range'].replace("bytes=", "").split('-')
+    def chunk_download_two_parts(self, config, remote_file_id, range_headers, path, seek_amt, bytes_to_read,
+                                 progress_queue):
+        start, end = range_headers['Range'].replace("bytes=", "").split('-')
         total = (int(end) - int(start) + 1)
         first = int(total / 2)
         rest = total - first
@@ -134,25 +138,29 @@ class TestFileDownloader(TestCase):
 
 class TestDownloadAsync(TestCase):
     @patch('ddsc.core.filedownloader.ChunkDownloader')
-    def test_download_async_too_large_error(self, mock_chunk_downloader):
+    @patch('ddsc.core.filedownloader.RemoteStore')
+    def test_download_async_too_large_error(self, mock_remote_store, mock_chunk_downloader):
         # If we get too much data we should quit immediately sending a message to the progress_queue error
         mock_chunk_downloader.return_value.run.side_effect = TooLargeChunkDownloadError(100, 10, '/tmp/data.dat')
         progress_queue = MagicMock()
-        download_async(url='', headers=None, path=None, seek_amt=0, bytes_to_read=10, progress_queue=progress_queue)
+        download_async(config=MagicMock(), remote_file_id=123, range_headers={}, path=None, seek_amt=0,
+                       bytes_to_read=10, progress_queue=progress_queue)
         self.assertEqual(1, mock_chunk_downloader.call_count, "on too big we should only try downloading once")
         expected = 'Received too many bytes downloading part of a file. Actual: 100 Expected: 10 File:/tmp/data.dat'
         progress_queue.error.assert_called_with(expected)
 
     @patch('ddsc.core.filedownloader.ChunkDownloader')
     @patch('ddsc.core.filedownloader.time.sleep')
-    def test_download_async_partial_twice(self, mock_sleep, mock_chunk_downloader):
+    @patch('ddsc.core.filedownloader.RemoteStore')
+    def test_download_async_partial_twice(self, mock_remote_store, mock_sleep, mock_chunk_downloader):
         mock_chunk_downloader.return_value.run.side_effect = [
             PartialChunkDownloadError(2, 10, '/tmp/data.dat'),
             PartialChunkDownloadError(2, 10, '/tmp/data.dat'),
             None
         ]
         progress_queue = MagicMock()
-        download_async(url='', headers=None, path=None, seek_amt=0, bytes_to_read=10, progress_queue=progress_queue)
+        download_async(config=MagicMock(), remote_file_id=123, range_headers={}, path=None, seek_amt=0,
+                       bytes_to_read=10, progress_queue=progress_queue)
         self.assertEqual(3, mock_chunk_downloader.call_count, 'we should retry downloading multiple times')
         self.assertEqual(0, progress_queue.error.call_count, 'there should have been no errors')
         self.assertEqual(2, mock_sleep.call_count, 'we should have called sleep')
@@ -160,14 +168,16 @@ class TestDownloadAsync(TestCase):
 
     @patch('ddsc.core.filedownloader.ChunkDownloader')
     @patch('ddsc.core.filedownloader.time.sleep')
-    def test_download_async_connection_error_twice(self, mock_sleep, mock_chunk_downloader):
+    @patch('ddsc.core.filedownloader.RemoteStore')
+    def test_download_async_connection_error_twice(self, mock_remote_store, mock_sleep, mock_chunk_downloader):
         mock_chunk_downloader.return_value.run.side_effect = [
             ConnectionError(),
             ConnectionError(),
             None
         ]
         progress_queue = MagicMock()
-        download_async(url='', headers=None, path=None, seek_amt=0, bytes_to_read=10, progress_queue=progress_queue)
+        download_async(config=MagicMock(), remote_file_id=123, range_headers={}, path=None, seek_amt=0,
+                       bytes_to_read=10, progress_queue=progress_queue)
         self.assertEqual(3, mock_chunk_downloader.call_count, 'we should retry downloading multiple times')
         self.assertEqual(0, progress_queue.error.call_count, 'there should have been no errors')
         self.assertEqual(2, mock_sleep.call_count, 'we should have called sleep')
@@ -175,7 +185,8 @@ class TestDownloadAsync(TestCase):
 
     @patch('ddsc.core.filedownloader.ChunkDownloader')
     @patch('ddsc.core.filedownloader.time.sleep')
-    def test_download_async_partial_too_many_times(self, mock_sleep, mock_chunk_downloader):
+    @patch('ddsc.core.filedownloader.RemoteStore')
+    def test_download_async_partial_too_many_times(self, mock_remote_store, mock_sleep, mock_chunk_downloader):
         mock_chunk_downloader.return_value.run.side_effect = [
             PartialChunkDownloadError(2, 10, '/tmp/data.dat'),
             PartialChunkDownloadError(2, 10, '/tmp/data.dat'),
@@ -185,7 +196,8 @@ class TestDownloadAsync(TestCase):
             PartialChunkDownloadError(2, 10, '/tmp/data.dat'),
         ]
         progress_queue = MagicMock()
-        download_async(url='', headers=None, path=None, seek_amt=0, bytes_to_read=10, progress_queue=progress_queue)
+        download_async(config=MagicMock(), remote_file_id=123, range_headers={}, path=None, seek_amt=0,
+                       bytes_to_read=10, progress_queue=progress_queue)
         self.assertEqual(6, mock_chunk_downloader.call_count, 'we should retry downloading multiple times')
         self.assertEqual(5, mock_sleep.call_count, 'we should have called sleep four times')
         self.assertEqual(1, progress_queue.error.call_count)

--- a/ddsc/core/util.py
+++ b/ddsc/core/util.py
@@ -273,6 +273,8 @@ class ProgressQueue(object):
     """
     ERROR = 'error'
     PROCESSED = 'processed'
+    START_WAITING = 'start_waiting'
+    DONE_WAITING = 'done_waiting'
 
     def __init__(self, queue):
         self.queue = queue
@@ -282,6 +284,12 @@ class ProgressQueue(object):
 
     def processed(self, amt):
         self.queue.put((ProgressQueue.PROCESSED, amt))
+
+    def start_waiting(self):
+        self.queue.put((ProgressQueue.START_WAITING, None))
+
+    def done_waiting(self):
+        self.queue.put((ProgressQueue.DONE_WAITING, None))
 
     def get(self):
         """
@@ -307,6 +315,10 @@ def wait_for_processes(processes, size, progress_queue, watcher, item):
             chunk_size = value
             watcher.transferring_item(item, increment_amt=chunk_size)
             size -= chunk_size
+        elif progress_type == ProgressQueue.START_WAITING:
+            watcher.start_waiting()
+        elif progress_type == ProgressQueue.DONE_WAITING:
+            watcher.done_waiting()
         else:
             error_message = value
             for process in processes:


### PR DESCRIPTION
Moves code that fetches the url into the background process that downloads the chunk. That way we use it immediately after we retrieve it. Otherwise there is a possibility that we end up trying to download an expired url. This scenario was likely when retrying downloads due to connection problems. When we must retry downloading part of a file due to a connection error it will re-fetch the url.
Fixes #165