### PR TITLE
Configurable page size and fetch file list message

### DIFF
--- a/ddsc/config.py
+++ b/ddsc/config.py
@@ -22,6 +22,7 @@ AUTH_ENV_KEY_NAME = 'DUKE_DATA_SERVICE_AUTH'
 # when uploading skip .DS_Store, our key file, and ._ (resource fork metadata)
 FILE_EXCLUDE_REGEX_DEFAULT = '^\.DS_Store$|^\.ddsclient$|^\.\_'
 MAX_DEFAULT_WORKERS = 8
+GET_PAGE_SIZE_DEFAULT = 100  # fetch 100 items per page
 
 
 def get_user_config_filename():
@@ -69,6 +70,7 @@ class Config(object):
     DEBUG_MODE = 'debug'                               # show stack traces
     D4S2_URL = 'd4s2_url'                              # url for use with the D4S2 (share/deliver service)
     FILE_EXCLUDE_REGEX = 'file_exclude_regex'          # allows customization of which filenames will be uploaded
+    GET_PAGE_SIZE = 'get_page_size'                    # page size used for GET pagination requests
 
     def __init__(self):
         self.values = {}
@@ -198,3 +200,12 @@ class Config(object):
         :return: str: regex that when matches we should exclude a file from uploading.
         """
         return self.values.get(Config.FILE_EXCLUDE_REGEX, FILE_EXCLUDE_REGEX_DEFAULT)
+
+    @property
+    def page_size(self):
+        """
+        Returns the page size used to fetch paginated lists from DukeDS.
+        For DukeDS APIs that fail related to timeouts lowering this value can help.
+        :return:
+        """
+        return self.values.get(Config.GET_PAGE_SIZE, GET_PAGE_SIZE_DEFAULT)

--- a/ddsc/core/ddsapi.py
+++ b/ddsc/core/ddsapi.py
@@ -7,7 +7,6 @@ from ddsc.versioncheck import APP_NAME, get_internal_version_str
 
 AUTH_TOKEN_CLOCK_SKEW_MAX = 5 * 60  # 5 minutes
 SETUP_GUIDE_URL = "https://github.com/Duke-GCB/DukeDSClient/blob/master/docs/GettingAgentAndUserKeys.md"
-DEFAULT_RESULTS_PER_PAGE = 100
 RESOURCE_NOT_CONSISTENT_RETRY_SECONDS = 2
 
 
@@ -110,6 +109,13 @@ class DataServiceAuth(object):
             now_with_skew = time.time() + AUTH_TOKEN_CLOCK_SKEW_MAX
             return now_with_skew > self._expires
         return True
+
+    def get_page_size(self):
+        """
+        Return how many items we should include in each page for multi-page DukeDS results
+        :return: int
+        """
+        return self.config.page_size
 
 
 class DataServiceError(Exception):
@@ -237,7 +243,7 @@ class DataServiceApi(object):
     def _get_single_page(self, url_suffix, data, page_num):
         """
         Send GET request to API at url_suffix with post_data adding page and per_page parameters to
-        retrieve a single page. Always requests with per_page=DEFAULT_RESULTS_PER_PAGE.
+        retrieve a single page. Page size is determined by config.page_size.
         :param url_suffix: str URL path we are sending a GET to
         :param data: object data we are sending
         :param page_num: int: page number to fetch
@@ -245,7 +251,7 @@ class DataServiceApi(object):
         """
         data_with_per_page = dict(data)
         data_with_per_page['page'] = page_num
-        data_with_per_page['per_page'] = DEFAULT_RESULTS_PER_PAGE
+        data_with_per_page['per_page'] = self._get_page_size()
         (url, data_str, headers) = self._url_parts(url_suffix, data_with_per_page,
                                                    content_type=ContentType.form)
         resp = self.http.get(url, headers=headers, params=data_str)
@@ -862,6 +868,9 @@ class DataServiceApi(object):
         url = "/auth_providers/{}/affiliates/{}/dds_user/".format(auth_provider_id, username)
         return self._post(url, {})
 
+    def _get_page_size(self):
+        config = self.auth.config
+        return config.page_size
 
 class MultiJSONResponse(object):
     """

--- a/ddsc/core/ddsapi.py
+++ b/ddsc/core/ddsapi.py
@@ -872,6 +872,7 @@ class DataServiceApi(object):
         config = self.auth.config
         return config.page_size
 
