### PR TITLE
use python 2.7 for deploy/onpublish.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,4 +24,4 @@ deploy:
     script: ./deploy/onpublish.sh
     on:
       tags: true
-      python: '3.5'
+      python: '2.7'


### PR DESCRIPTION
2.7 was the version that was tested against
using 3.5 inside travis seems to have some issue talking to github