### PR TITLE
upload reads unix-shell wildcards from .ddsignore in folders

### DIFF
--- a/ddsc/core/ignorefile.py
+++ b/ddsc/core/ignorefile.py
@@ -93,4 +93,6 @@ class IgnoreFilePatterns(object):
             return [line for line in lines if line]
 
     def include(self, path, is_file):
-        return self.pattern_list.include(path) and self.file_filter.include(path, is_file)
+        ret = self.pattern_list.include(path) and \
+              self.file_filter.include(os.path.basename(path), is_file)
+        return ret

--- a/ddsc/core/ignorefile.py
+++ b/ddsc/core/ignorefile.py
@@ -1,0 +1,96 @@
+import os
+import re
+import fnmatch
+
+
+DDS_IGNORE_FILENAME = '.ddsignore'
+
+
+class FileFilter(object):
+    """
+    Provides a function for filtering files based on a regex.
+    """
+    def __init__(self, file_exclude_regex):
+        """
+        Set exclusion regex to be used when filtering.
+        Pass empty string to include everything.
+        :param file_exclude_regex: str: regex that matches files we want to exclude
+        """
+        if file_exclude_regex:
+            self.exclude_regex = re.compile(file_exclude_regex)
+        else:
+            self.exclude_regex = None
+
+    def include(self, filename, is_file):
+        """
+        Determines if a file should be included in a project for uploading.
+        If file_exclude_regex is empty it will include everything.
+        :param filename: str: filename to match it should not include directory
+        :param is_file: bool: is this a file if not this will always return true
+        :return: boolean: True if we should include the file.
+        """
+        if self.exclude_regex and is_file:
+            if self.exclude_regex.match(filename):
+                return False
+            return True
+        else:
+            return True
+
+
+class FilenamePatternList(object):
+    """
+    Contains a list of Unix shell-style wildcard patterns to exclude filenames.
+    """
+    def __init__(self):
+        self.regex_list = []
+
+    def add_filename_pattern(self, dir_name, pattern):
+        """
+        Adds a Unix shell-style wildcard pattern underneath the specified directory
+        :param dir_name: str: directory that contains the pattern
+        :param pattern: str: Unix shell-style wildcard pattern
+        """
+        full_pattern = '{}{}{}'.format(dir_name, os.sep, pattern)
+        filename_regex = fnmatch.translate(full_pattern)
+        self.regex_list.append(re.compile(filename_regex))
+
+    def include(self, path):
+        """
+        Returns False if any pattern matches the path
+        :param path: str: filename path to test
+        :return: boolean: True if we should include this path
+        """
+        for regex_item in self.regex_list:
+            if regex_item.match(path):
+                return False
+        return True
+
+
+class IgnoreFilePatterns(object):
+    """
+    Contains information
+    """
+    def __init__(self, file_filter):
+        self.file_filter = file_filter
+        self.pattern_list = FilenamePatternList()
+
+    def load_directory(self, top_path, followlinks):
+        for dir_name, child_dirs, child_files in os.walk(top_path, followlinks=followlinks):
+            for child_filename in child_files:
+                if child_filename == DDS_IGNORE_FILENAME:
+                    pattern_lines = self._read_non_empty_lines(dir_name, child_filename)
+                    self.add_patterns(dir_name, pattern_lines)
+
+    def add_patterns(self, dir_name, pattern_lines):
+        for pattern_line in pattern_lines:
+            self.pattern_list.add_filename_pattern(dir_name, pattern_line)
+
+    @staticmethod
+    def _read_non_empty_lines(dir_name, child_filename):
+        path = '{}{}{}'.format(dir_name, os.sep, child_filename)
+        with open(path, 'r') as infile:
+            lines = infile.read().split('\n')
+            return [line for line in lines if line]
+
+    def include(self, path, is_file):
+        return self.pattern_list.include(path) and self.file_filter.include(path, is_file)

