### PR TITLE
Share with multiple users

### DIFF
--- a/ddsc/cmdparser.py
+++ b/ddsc/cmdparser.py
@@ -147,51 +147,62 @@ def _add_follow_symlinks_arg(arg_parser):
                             dest='follow_symlinks')
 
 
-def add_user_or_email_arg(arg_parser, help_msg, nargs=None):
+def add_user_or_email_arg(arg_parser, help_msg, allow_multiple=False):
     """
     Adds mutually exclusive user and email arguments to a parser.
     :param arg_parser: ArgumentParser parser to add these arguments to.
     :param help_msg: short help str to add to our help message
-    :param nargs:argparse nargs value
+    :param allow_multiple: boolean: True user can specify multiple users or emails
     """
+    nargs = None
+    user_arg_dest = 'username'
+    email_arg_dest = 'email'
+    if allow_multiple:
+        nargs = '+'
+        user_arg_dest = 'usernames'
+        email_arg_dest = 'emails'
     user_or_email = arg_parser.add_mutually_exclusive_group(required=True)
     help_suffix = "You must specify either --email or this flag."
     add_user_arg(user_or_email,
                  help_str="Username(NetID) to {}. {}".format(help_msg, help_suffix),
+                 dest=user_arg_dest,
                  nargs=nargs)
     add_email_arg(user_or_email,
                   help_str="Email of the person to {}. {}".format(help_msg, help_suffix),
+                  dest=email_arg_dest,
                   nargs=nargs)
 
 
-def add_user_arg(arg_parser, help_str, nargs=None):
+def add_user_arg(arg_parser, help_str, dest, nargs):
     """
     Adds username parameter to a parser.
     :param arg_parser: ArgumentParser parser to add this argument to.
     :param help_str: str help text
+    :param dest: destination variable name
     :param nargs: argparse nargs value
     """
 
     arg_parser.add_argument("--user",
                             metavar='Username',
                             type=to_unicode,
-                            dest='username',
+                            dest=dest,
                             help=help_str,
                             nargs=nargs)
 
 
-def add_email_arg(arg_parser, help_str, nargs=None):
+def add_email_arg(arg_parser, help_str, dest, nargs):
     """
     Adds user_email parameter to a parser.
     :param arg_parser: ArgumentParser parser to add this argument to.
     :param help_str: str help text
+    :param dest: destination variable name
     :param nargs: argparse nargs value
     """
     help = "{} You must specify either --user or this flag.".format(help_str)
     arg_parser.add_argument("--email",
                             metavar='UserEmail',
                             type=to_unicode,
-                            dest='email',
+                            dest=dest,
                             help=help_str,
                             nargs=nargs)
 
@@ -414,7 +425,7 @@ class CommandParser(object):
                       "If not specified this command gives user download permissions."
         share_parser = self.subparsers.add_parser('share', description=description)
         add_project_name_or_id_arg(share_parser)