+
 class MultiJSONResponse(object):
     """
     Wraps up multiple requests.Response objects into an object that will return composite dictionary for json() method.

--- a/ddsc/core/ddsapi.py
+++ b/ddsc/core/ddsapi.py
@@ -110,13 +110,6 @@ class DataServiceAuth(object):
             return now_with_skew > self._expires
         return True
 
-    def get_page_size(self):
-        """
-        Return how many items we should include in each page for multi-page DukeDS results
-        :return: int
-        """
-        return self.config.page_size
-
 
 class DataServiceError(Exception):
     """
@@ -869,6 +862,10 @@ class DataServiceApi(object):
         return self._post(url, {})
 
     def _get_page_size(self):
+        """
+        Return how many items we should include in each page for multi-page DukeDS results
+        :return: int
+        """
         config = self.auth.config
         return config.page_size
 

--- a/ddsc/core/tests/test_ddsapi.py
+++ b/ddsc/core/tests/test_ddsapi.py
@@ -56,7 +56,7 @@ class TestDataServiceApi(TestCase):
             fake_response_with_pages(status_code=200,
                                      json_return_value={"results": [1, 2, 3]},
                                      num_pages=1)]
-        api = DataServiceApi(auth=None, url="something.com/v1/", http=mock_requests)
+        api = DataServiceApi(auth=MagicMock(config=Mock(page_size=50)), url="something.com/v1/", http=mock_requests)
         response = api._get_collection(url_suffix="users", data={})
         self.assertEqual([1, 2, 3], response.json()["results"])
         call_args_list = mock_requests.get.call_args_list
@@ -68,7 +68,7 @@ class TestDataServiceApi(TestCase):
         dict_param = call_args[1]
         self.assertEqual('application/x-www-form-urlencoded', dict_param['headers']['Content-Type'])
         self.assertIn("DukeDSClient/", dict_param['headers']['User-Agent'])
-        self.assertEqual(100, dict_param['params']['per_page'])
+        self.assertEqual(50, dict_param['params']['per_page'])
         self.assertEqual(1, dict_param['params']['page'])
 
     def test_get_collection_two_pages(self):
@@ -81,7 +81,7 @@ class TestDataServiceApi(TestCase):
                                      json_return_value={"results": [4, 5]},
                                      num_pages=2)
         ]
-        api = DataServiceApi(auth=None, url="something.com/v1/", http=mock_requests)
+        api = DataServiceApi(auth=MagicMock(config=Mock(page_size=100)), url="something.com/v1/", http=mock_requests)
         response = api._get_collection(url_suffix="projects", data={})
         self.assertEqual([1, 2, 3, 4, 5], response.json()["results"])
         call_args_list = mock_requests.get.call_args_list
@@ -118,7 +118,7 @@ class TestDataServiceApi(TestCase):
                                      json_return_value={"results": [6, 7]},
                                      num_pages=3)
         ]
-        api = DataServiceApi(auth=None, url="something.com/v1/", http=mock_requests)
+        api = DataServiceApi(auth=MagicMock(config=Mock(page_size=100)), url="something.com/v1/", http=mock_requests)
         response = api._get_collection(url_suffix="uploads", data={})
         self.assertEqual([1, 2, 3, 4, 5, 6, 7], response.json()["results"])
         call_args_list = mock_requests.get.call_args_list
@@ -193,7 +193,7 @@ class TestDataServiceApi(TestCase):
         mock_requests.get.side_effect = [
             fake_response_with_pages(status_code=200, json_return_value={"ok": True}, num_pages=3)
         ]
-        api = DataServiceApi(auth=None, url="something.com/v1/", http=mock_requests)
+        api = DataServiceApi(auth=MagicMock(config=Mock(page_size=100)), url="something.com/v1/", http=mock_requests)
         resp = api._get_single_page(url_suffix='stuff', data={}, page_num=1)
         self.assertEqual(True, resp.json()['ok'])
 
@@ -215,7 +215,7 @@ class TestDataServiceApi(TestCase):
         mock_requests.get.side_effect = [
             fake_response_with_pages(status_code=200, json_return_value=json_results, num_pages=1)
         ]
-        api = DataServiceApi(auth=None, url="something.com/v1", http=mock_requests)
+        api = DataServiceApi(auth=MagicMock(), url="something.com/v1", http=mock_requests)
         result = api.get_auth_providers()
         self.assertEqual(200, result.status_code)
         self.assertEqual(json_results, result.json())
@@ -230,7 +230,7 @@ class TestDataServiceApi(TestCase):
         mock_requests.post.side_effect = [
             fake_response(status_code=200, json_return_value=user)
         ]
-        api = DataServiceApi(auth=None, url="something.com/v1", http=mock_requests)
+        api = DataServiceApi(auth=MagicMock(), url="something.com/v1", http=mock_requests)
         result = api.auth_provider_add_user('123', "joe")
         self.assertEqual(200, result.status_code)
         self.assertEqual(user, result.json())