--- a/ddsc/core/ignorefile.py
+++ b/ddsc/core/ignorefile.py
@@ -68,13 +68,18 @@ class FilenamePatternList(object):
 
 class IgnoreFilePatterns(object):
     """
-    Contains information
+    Determines if folders/files should be included based on .ddsignore files and config exclude filenames
     """
     def __init__(self, file_filter):
         self.file_filter = file_filter
         self.pattern_list = FilenamePatternList()
 
     def load_directory(self, top_path, followlinks):
+        """
+        Traverse top_path directory and save patterns in any .ddsignore files found.
+        :param top_path: str: directory name we should traverse looking for ignore files
+        :param followlinks: boolean: should we traverse symbolic links
+        """
         for dir_name, child_dirs, child_files in os.walk(top_path, followlinks=followlinks):
             for child_filename in child_files:
                 if child_filename == DDS_IGNORE_FILENAME:
@@ -82,6 +87,11 @@ class IgnoreFilePatterns(object):
                     self.add_patterns(dir_name, pattern_lines)
 
     def add_patterns(self, dir_name, pattern_lines):
+        """
+        Add patterns the should apply below dir_name
+        :param dir_name: str: directory that contained the patterns
+        :param pattern_lines: [str]: array of patterns
+        """
         for pattern_line in pattern_lines:
             self.pattern_list.add_filename_pattern(dir_name, pattern_line)
 
@@ -93,6 +103,9 @@ class IgnoreFilePatterns(object):
             return [line for line in lines if line]
 
     def include(self, path, is_file):
-        ret = self.pattern_list.include(path) and \
-              self.file_filter.include(os.path.basename(path), is_file)
-        return ret
+        """
+        Returns False if any pattern matches the path
+        :param path: str: filename path to test
+        :return: boolean: True if we should include this path
+        """
+        return self.pattern_list.include(path) and self.file_filter.include(os.path.basename(path), is_file)

--- a/ddsc/core/localstore.py
+++ b/ddsc/core/localstore.py
@@ -444,7 +444,6 @@ class DDSIgnoreRegexMap(object):
         """
         ignore_filename = '{}/{}'.format(dir_name, DDS_IGNORE_FILENAME)
         if os.path.exists(ignore_filename):
-            print("Found ignore file {}".format(ignore_filename))
             self.dir_name_to_filter[dir_name] = DDSIgnoreFilter.create_from_file(self.file_filter, ignore_filename)
 
     def get_dds_ignore_filter(self, dir_name):

--- a/ddsc/core/localstore.py
+++ b/ddsc/core/localstore.py
@@ -124,15 +124,16 @@ def _build_folder_tree(top_abspath, followsymlinks, file_filter):
         if parent_path:
             path_to_content[parent_path].add_child(folder)
         for child_dir in child_dirs:
-            if ignore_file_patterns.include(child_dir, is_file=False):
-                # Record dir_name as the parent of child_dir so we can call add_child when get to it.
-                abs_child_path = os.path.abspath(os.path.join(dir_name, child_dir))
+            # Record dir_name as the parent of child_dir so we can call add_child when get to it.
+            abs_child_path = os.path.abspath(os.path.join(dir_name, child_dir))
+            if ignore_file_patterns.include(abs_child_path, is_file=False):
                 child_to_parent[abs_child_path] = abspath
             else:
                 child_dirs.remove(child_dir)
         for child_filename in child_files:
-            if ignore_file_patterns.include(child_filename, is_file=True):
-                folder.add_child(LocalFile(os.path.join(dir_name, child_filename)))
+            abs_child_filename = os.path.join(dir_name, child_filename)
+            if ignore_file_patterns.include(abs_child_filename, is_file=True):
+                folder.add_child(LocalFile(abs_child_filename))
     return path_to_content.get(top_abspath)
 
 

--- a/ddsc/core/localstore.py
+++ b/ddsc/core/localstore.py
@@ -461,7 +461,7 @@ class DDSIgnoreFilter(object):
         """
         Determines if a file or folder name should be included in a project for uploading.
         :param file_or_folder_name: str: file/folder name to test
