### PR TITLE
Deliver share users

### DIFF
--- a/ddsc/cmdparser.py
+++ b/ddsc/cmdparser.py
@@ -183,7 +183,7 @@ def add_share_usernames_arg(arg_parser):
 
 
 def add_share_emails_arg(arg_parser):
-    arg_parser.add_argument("--share-email",
+    arg_parser.add_argument("--share-emails",
                             metavar='ShareEmails',
                             type=to_unicode,
                             nargs='+',

--- a/ddsc/cmdparser.py
+++ b/ddsc/cmdparser.py
@@ -173,6 +173,24 @@ def add_email_arg(arg_parser):
                                  " You must specify either --user or this flag.")
 
 
+def add_share_usernames_arg(arg_parser):
+    arg_parser.add_argument("--share-users",
+                            metavar='ShareUsers',
+                            type=to_unicode,
+                            nargs='+',
+                            dest='share_usernames',
+                            help="Usernames(NetIDs) of the people you want to share with upon delivery acceptance.")
+
+
+def add_share_emails_arg(arg_parser):
+    arg_parser.add_argument("--share-email",
+                            metavar='ShareEmails',
+                            type=to_unicode,
+                            nargs='+',
+                            dest='share_emails',
+                            help="Email of the person you want to share with upon delivery acceptance.")
+
+
 def _add_auth_role_arg(arg_parser, default_permissions):
     """
     Adds optional auth_role parameter to a parser.
@@ -417,6 +435,8 @@ class CommandParser(object):
         user_or_email = deliver_parser.add_mutually_exclusive_group(required=True)
         add_user_arg(user_or_email)
         add_email_arg(user_or_email)
+        add_share_usernames_arg(deliver_parser)
+        add_share_emails_arg(deliver_parser)
         _add_copy_project_arg(deliver_parser)
         _add_resend_arg(deliver_parser, "Resend delivery")
         include_or_exclude = deliver_parser.add_mutually_exclusive_group(required=False)

--- a/ddsc/core/d4s2.py
+++ b/ddsc/core/d4s2.py
@@ -288,7 +288,8 @@ class D4S2Project(object):
         :return: RemoteProject new project we copied data to
         """
         temp_directory = tempfile.mkdtemp()
-        remote_project = self.remote_store.fetch_remote_project(new_project_name)
+        new_project_name_or_id = ProjectNameOrId.create_from_name(new_project_name)
+        remote_project = self.remote_store.fetch_remote_project(new_project_name_or_id)
         if remote_project:
             raise ValueError("A project with name '{}' already exists.".format(new_project_name))
         activity = CopyActivity(self.remote_store.data_service, project, new_project_name)
@@ -296,7 +297,7 @@ class D4S2Project(object):
         self._upload_project(activity, new_project_name, temp_directory)
         activity.finished()
         shutil.rmtree(temp_directory)
-        return self.remote_store.fetch_remote_project(new_project_name, must_exist=True)
+        return self.remote_store.fetch_remote_project(new_project_name_or_id, must_exist=True)
 
     def _download_project(self, activity, project, temp_directory, path_filter):
         """
@@ -307,8 +308,7 @@ class D4S2Project(object):
         :param path_filter: PathFilter: filters what files are shared
         """
         self.print_func("Downloading a copy of '{}'.".format(project.name))
-        project_name_or_id = project.get_project_name_or_id()
-        downloader = ProjectDownload(self.remote_store, project_name_or_id, temp_directory, path_filter,
+        downloader = ProjectDownload(self.remote_store, project, temp_directory, path_filter,
                                      file_download_pre_processor=DownloadedFileRelations(activity))
         downloader.run()
 

--- a/ddsc/core/d4s2.py
+++ b/ddsc/core/d4s2.py
@@ -230,13 +230,14 @@ class D4S2Project(object):
         """
         self.remote_store.set_user_project_permission(project, user, auth_role)
 
-    def deliver(self, project, new_project_name, to_user, force_send, path_filter, user_message):
+    def deliver(self, project, new_project_name, to_user, share_users, force_send, path_filter, user_message):
         """
         Remove access to project_name for to_user, copy to new_project_name if not None,
         send message to service to email user so they can have access.
         :param project: RemoteProject pre-existing project to be delivered
         :param new_project_name: str name of non-existing project to copy project_name to, if None we don't copy
         :param to_user: RemoteUser user we are handing over the project to
+        :param share_users: [RemoteUser] who will have project shared with them once to_user accepts the project
         :param force_send: boolean enables resending of email for existing projects
         :param path_filter: PathFilter: filters what files are shared
         :param user_message: str message to be sent with the share
@@ -245,7 +246,9 @@ class D4S2Project(object):
         self.remove_user_permission(project, to_user)
         if new_project_name:
             project = self._copy_project(project, new_project_name, path_filter)
-        return self._share_project(D4S2Api.DELIVER_DESTINATION, project, to_user, force_send, user_message=user_message)
+        # TODO pass share_users
+        return self._share_project(D4S2Api.DELIVER_DESTINATION, project, to_user,
+                                   force_send, user_message=user_message)
 
     def remove_user_permission(self, project, user):
         """

--- a/ddsc/core/d4s2.py
+++ b/ddsc/core/d4s2.py
@@ -266,7 +266,7 @@ class D4S2Project(object):
     def _share_project(self, destination, project, to_user, force_send, auth_role='', user_message='',
                        share_users=None):
         """
-        Send message to remove service to email/share project with to_user.
+        Send message to remote service to email/share project with to_user.
         :param destination: str which type of sharing we are doing (SHARE_DESTINATION or DELIVER_DESTINATION)
         :param project: RemoteProject project we are sharing
         :param to_user: RemoteUser user we are sharing with

--- a/ddsc/core/tests/test_d4s2.py
+++ b/ddsc/core/tests/test_d4s2.py
@@ -33,7 +33,7 @@ class TestD4S2Project(TestCase):
         project.deliver(project=Mock(name='mouserna'),
                         new_project_name=None,
                         to_user=MagicMock(id='456'),
-                        share_users=[],
+                        share_users=[Mock(id='777'), Mock(id='888')],
                         force_send=False,
                         path_filter='',
                         user_message='Yet Another Message.')
@@ -42,6 +42,7 @@ class TestD4S2Project(TestCase):
         self.assertEqual(mock_d4s2api.DELIVER_DESTINATION, item.destination)
         self.assertEqual('456', item.to_user_id)
         self.assertEqual('Yet Another Message.', item.user_message)
+        self.assertEqual(['777', '888'], item.share_user_ids)
         mock_d4s2api().send_item.assert_called()
 
     @patch('ddsc.core.d4s2.ProjectDownload')

--- a/ddsc/core/tests/test_d4s2.py
+++ b/ddsc/core/tests/test_d4s2.py
@@ -33,6 +33,7 @@ class TestD4S2Project(TestCase):
         project.deliver(project=Mock(name='mouserna'),
                         new_project_name=None,
                         to_user=MagicMock(id='456'),
+                        share_users=[],
                         force_send=False,
                         path_filter='',
                         user_message='Yet Another Message.')

--- a/ddsc/ddsclient.py
+++ b/ddsc/ddsclient.py
@@ -339,7 +339,6 @@ class DeliverCommand(BaseCommand):
         :param project_name: str: name of project we will copy
         :return: str
         """
-        self.remote_store.fetch_remote_project_by_id()
         timestamp_str = datetime.datetime.utcnow().strftime('%Y-%m-%d %H:%M')
         return "{} {}".format(project_name, timestamp_str)
 

--- a/ddsc/tests/test_cmdparser.py
+++ b/ddsc/tests/test_cmdparser.py
@@ -55,6 +55,8 @@ class TestCommandParser(TestCase):
         self.assertEqual(None, self.parsed_args.msg_file)
         self.assertEqual('someproject', self.parsed_args.project_name)
         self.assertEqual(None, self.parsed_args.project_id)
+        self.assertEqual(None, self.parsed_args.share_usernames)
+        self.assertEqual(None, self.parsed_args.share_emails)
 
     def test_deliver_with_msg(self):
         command_parser = CommandParser(version_str='1.0')
@@ -64,6 +66,19 @@ class TestCommandParser(TestCase):
         self.assertIn('setup(', self.parsed_args.msg_file.read())
         self.assertEqual(None, self.parsed_args.project_name)
         self.assertEqual('123', self.parsed_args.project_id)
+
+    def test_deliver_with_share_users(self):
+        command_parser = CommandParser(version_str='1.0')
+        command_parser.register_deliver_command(self.set_parsed_args)
+        self.assertEqual(['deliver'], list(command_parser.subparsers.choices.keys()))
+        command_parser.run_command(['deliver', '-i', '123',
+                                    '--user', 'joe123',
+                                    '--share-users', 'bob555', 'tom666',
+                                    '--share-emails', 'bob@bob.bob'])
+        self.assertEqual(None, self.parsed_args.project_name)
+        self.assertEqual('123', self.parsed_args.project_id)
+        self.assertEqual(['bob555', 'tom666'], self.parsed_args.share_usernames)
+        self.assertEqual(['bob@bob.bob'], self.parsed_args.share_emails)
 
     def test_share_no_msg(self):
         command_parser = CommandParser(version_str='1.0')

--- a/ddsc/tests/test_ddsclient.py
+++ b/ddsc/tests/test_ddsclient.py
@@ -156,13 +156,15 @@ class TestDeliverCommand(TestCase):
                       email=None,
                       resend=False,
                       username='joe123',
+                      share_usernames=[],
+                      share_emails=[],
                       skip_copy_project=True,
                       include_paths=None,
                       exclude_paths=None,
                       msg_file=None)
         cmd.run(myargs)
         args, kwargs = mock_d4s2_project().deliver.call_args
-        project, new_project_name, to_user, force_send, path_filter, message = args
+        project, new_project_name, to_user, share_users, force_send, path_filter, message = args
         self.assertEqual(project, mock_remote_store.return_value.fetch_remote_project.return_value)
         self.assertEqual(False, force_send)
         self.assertEqual('', message)
@@ -179,13 +181,15 @@ class TestDeliverCommand(TestCase):
                           resend=False,
                           email=None,
                           username='joe123',
+                          share_emails=[],
+                          share_usernames=[],
                           skip_copy_project=True,
                           include_paths=None,
                           exclude_paths=None,
                           msg_file=message_infile)
             cmd.run(myargs)
             args, kwargs = mock_d4s2_project().deliver.call_args
-            project, new_project_name, to_user, force_send, path_filter, message = args
+            project, new_project_name, to_user, share_users, force_send, path_filter, message = args
             self.assertEqual(project, mock_remote_store.return_value.fetch_remote_project.return_value)
             self.assertEqual(False, force_send)
             self.assertIn('setup(', message)


### PR DESCRIPTION
Adds two new flags to the `deliver` command to specify a list of users to have a project shared with once the delivery is accepted by the owner.
Requires https://github.com/Duke-GCB/D4S2/pull/102