@@ -250,7 +250,7 @@ class TestDataServiceApi(TestCase):
         mock_requests.get.side_effect = [
             fake_response_with_pages(status_code=200, json_return_value=return_value, num_pages=1)
         ]
-        api = DataServiceApi(auth=None, url="something.com/v1/", http=mock_requests)
+        api = DataServiceApi(auth=MagicMock(), url="something.com/v1/", http=mock_requests)
         resp = api.get_auth_roles(context='')
         self.assertEqual(1, len(resp.json()['results']))
         self.assertEqual("Project Admin", resp.json()['results'][0]['name'])
@@ -267,13 +267,13 @@ class TestDataServiceApi(TestCase):
         mock_requests.get.side_effect = [
             fake_response_with_pages(status_code=200, json_return_value=return_value, num_pages=1)
         ]
-        api = DataServiceApi(auth=None, url="something.com/v1/", http=mock_requests)
+        api = DataServiceApi(auth=MagicMock(), url="something.com/v1/", http=mock_requests)
         resp = api.get_project_transfers(project_id='4521')
         self.assertEqual(1, len(resp.json()['results']))
         self.assertEqual("1234", resp.json()['results'][0]['id'])
 
     def test_relations_methods(self):
-        api = DataServiceApi(auth=None, url="base/v1/", http=MagicMock())
+        api = DataServiceApi(auth=MagicMock(), url="base/v1/", http=MagicMock())
         api._get_collection = MagicMock()
         api._get_single_item = MagicMock()
         api._post = MagicMock()
@@ -405,7 +405,7 @@ class TestDataServiceApi(TestCase):
             fake_response_with_pages(status_code=200, json_return_value=page1, num_pages=2),
             fake_response_with_pages(status_code=200, json_return_value=page2, num_pages=2),
         ]
-        api = DataServiceApi(auth=None, url="something.com/v1", http=mock_requests)
+        api = DataServiceApi(auth=MagicMock(config=Mock(page_size=100)), url="something.com/v1", http=mock_requests)
         resp = api.get_projects()
         self.assertEqual(2, len(resp.json()['results']))
         self.assertEqual("1234", resp.json()['results'][0]['id'])

--- a/ddsc/ddsclient.py
+++ b/ddsc/ddsclient.py
@@ -108,8 +108,8 @@ class BaseCommand(object):
         if include_children:
             print("Fetching list of files for project {}.".format(project_name_or_id.value))
         project = self.remote_store.fetch_remote_project(project_name_or_id,
-                                                      must_exist=must_exist,
-                                                      include_children=include_children)
+                                                         must_exist=must_exist,
+                                                         include_children=include_children)
         if include_children:
             print("Done fetching list of files.".format(project_name_or_id.value))
         return project

--- a/ddsc/ddsclient.py
+++ b/ddsc/ddsclient.py
@@ -105,9 +105,14 @@ class BaseCommand(object):
 
     def fetch_project(self, args, must_exist=True, include_children=False):
         project_name_or_id = self.create_project_name_or_id_from_args(args)
-        return self.remote_store.fetch_remote_project(project_name_or_id,
+        if include_children:
+            print("Fetching list of files for project {}.".format(project_name_or_id.value))
+        project = self.remote_store.fetch_remote_project(project_name_or_id,
                                                       must_exist=must_exist,
                                                       include_children=include_children)
+        if include_children:
+            print("Done fetching list of files.".format(project_name_or_id.value))
+        return project
 
 
 class UploadCommand(BaseCommand):

--- a/ddsc/tests/test_config.py
+++ b/ddsc/tests/test_config.py
@@ -135,3 +135,13 @@ class TestConfig(TestCase):
         mock_os.environ.get.return_value = '/tmp/special.ddsclient.conf'
         self.assertEqual('/tmp/special.ddsclient.conf', ddsc.config.get_user_config_filename())
         mock_os.environ.get.assert_called_with(ddsc.config.LOCAL_CONFIG_ENV)
+
+    @patch('ddsc.config.os')
+    def test_get_user_config_get_page_size(self, mock_os):
+        config = ddsc.config.Config()
+        self.assertEqual(config.page_size, 100)
+        some_config = {
+            'get_page_size': 200,
+        }
+        config.update_properties(some_config)
+        self.assertEqual(config.page_size, 200)


### PR DESCRIPTION
Allows users to customize the page size used when fetching paginated data from DukeDS.
Lowering this value from the default of 100 may help with 500 errors due to timeouts and paginated data.
Also displays a message before and after we download the list of files in a project.
This will let users know ddsclient isn't hung when this request takes a while.