-        :param is_file: bool: is this a file
+        :param is_file: boolean: is this a file (this is just passed to file_filter)
         :return: boolean: True if we should include the file.
         """
         for exclude_regex in self.exclude_regex_list:
@@ -474,6 +474,11 @@ class DDSIgnoreFilter(object):
 
     @staticmethod
     def create_from_file(file_filter, dds_ignore_filename):
+        """
+        :param file_filter: FileFilter: base filename filter based on
+        :param dds_ignore_filename: str: filename of .ddsignore file
+        :return: DDSIgnoreFilter
+        """
         with open(dds_ignore_filename, 'r') as infile:
             lines = infile.read().split('\n')
             exclude_regex_lines = [fnmatch.translate(line) for line in lines if line]

--- a/ddsc/core/localstore.py
+++ b/ddsc/core/localstore.py
@@ -416,22 +416,43 @@ class FileFilter(object):
 
 
 class DDSIgnoreRegexMap(object):
+    """
+    Contains a map of directory name to a DDSIgnoreFilter or FileFilter
+    """
     def __init__(self, file_filter, top_abspath):
+        """
+        :param file_filter: FileFilter: base filename filter based on
+        :param top_abspath:
+        """
         self.file_filter = file_filter
         self.top_abspath = top_abspath
         self.dir_name_to_filter = {}
 
     def determine_dds_ignore_filter(self, dir_name):
+        """
+        Record filtering settings for dir_name and return whatever settings is appropriate.
+        :param dir_name: str: directory that we want to get filtering settings for
+        :return: DDSIgnoreFilter or FileFilter
+        """
         self.check_for_ignore_filename(dir_name)
         return self.get_dds_ignore_filter(dir_name)
 
     def check_for_ignore_filename(self, dir_name):
+        """
+        If a .ddsignore file exists in the specified directory load it into the map.
+        :param dir_name: str: directory that may contain a .ddsignore
+        """
         ignore_filename = '{}/{}'.format(dir_name, DDS_IGNORE_FILENAME)
         if os.path.exists(ignore_filename):
             print("Found ignore file {}".format(ignore_filename))
             self.dir_name_to_filter[dir_name] = DDSIgnoreFilter.create_from_file(self.file_filter, ignore_filename)
 
     def get_dds_ignore_filter(self, dir_name):
+        """
+        Get DDSIgnoreFilter or FileFilter for dir_name
+        :param dir_name: str: directory we want to determine filtering settings for
+        :return: DDSIgnoreFilter or FileFilter
+        """
         ignore_filter = self.dir_name_to_filter.get(dir_name)
         if ignore_filter:
             return ignore_filter

--- a/ddsc/core/localstore.py
+++ b/ddsc/core/localstore.py
@@ -115,7 +115,7 @@ def _build_folder_tree(top_abspath, followsymlinks, file_filter):
     child_to_parent = {}
     ignore_file_patterns = IgnoreFilePatterns(file_filter)
     ignore_file_patterns.load_directory(top_abspath, followsymlinks)
-    for dir_name, child_dirs, child_files in os.walk(top_abspath, followlinks=followsymlinks, topdown=True):
+    for dir_name, child_dirs, child_files in os.walk(top_abspath, followlinks=followsymlinks):
         abspath = os.path.abspath(dir_name)
         folder = LocalFolder(abspath)
         path_to_content[abspath] = folder

--- a/ddsc/core/tests/test_ignorefile.py
+++ b/ddsc/core/tests/test_ignorefile.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 from ddsc.core.ignorefile import FileFilter, FilenamePatternList, IgnoreFilePatterns
-from mock import patch, Mock, mock_open, call, MagicMock
+from mock import patch, mock_open, call, MagicMock
 from ddsc.config import FILE_EXCLUDE_REGEX_DEFAULT
 
 

--- a/ddsc/core/tests/test_ignorefile.py
+++ b/ddsc/core/tests/test_ignorefile.py
@@ -1,0 +1,98 @@
+from unittest import TestCase
+from ddsc.core.ignorefile import FileFilter, FilenamePatternList, IgnoreFilePatterns
+from mock import patch, Mock, mock_open, call, MagicMock
+from ddsc.config import FILE_EXCLUDE_REGEX_DEFAULT
+
+
+class TestFileFilter(TestCase):
+    def test_default_file_exclude_regex(self):
+        include_file = FileFilter(FILE_EXCLUDE_REGEX_DEFAULT).include
+        good_files = [
+            'data.txt',
+            'long file with many words and stuff 2000.csv',
+            '.gitignore',
+            '.ddsclient_other',
+            '.DS_Storeage',
+            'DS_Store'
+        ]
+        bad_files = [
+            '.ddsclient',
+            '.DS_Store',
+            '._anything',
+            '._abc'
+        ]
+        # include good filenames
+        for good_filename in good_files:
+            self.assertEqual(include_file(good_filename, is_file=True), True)
+        # exclude bad filenames
+        for bad_filename in bad_files:
+            self.assertEqual(include_file(bad_filename, is_file=True), False)
+
+
+class FilenamePatternListTests(TestCase):
+    def test_add_filename_pattern(self):
+        filename_pattern_list = FilenamePatternList()
+        self.assertEqual(True, filename_pattern_list.include("/tmp/data/file1.zip"))
+        self.assertEqual(True, filename_pattern_list.include("/tmp/data/file2.dat"))
+
+        filename_pattern_list.add_filename_pattern("/tmp/data", "file1.zip")
+        self.assertEqual(False, filename_pattern_list.include("/tmp/data/file1.zip"))
+        self.assertEqual(True, filename_pattern_list.include("/tmp/data/file2.dat"))
+
+        filename_pattern_list.add_filename_pattern("/tmp/data", "*.dat")
+        self.assertEqual(False, filename_pattern_list.include("/tmp/data/file1.zip"))
+        self.assertEqual(False, filename_pattern_list.include("/tmp/data/file2.dat"))
+
+
+class IgnoreFilePatternsTests(TestCase):
+    def test_add_patterns(self):
+        mock_file_filter = MagicMock()
+        mock_file_filter.include.return_value = True
+        ignore_file_data = IgnoreFilePatterns(mock_file_filter)
+        ignore_file_data.add_patterns('/tmp/data', ['*.log', '*.sv'])
+        ignore_file_data.add_patterns('/tmp/data/backup', ['*.zip'])
+        include_filenames = [
+            '/tmp/data/data.dat',
+            '/tmp/data/data.log.dat',
+            '/tmp/data/backup/file1.zip.tar',
+        ]
+        for include_filename in include_filenames:
+            self.assertEqual(True, ignore_file_data.include(include_filename, is_file=True))
+        exclude_filenames = [
+            '/tmp/data/file1.log',
+            '/tmp/data/file2.sv',
+            '/tmp/data/backup/file1.zip',
+            '/tmp/data/backup/data.log',
+        ]
+        for exclude_filename in exclude_filenames:
+            self.assertEqual(False, ignore_file_data.include(exclude_filename, is_file=True))
+
+    @patch('ddsc.core.ignorefile.os')
+    def test_load_directory(self, mock_os):
+        mock_os.sep = '/'
+        mock_os.walk.return_value = [
+            ('/tmp/data', ['results', 'script'], ['.ddsignore']),
+            ('/tmp/data/results', ['files'], ['result.bam']),
+            ('/tmp/data/results/files', [], ['file1.zip', 'file2.log', 'file3.bam']),
+            ('/tmp/data/script', [], ['run.sh']),
+        ]
+
+        mock_file_filter = MagicMock()
+        mock_file_filter.include.return_value = True
+        ignore_file_data = IgnoreFilePatterns(mock_file_filter)
+        file_data = '*.log\n*.zip'
+        fake_open = mock_open(read_data=file_data)
+        with patch('ddsc.core.ignorefile.open', fake_open, create=True):
+            ignore_file_data.load_directory(top_path='/tmp/data', followlinks=False)
+        fake_open.assert_has_calls([
+            call('/tmp/data/.ddsignore', 'r'),
+        ], any_order=True)
+
+        self.assertEqual(False, ignore_file_data.include('/tmp/data/toplevel.log', is_file=True))
+        self.assertEqual(False, ignore_file_data.include('/tmp/data/results/file2.log', is_file=True))
+        self.assertEqual(False, ignore_file_data.include('/tmp/data/results/file1.zip', is_file=True))
+
+        self.assertEqual(True, ignore_file_data.include('/tmp/data/toplevel.bam', is_file=True))
+        self.assertEqual(True, ignore_file_data.include('/tmp/data/script/run.sh', is_file=True))
+        self.assertEqual(True, ignore_file_data.include('/tmp/data/results/file1.txt', is_file=True))
+        self.assertEqual(True, ignore_file_data.include('/tmp/data/results/foies/result.bam', is_file=True))

--- a/ddsc/core/tests/test_localstore.py
+++ b/ddsc/core/tests/test_localstore.py
@@ -2,10 +2,11 @@ import shutil
 import tarfile
 import fnmatch
 from unittest import TestCase
-from ddsc.core.localstore import LocalFile, LocalFolder, LocalProject, FileFilter, DDSIgnoreFilter
+from ddsc.core.localstore import LocalFile, LocalFolder, LocalProject, FileFilter, DDSIgnoreFilter, DDSIgnoreRegexMap
 from ddsc.config import FILE_EXCLUDE_REGEX_DEFAULT
-from mock import patch, Mock, call
+from mock import patch, Mock, MagicMock
 import mock
+
 
 INCLUDE_ALL = ''
 
@@ -210,10 +211,15 @@ class DDSIgnoreFilterTests(TestCase):
         expected_regex_list = ['stuff\\..*\\Z(?ms)', 'data\\Z(?ms)']
 
         file_filter = Mock()
-        with mock.patch('ddsc.core.localstore.open',
-                        mock.mock_open(read_data=file_data),
-                        create=True) as mock_open:
+        with mock.patch('ddsc.core.localstore.open', mock.mock_open(read_data=file_data), create=True):
             dds_ignore_filter = DDSIgnoreFilter.create_from_file(file_filter, '/tmp/fakestuff/.ddsignore')
 
         actual_regex_list = [regex.pattern for regex in dds_ignore_filter.exclude_regex_list]
         self.assertEqual(expected_regex_list, actual_regex_list)
+
+
+class DDSIgnoreRegexMapTests(TestCase):
+    def test_stuff(self):
+        file_filter = MagicMock()
+        dds_ignore_regex_map = DDSIgnoreRegexMap(file_filter, top_abspath='/tmp/fakedir')
+        self.assertEqual(1, dds_ignore_regex_map)

--- a/ddsc/core/tests/test_localstore.py
+++ b/ddsc/core/tests/test_localstore.py
@@ -155,10 +155,10 @@ class TestFileFilter(TestCase):
         ]
         # include good filenames
         for good_filename in good_files:
-            self.assertEqual(include_file(good_filename), True)
+            self.assertEqual(include_file(good_filename, is_file=True), True)
         # exclude bad filenames
         for bad_filename in bad_files:
-            self.assertEqual(include_file(bad_filename), False)
+            self.assertEqual(include_file(bad_filename, is_file=True), False)
 
 
 class TestLocalFile(TestCase):


### PR DESCRIPTION
Using this library to allow more natural command line wildcards: https://docs.python.org/2/library/fnmatch.html
Supports `.ddignore` files inside directories that are uploaded.