-        add_user_or_email_arg(share_parser, help_msg="share project with", nargs='+')
+        add_user_or_email_arg(share_parser, help_msg="share project with", allow_multiple=True)
         _add_auth_role_arg(share_parser, default_permissions='file_downloader')
         _add_resend_arg(share_parser, "Resend share")
         _add_message_file(share_parser, "Filename containing a message to be sent with the share. "
@@ -431,7 +442,7 @@ class CommandParser(object):
                       "access to the copy of the project once user acknowledges receiving the data."
         deliver_parser = self.subparsers.add_parser('deliver', description=description)
         add_project_name_or_id_arg(deliver_parser)
-        add_user_or_email_arg(deliver_parser, help_msg="deliver project to", nargs='+')
+        add_user_or_email_arg(deliver_parser, help_msg="deliver project to", allow_multiple=True)
         _add_copy_project_arg(deliver_parser)
         _add_resend_arg(deliver_parser, "Resend delivery")
         include_or_exclude = deliver_parser.add_mutually_exclusive_group(required=False)

--- a/ddsc/cmdparser.py
+++ b/ddsc/cmdparser.py
@@ -198,7 +198,6 @@ def add_email_arg(arg_parser, help_str, dest, nargs):
     :param dest: destination variable name
     :param nargs: argparse nargs value
     """
-    help = "{} You must specify either --user or this flag.".format(help_str)
     arg_parser.add_argument("--email",
                             metavar='UserEmail',
                             type=to_unicode,

--- a/ddsc/cmdparser.py
+++ b/ddsc/cmdparser.py
@@ -147,30 +147,53 @@ def _add_follow_symlinks_arg(arg_parser):
                             dest='follow_symlinks')
 
 
-def add_user_arg(arg_parser):
+def add_user_or_email_arg(arg_parser, help_msg, nargs=None):
+    """
+    Adds mutually exclusive user and email arguments to a parser.
+    :param arg_parser: ArgumentParser parser to add these arguments to.
+    :param help_msg: short help str to add to our help message
+    :param nargs:argparse nargs value
+    """
+    user_or_email = arg_parser.add_mutually_exclusive_group(required=True)
+    help_suffix = "You must specify either --email or this flag."
+    add_user_arg(user_or_email,
+                 help_str="Username(NetID) to {}. {}".format(help_msg, help_suffix),
+                 nargs=nargs)
+    add_email_arg(user_or_email,
+                  help_str="Email of the person to {}. {}".format(help_msg, help_suffix),
+                  nargs=nargs)
+
+
+def add_user_arg(arg_parser, help_str, nargs=None):
     """
     Adds username parameter to a parser.
     :param arg_parser: ArgumentParser parser to add this argument to.
+    :param help_str: str help text
+    :param nargs: argparse nargs value
     """
+
     arg_parser.add_argument("--user",
                             metavar='Username',
                             type=to_unicode,
                             dest='username',
-                            help="Username(NetID) to update permissions on. "
-                                 "You must specify either --email or this flag.")
+                            help=help_str,
+                            nargs=nargs)
 
 
-def add_email_arg(arg_parser):
+def add_email_arg(arg_parser, help_str, nargs=None):
     """
     Adds user_email parameter to a parser.
     :param arg_parser: ArgumentParser parser to add this argument to.
+    :param help_str: str help text
+    :param nargs: argparse nargs value
     """
+    help = "{} You must specify either --user or this flag.".format(help_str)
     arg_parser.add_argument("--email",
                             metavar='UserEmail',
                             type=to_unicode,
                             dest='email',
-                            help="Email of the person you want to update permissions on."
-                                 " You must specify either --user or this flag.")
+                            help=help_str,
+                            nargs=nargs)
 
 
 def _add_auth_role_arg(arg_parser, default_permissions):
@@ -352,9 +375,7 @@ class CommandParser(object):
         description = "Gives user permission to access a remote project."
         add_user_parser = self.subparsers.add_parser('add-user', description=description)
         add_project_name_or_id_arg(add_user_parser, help_text_suffix="add a user to")
-        user_or_email = add_user_parser.add_mutually_exclusive_group(required=True)
-        add_user_arg(user_or_email)
-        add_email_arg(user_or_email)
+        add_user_or_email_arg(add_user_parser, help_msg="update permissions on")
         _add_auth_role_arg(add_user_parser, default_permissions='project_admin')
         add_user_parser.set_defaults(func=add_user_func)
 
@@ -366,9 +387,7 @@ class CommandParser(object):
         description = "Removes user permission to access a remote project."
         remove_user_parser = self.subparsers.add_parser('remove-user', description=description)
         add_project_name_or_id_arg(remove_user_parser, help_text_suffix="remove a user from")
-        user_or_email = remove_user_parser.add_mutually_exclusive_group(required=True)
-        add_user_arg(user_or_email)
-        add_email_arg(user_or_email)
+        add_user_or_email_arg(remove_user_parser, help_msg="remove permissions from")
         remove_user_parser.set_defaults(func=remove_user_func)
 
     def register_download_command(self, download_func):
@@ -395,9 +414,7 @@ class CommandParser(object):
                       "If not specified this command gives user download permissions."
         share_parser = self.subparsers.add_parser('share', description=description)
         add_project_name_or_id_arg(share_parser)
-        user_or_email = share_parser.add_mutually_exclusive_group(required=True)
-        add_user_arg(user_or_email)
-        add_email_arg(user_or_email)
+        add_user_or_email_arg(share_parser, help_msg="share project with", nargs='+')
         _add_auth_role_arg(share_parser, default_permissions='file_downloader')
         _add_resend_arg(share_parser, "Resend share")
         _add_message_file(share_parser, "Filename containing a message to be sent with the share. "
@@ -414,9 +431,7 @@ class CommandParser(object):
                       "access to the copy of the project once user acknowledges receiving the data."
         deliver_parser = self.subparsers.add_parser('deliver', description=description)
         add_project_name_or_id_arg(deliver_parser)
-        user_or_email = deliver_parser.add_mutually_exclusive_group(required=True)
-        add_user_arg(user_or_email)
-        add_email_arg(user_or_email)
+        add_user_or_email_arg(deliver_parser, help_msg="deliver project to", nargs='+')
         _add_copy_project_arg(deliver_parser)
         _add_resend_arg(deliver_parser, "Resend delivery")
         include_or_exclude = deliver_parser.add_mutually_exclusive_group(required=False)

--- a/ddsc/core/d4s2.py
+++ b/ddsc/core/d4s2.py
@@ -218,7 +218,8 @@ class D4S2Project(object):
         :param user_message: str message to be sent with the share
         :return: [str] the email addresses we will email share message to soon
         """
-        self.set_user_project_permission(project, to_users, auth_role)
+        for to_user in to_users:
+            self.set_user_project_permission(project, to_user, auth_role)
         return self._share_project(D4S2Api.SHARE_DESTINATION, project, to_users, force_send, auth_role, user_message)
 
     def set_user_project_permission(self, project, user, auth_role):

--- a/ddsc/core/d4s2.py
+++ b/ddsc/core/d4s2.py
@@ -263,7 +263,7 @@ class D4S2Project(object):
         :param to_users: RemoteUser user we are sharing with
         :param auth_role: str project role eg 'project_admin' email is customized based on this setting.
         :param user_message: str message to be sent with the share
-        :return: the email addresses that should receive a message on soon
+        :return: [str]: the email addresses that should receive a message on soon
         """
         from_user = self.remote_store.get_current_user()
         item = D4S2Item(destination=destination,
@@ -274,7 +274,7 @@ class D4S2Project(object):
                         auth_role=auth_role,
                         user_message=user_message)
         item.send(self.api, force_send)
-        return to_user.email
+        return [to_user.email for to_user in to_users]
 
     def _copy_project(self, project, new_project_name, path_filter):
         """

--- a/ddsc/core/tests/test_d4s2.py
+++ b/ddsc/core/tests/test_d4s2.py
@@ -13,14 +13,14 @@ class TestD4S2Project(TestCase):
         mock_d4s2api().get_existing_item.return_value = Mock(json=Mock(return_value=[]))
         project = D4S2Project(config=MagicMock(), remote_store=MagicMock(), print_func=MagicMock())
         project.share(project=Mock(name='mouserna'),
-                      to_user=MagicMock(id='123'),
+                      to_users=[MagicMock(id='123')],
                       force_send=False,
                       auth_role='project_viewer',
                       user_message='This is a test.')
         args, kwargs = mock_d4s2api().create_item.call_args
         item = args[0]
         self.assertEqual(mock_d4s2api.SHARE_DESTINATION, item.destination)
-        self.assertEqual('123', item.to_user_id)
+        self.assertEqual(['123'], item.to_user_ids)
         self.assertEqual('project_viewer', item.auth_role)
         self.assertEqual('This is a test.', item.user_message)
         mock_d4s2api().send_item.assert_called()
@@ -32,14 +32,14 @@ class TestD4S2Project(TestCase):
         project = D4S2Project(config=MagicMock(), remote_store=MagicMock(), print_func=MagicMock())
         project.deliver(project=Mock(name='mouserna'),
                         new_project_name=None,
-                        to_user=MagicMock(id='456'),
+                        to_users=[MagicMock(id='456')],
                         force_send=False,
                         path_filter='',
                         user_message='Yet Another Message.')
         args, kwargs = mock_d4s2api().create_item.call_args
         item = args[0]
         self.assertEqual(mock_d4s2api.DELIVER_DESTINATION, item.destination)
-        self.assertEqual('456', item.to_user_id)
+        self.assertEqual(['456'], item.to_user_ids)
         self.assertEqual('Yet Another Message.', item.user_message)
         mock_d4s2api().send_item.assert_called()
 

--- a/ddsc/core/tests/test_d4s2.py
+++ b/ddsc/core/tests/test_d4s2.py
@@ -27,6 +27,24 @@ class TestD4S2Project(TestCase):
 
     @patch('ddsc.core.d4s2.D4S2Api')
     @patch('ddsc.core.d4s2.requests')
+    def test_share_multiple_users(self, mock_requests, mock_d4s2api):
+        mock_d4s2api().get_existing_item.return_value = Mock(json=Mock(return_value=[]))
+        project = D4S2Project(config=MagicMock(), remote_store=MagicMock(), print_func=MagicMock())
+        project.share(project=Mock(name='mouserna'),
+                      to_users=[MagicMock(id='123'), MagicMock(id='456')],
+                      force_send=False,
+                      auth_role='project_viewer',
+                      user_message='This is a test.')
+        args, kwargs = mock_d4s2api().create_item.call_args
+        item = args[0]
+        self.assertEqual(mock_d4s2api.SHARE_DESTINATION, item.destination)
+        self.assertEqual(['123', '456'], item.to_user_ids)
+        self.assertEqual('project_viewer', item.auth_role)
+        self.assertEqual('This is a test.', item.user_message)
+        mock_d4s2api().send_item.assert_called()
+
+    @patch('ddsc.core.d4s2.D4S2Api')
+    @patch('ddsc.core.d4s2.requests')
     def test_deliver(self, mock_requests, mock_d4s2api):
         mock_d4s2api().get_existing_item.return_value = Mock(json=Mock(return_value=[]))
         project = D4S2Project(config=MagicMock(), remote_store=MagicMock(), print_func=MagicMock())
@@ -40,6 +58,24 @@ class TestD4S2Project(TestCase):
         item = args[0]
         self.assertEqual(mock_d4s2api.DELIVER_DESTINATION, item.destination)
         self.assertEqual(['456'], item.to_user_ids)
+        self.assertEqual('Yet Another Message.', item.user_message)
+        mock_d4s2api().send_item.assert_called()
+
+    @patch('ddsc.core.d4s2.D4S2Api')
+    @patch('ddsc.core.d4s2.requests')
+    def test_deliver_multiple_users(self, mock_requests, mock_d4s2api):
+        mock_d4s2api().get_existing_item.return_value = Mock(json=Mock(return_value=[]))
+        project = D4S2Project(config=MagicMock(), remote_store=MagicMock(), print_func=MagicMock())
+        project.deliver(project=Mock(name='mouserna'),
+                        new_project_name=None,
+                        to_users=[MagicMock(id='456'), MagicMock(id='789')],
+                        force_send=False,
+                        path_filter='',
+                        user_message='Yet Another Message.')
+        args, kwargs = mock_d4s2api().create_item.call_args
+        item = args[0]
+        self.assertEqual(mock_d4s2api.DELIVER_DESTINATION, item.destination)
+        self.assertEqual(['456', '789'], item.to_user_ids)
         self.assertEqual('Yet Another Message.', item.user_message)
         mock_d4s2api().send_item.assert_called()
 

--- a/ddsc/core/tests/test_fileuploader.py
+++ b/ddsc/core/tests/test_fileuploader.py
@@ -81,7 +81,8 @@ class TestFileUploadOperations(TestCase):
         fop.send_file_external(url_json, chunk='DATADATADATA')
         self.assertEqual(1, data_service.send_external.call_count)
 
-    def test_send_file_external_retry_put(self):
+    @patch('ddsc.core.fileuploader.time')
+    def test_send_file_external_retry_put(self, mock_time):
         data_service = MagicMock()
         data_service.send_external.side_effect = [requests.exceptions.ConnectionError, Mock(status_code=201)]
         fop = FileUploadOperations(data_service, MagicMock())

--- a/ddsc/ddsclient.py
+++ b/ddsc/ddsclient.py
@@ -308,8 +308,8 @@ class DeliverCommand(BaseCommand):
         When user accepts delivery they receive access and we lose admin privileges.
         :param args Namespace arguments parsed from the command line
         """
-        emails = args.emails                # emails of people to deliver to
-        usernames = args.usernames          # usernames of people to deliver to, will be None if email is specified
+        emails = args.emails                 # emails of people to deliver to
+        usernames = args.usernames           # usernames of people to deliver to, will be None if email is specified
         skip_copy_project = args.skip_copy_project  # should we skip the copy step
         force_send = args.resend            # is this a resend so we should force sending
         msg_file = args.msg_file            # message file who's contents will be sent with the delivery
@@ -337,7 +337,6 @@ class DeliverCommand(BaseCommand):
         :param project_name: str: name of project we will copy
         :return: str
         """
-        self.remote_store.fetch_remote_project_by_id()
         timestamp_str = datetime.datetime.utcnow().strftime('%Y-%m-%d %H:%M')
         return "{} {}".format(project_name, timestamp_str)
 

--- a/ddsc/ddsclient.py
+++ b/ddsc/ddsclient.py
@@ -269,8 +269,8 @@ class ShareCommand(BaseCommand):
         Gives user permission based on auth_role arg and sends email to that user.
         :param args Namespace arguments parsed from the command line
         """
-        emails = args.email                 # emails of people to send email to
-        usernames = args.username           # usernames of people to send email to, will be None if email is specified
+        emails = args.emails                # emails of people to send email to
+        usernames = args.usernames          # usernames of people to send email to, will be None if email is specified
         force_send = args.resend            # is this a resend so we should force sending
         auth_role = args.auth_role          # authorization role(project permissions) to give to the user
         msg_file = args.msg_file            # message file who's contents will be sent with the share
@@ -308,8 +308,8 @@ class DeliverCommand(BaseCommand):
         When user accepts delivery they receive access and we lose admin privileges.
         :param args Namespace arguments parsed from the command line
         """
-        emails = args.email                 # emails of people to deliver to
-        usernames = args.username           # usernames of people to deliver to, will be None if email is specified
+        emails = args.emails                # emails of people to deliver to
+        usernames = args.usernames          # usernames of people to deliver to, will be None if email is specified
         skip_copy_project = args.skip_copy_project  # should we skip the copy step
         force_send = args.resend            # is this a resend so we should force sending
         msg_file = args.msg_file            # message file who's contents will be sent with the delivery

--- a/ddsc/ddsclient.py
+++ b/ddsc/ddsclient.py
@@ -114,6 +114,30 @@ class BaseCommand(object):
             print("Done fetching list of files.".format(project_name_or_id.value))
         return project
 
+    def make_user_list(self, emails, usernames):
+        """
+        Given a list of emails and usernames fetch DukeDS user info.
+        Parameters that are None will be skipped.
+        :param emails: [str]: list of emails (can be null)
+        :param usernames:  [str]: list of usernames(netid)
+        :return: [RemoteUser]: details about any users referenced the two parameters
+        """
+        to_users = []
+        remaining_emails = [] if not emails else list(emails)
+        remaining_usernames = [] if not usernames else list(usernames)
+        for user in self.remote_store.fetch_all_users():
+            if user.email in remaining_emails:
+                to_users.append(user)
+                remaining_emails.remove(user.email)
+            elif user.username in remaining_usernames:
+                to_users.append(user)
+                remaining_usernames.remove(user.username)
+        if remaining_emails or remaining_usernames:
+            unable_to_find_users = ','.join(remaining_emails + remaining_usernames)
+            msg = "Unable to find users for the following email/usernames: {}".format(unable_to_find_users)
+            raise ValueError(msg)
+        return to_users
+
 
 class UploadCommand(BaseCommand):
     """
@@ -245,18 +269,19 @@ class ShareCommand(BaseCommand):
         Gives user permission based on auth_role arg and sends email to that user.
         :param args Namespace arguments parsed from the command line
         """
-        email = args.email                  # email of person to send email to
-        username = args.username            # username of person to send email to, will be None if email is specified
+        emails = args.email                 # emails of people to send email to
+        usernames = args.username           # usernames of people to send email to, will be None if email is specified
         force_send = args.resend            # is this a resend so we should force sending
         auth_role = args.auth_role          # authorization role(project permissions) to give to the user
         msg_file = args.msg_file            # message file who's contents will be sent with the share
         message = read_argument_file_contents(msg_file)
         print("Sharing project.")
-        to_user = self.remote_store.lookup_or_register_user_by_email_or_username(email, username)
+        to_users = self.make_user_list(emails, usernames)
         try:
             project = self.fetch_project(args, must_exist=True, include_children=False)
-            dest_email = self.service.share(project, to_user, force_send, auth_role, message)
-            print("Share email message sent to " + dest_email)
+            dest_emails = self.service.share(project, to_users, force_send, auth_role, message)
+            dest_emails_str = ', '.join(dest_emails)
+            print("Share email message sent to {}".format(dest_emails_str))
         except D4S2Error as ex:
             if ex.warning:
                 print(ex.message)
@@ -283,8 +308,8 @@ class DeliverCommand(BaseCommand):
         When user accepts delivery they receive access and we lose admin privileges.
         :param args Namespace arguments parsed from the command line
         """
-        email = args.email                  # email of person to deliver to, will be None if username is specified
-        username = args.username            # username of person to deliver to, will be None if email is specified
+        emails = args.email                 # emails of people to deliver to
+        usernames = args.username           # usernames of people to deliver to, will be None if email is specified
         skip_copy_project = args.skip_copy_project  # should we skip the copy step
         force_send = args.resend            # is this a resend so we should force sending
         msg_file = args.msg_file            # message file who's contents will be sent with the delivery
@@ -294,11 +319,12 @@ class DeliverCommand(BaseCommand):
         new_project_name = None
         if not skip_copy_project:
             new_project_name = self.get_new_project_name(project.name)
-        to_user = self.remote_store.lookup_or_register_user_by_email_or_username(email, username)
+        to_users = self.make_user_list(emails, usernames)
         try:
             path_filter = PathFilter(args.include_paths, args.exclude_paths)
-            dest_email = self.service.deliver(project, new_project_name, to_user, force_send, path_filter, message)
-            print("Delivery email message sent to " + dest_email)
+            dest_emails = self.service.deliver(project, new_project_name, to_users, force_send, path_filter, message)
+            dest_emails_str = ', '.join(dest_emails)
+            print("Delivery email message sent to {}".format(dest_emails_str))
         except D4S2Error as ex:
             if ex.warning:
                 print(ex.message)

--- a/ddsc/tests/test_cmdparser.py
+++ b/ddsc/tests/test_cmdparser.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 from unittest import TestCase
 from ddsc.cmdparser import CommandParser, add_user_or_email_arg
-from mock import Mock, MagicMock, call
+from mock import Mock, MagicMock
 
 
 def no_op():

--- a/ddsc/tests/test_ddsclient.py
+++ b/ddsc/tests/test_ddsclient.py
@@ -117,8 +117,11 @@ class TestShareCommand(TestCase):
     @patch('ddsc.ddsclient.RemoteStore')
     @patch('ddsc.ddsclient.D4S2Project')
     def test_run_no_message(self, mock_d4s2_project, mock_remote_store):
+        mock_remote_store.return_value.fetch_all_users.return_value = [
+            Mock(username='joe123', id='123', email='joe@joe.joe')
+        ]
         cmd = ShareCommand(MagicMock())
-        myargs = Mock(project_name='mouse', email=None, username='joe123', force_send=False,
+        myargs = Mock(project_name='mouse', email=None, username=['joe123'], force_send=False,
                       auth_role='project_viewer', msg_file=None)
         cmd.run(myargs)
         args, kwargs = mock_d4s2_project().share.call_args
@@ -132,9 +135,12 @@ class TestShareCommand(TestCase):
     @patch('ddsc.ddsclient.RemoteStore')
     @patch('ddsc.ddsclient.D4S2Project')
     def test_run_message(self, mock_d4s2_project, mock_remote_store):
+        mock_remote_store.return_value.fetch_all_users.return_value = [
+            Mock(username='joe123', id='123', email='joe@joe.joe')
+        ]
         with open('setup.py') as message_infile:
             cmd = ShareCommand(MagicMock())
-            myargs = Mock(project_name=None, project_id='123', email=None, username='joe123', force_send=False,
+            myargs = Mock(project_name=None, project_id='123', email=None, username=['joe123'], force_send=False,
                           auth_role='project_viewer', msg_file=message_infile)
             cmd.run(myargs)
             args, kwargs = mock_d4s2_project().share.call_args
@@ -150,12 +156,15 @@ class TestDeliverCommand(TestCase):
     @patch('ddsc.ddsclient.RemoteStore')
     @patch('ddsc.ddsclient.D4S2Project')
     def test_run_no_message(self, mock_d4s2_project, mock_remote_store):
+        mock_remote_store.return_value.fetch_all_users.return_value = [
+            Mock(username='joe123', id='123', email='joe@joe.joe')
+        ]
         cmd = DeliverCommand(MagicMock())
         myargs = Mock(project_name='mouse',
                       project_id=None,
                       email=None,
                       resend=False,
-                      username='joe123',
+                      username=['joe123'],
                       skip_copy_project=True,
                       include_paths=None,
                       exclude_paths=None,
@@ -173,12 +182,15 @@ class TestDeliverCommand(TestCase):
     @patch('ddsc.ddsclient.D4S2Project')
     def test_run_message(self, mock_d4s2_project, mock_remote_store):
         with open('setup.py') as message_infile:
+            mock_remote_store.return_value.fetch_all_users.return_value = [
+                Mock(username='joe123', id='123', email='joe@joe.joe')
+            ]
             cmd = DeliverCommand(MagicMock())
             myargs = Mock(project_name=None,
                           project_id='456',
                           resend=False,
                           email=None,
-                          username='joe123',
+                          username=['joe123'],
                           skip_copy_project=True,
                           include_paths=None,
                           exclude_paths=None,

--- a/ddsc/tests/test_ddsclient.py
+++ b/ddsc/tests/test_ddsclient.py
@@ -121,7 +121,7 @@ class TestShareCommand(TestCase):
             Mock(username='joe123', id='123', email='joe@joe.joe')
         ]
         cmd = ShareCommand(MagicMock())
-        myargs = Mock(project_name='mouse', email=None, username=['joe123'], force_send=False,
+        myargs = Mock(project_name='mouse', emails=None, usernames=['joe123'], force_send=False,
                       auth_role='project_viewer', msg_file=None)
         cmd.run(myargs)
         args, kwargs = mock_d4s2_project().share.call_args
@@ -140,7 +140,7 @@ class TestShareCommand(TestCase):
         ]
         with open('setup.py') as message_infile:
             cmd = ShareCommand(MagicMock())
-            myargs = Mock(project_name=None, project_id='123', email=None, username=['joe123'], force_send=False,
+            myargs = Mock(project_name=None, project_id='123', emails=None, usernames=['joe123'], force_send=False,
                           auth_role='project_viewer', msg_file=message_infile)
             cmd.run(myargs)
             args, kwargs = mock_d4s2_project().share.call_args
@@ -162,9 +162,9 @@ class TestDeliverCommand(TestCase):
         cmd = DeliverCommand(MagicMock())
         myargs = Mock(project_name='mouse',
                       project_id=None,
-                      email=None,
+                      emails=None,
                       resend=False,
-                      username=['joe123'],
+                      usernames=['joe123'],
                       skip_copy_project=True,
                       include_paths=None,
                       exclude_paths=None,
@@ -189,8 +189,8 @@ class TestDeliverCommand(TestCase):
             myargs = Mock(project_name=None,
                           project_id='456',
                           resend=False,
-                          email=None,
-                          username=['joe123'],
+                          emails=None,
+                          usernames=['joe123'],
                           skip_copy_project=True,
                           include_paths=None,
                           exclude_paths=None,


### PR DESCRIPTION
Changes to allow users to specify multiple emails or usernames when sharing or delivering a project.
This results in a change in the payload sent to the [D4S2](https://github.com/Duke-GCB/D4S2) API.
The `to_user_id` field in the share/deliver D4S2 payload has been replaced with `to_user_ids`.
The value is now an array of DukeDS user ids.

This needs to wait for D4S2 changes since this fails with 500 errors when creating share/delivery.
