### PR TITLE
Resume download

### DIFF
--- a/ddsc/cmdparser.py
+++ b/ddsc/cmdparser.py
@@ -8,8 +8,6 @@ from builtins import str
 
 DESCRIPTION_STR = "DukeDSClient ({}) Manage projects/folders/files in the duke-data-service"
 INVALID_PATH_CHARS = (':', '/', '\\')
-DESTINATION_PATH_EXISTS_FMT = """Directory {} already exists and is not empty.
-To restart a failed download you can add the --resume flag."""
 
 
 def replace_invalid_path_chars(path):
@@ -87,16 +85,12 @@ def _paths_must_exists(path):
     return path
 
 
-def format_destination_path(path, must_be_empty):
+def format_destination_path(path):
     """
-    Raises error if the directory the path exists and contains any files.
+    Formats command line destination path.
     :param path: str path to check
-    :param resume: boolean path can exist
     :return: str path
     """
-    if must_be_empty and os.path.exists(path):
-        if os.listdir(path):
-            raise argparse.ArgumentTypeError(DESTINATION_PATH_EXISTS_FMT.format(path))
     path = to_unicode(path)
     return _path_has_ok_chars(path)
 
@@ -334,18 +328,6 @@ def _add_long_format_option(arg_parser, help_text):
                             dest='long_format')
 
 
-def _add_resume_arg(arg_parser, help_text):
-    """
-    Adds resume argument to a parser.
-    :param arg_parser: ArgumentParser parser to add this argument to.
-    :param help_text: str: help text to show for this option
-    """
-    arg_parser.add_argument("-r", '--resume',
-                            help=help_text,
-                            action='store_true',
-                            dest='resume')
-
-
 class CommandParser(object):
     """
     Root command line parser. Supports the following commands: upload and add_user.
@@ -404,7 +386,8 @@ class CommandParser(object):
 
     def register_download_command(self, download_func):
         """
-        Add 'download' command for downloading a project to a non-existing or empty directory.
+        Add 'download' command for downloading a project to a directory.
+        For non empty directories it will download remote files replacing local files.
         :param download_func: function to run when user choses this option
         """
         description = "Download the contents of a remote remote project to a local folder."
@@ -414,7 +397,6 @@ class CommandParser(object):
         include_or_exclude = download_parser.add_mutually_exclusive_group(required=False)
         _add_include_arg(include_or_exclude)
         _add_exclude_arg(include_or_exclude)
-        _add_resume_arg(download_parser, help_text='Resume download. Destination directory can exist.')
         download_parser.set_defaults(func=download_func)
 
     def register_share_command(self, share_func):

--- a/ddsc/core/download.py
+++ b/ddsc/core/download.py
@@ -2,6 +2,7 @@ import os
 from ddsc.core.util import ProgressPrinter
 from ddsc.core.filedownloader import FileDownloader
 from ddsc.core.pathfilter import PathFilteredProject
+from ddsc.core.localstore import PathData
 
 
 class ProjectDownload(object):
@@ -83,6 +84,22 @@ class ProjectDownload(object):
         if self.file_download_pre_processor:
             self.file_download_pre_processor.run(self.remote_store.data_service, item)
         path = os.path.join(self.dest_directory, item.remote_path)
+        if self._file_exists_with_same_hash(item, path):
+            # Update progress bar skipping this file
+            self.watcher.transferring_item(item, increment_amt=item.size)
+        else:
+            downloader = FileDownloader(self.remote_store.config, item, path, self.watcher)
+            downloader.run()
+            ProjectDownload.check_file_size(item, path)
+
+    @staticmethod
+    def _file_exists_with_same_hash(item, path):
+        if os.path.exists(path):
+            hash_data = PathData(path).get_hash()
+            return hash_data.matches(item.hash_alg, item.file_hash)
+        return False
+
+    def _download_item(self, item, path):
         downloader = FileDownloader(self.remote_store.config, item, path, self.watcher)
         downloader.run()
         ProjectDownload.check_file_size(item, path)

--- a/ddsc/core/download.py
+++ b/ddsc/core/download.py
@@ -84,7 +84,7 @@ class ProjectDownload(object):
         if self.file_download_pre_processor:
             self.file_download_pre_processor.run(self.remote_store.data_service, item)
         path = os.path.join(self.dest_directory, item.remote_path)
-        if self._file_exists_with_same_hash(item, path):
+        if self.file_exists_with_same_hash(item, path):
             # Update progress bar skipping this file
             self.watcher.transferring_item(item, increment_amt=item.size)
         else:
@@ -93,16 +93,11 @@ class ProjectDownload(object):
             ProjectDownload.check_file_size(item, path)
 
     @staticmethod
-    def _file_exists_with_same_hash(item, path):
+    def file_exists_with_same_hash(item, path):
         if os.path.exists(path):
             hash_data = PathData(path).get_hash()
             return hash_data.matches(item.hash_alg, item.file_hash)
         return False
-
-    def _download_item(self, item, path):
-        downloader = FileDownloader(self.remote_store.config, item, path, self.watcher)
-        downloader.run()
-        ProjectDownload.check_file_size(item, path)
 
     @staticmethod
     def check_file_size(item, path):

--- a/ddsc/core/tests/test_download.py
+++ b/ddsc/core/tests/test_download.py
@@ -7,16 +7,23 @@ from mock import MagicMock, Mock, patch
 class TestProjectDownload(TestCase):
     @patch('ddsc.core.download.FileDownloader')
     @patch('ddsc.core.download.ProjectDownload.check_file_size')
-    def test_visit_file_download_pre_processor_off(self, mock_file_downloader, mock_check_file_size):
+    @patch('ddsc.core.download.os')
+    @patch('ddsc.core.download.PathData')
+    def test_visit_file_download_pre_processor_off(self, mock_path_data, mock_os, mock_file_downloader,
+                                                   mock_check_file_size):
         project_download = ProjectDownload(remote_store=MagicMock(),
                                            project=Mock(name='test'),
                                            dest_directory='/tmp/fakedir',
                                            path_filter=MagicMock())
+        project_download.watcher = Mock()
         project_download.visit_file(Mock(), None)
 
     @patch('ddsc.core.download.FileDownloader')
     @patch('ddsc.core.download.ProjectDownload.check_file_size')
-    def test_visit_file_download_pre_processor_on(self, mock_file_downloader, mock_check_file_size):
+    @patch('ddsc.core.download.os')
+    @patch('ddsc.core.download.PathData')
+    def test_visit_file_download_pre_processor_on(self, mock_path_data, mock_os, mock_file_downloader,
+                                                  mock_check_file_size):
         pre_processor_run = MagicMock()
         pre_processor = Mock(run=pre_processor_run)
         project_download = ProjectDownload(remote_store=MagicMock(),
@@ -24,6 +31,7 @@ class TestProjectDownload(TestCase):
                                            dest_directory='/tmp/fakedir',
                                            path_filter=MagicMock(),
                                            file_download_pre_processor=pre_processor)
+        project_download.watcher = Mock()
         fake_file = MagicMock()
         project_download.visit_file(fake_file, None)
         pre_processor_run.assert_called()

--- a/ddsc/core/util.py
+++ b/ddsc/core/util.py
@@ -367,8 +367,3 @@ def mode_allows_group_or_other(st_mode):
     :return: bool: true when group or other has some permissions
     """
     return (st_mode & stat.S_IRWXO or st_mode & stat.S_IRWXG) != 0
-
-
-def format_destination_path(path):
-
-    return path

--- a/ddsc/core/util.py
+++ b/ddsc/core/util.py
@@ -367,3 +367,8 @@ def mode_allows_group_or_other(st_mode):
     :return: bool: true when group or other has some permissions
     """
     return (st_mode & stat.S_IRWXO or st_mode & stat.S_IRWXG) != 0
+
+
+def format_destination_path(path):
+
+    return path

--- a/ddsc/ddsclient.py
+++ b/ddsc/ddsclient.py
@@ -1,13 +1,14 @@
 """ Runs the appropriate command for a user based on arguments. """
 from __future__ import print_function, unicode_literals
 from builtins import input
+import os
 import sys
 import datetime
 import time
 from ddsc.core.d4s2 import D4S2Project, D4S2Error
 from ddsc.core.remotestore import RemoteStore, RemoteAuthRole, ProjectNameOrId
 from ddsc.core.upload import ProjectUpload
-from ddsc.cmdparser import CommandParser, path_does_not_exist_or_is_empty, replace_invalid_path_chars
+from ddsc.cmdparser import CommandParser, format_destination_path, replace_invalid_path_chars
 from ddsc.core.download import ProjectDownload
 from ddsc.core.util import ProjectDetailsList, verify_terminal_encoding
 from ddsc.core.pathfilter import PathFilter
@@ -193,13 +194,14 @@ class DownloadCommand(BaseCommand):
         """
         project_name_or_id = self.create_project_name_or_id_from_args(args)
         folder = args.folder                # path to a folder to download data into
+        resume = args.resume                # are we resuming a download
         # Default to project name with spaces replaced with '_' if not specified
         if not folder:
-            fixed_path = replace_invalid_path_chars(project_name_or_id.value.replace(' ', '_'))
-            folder = path_does_not_exist_or_is_empty(fixed_path)
+            folder = replace_invalid_path_chars(project_name_or_id.value.replace(' ', '_'))
+        destination_path = format_destination_path(folder, must_be_empty=(not resume))
         path_filter = PathFilter(args.include_paths, args.exclude_paths)
         project = self.fetch_project(args, must_exist=True, include_children=True)
-        project_download = ProjectDownload(self.remote_store, project, folder, path_filter)
+        project_download = ProjectDownload(self.remote_store, project, destination_path, path_filter)
         project_download.run()
 
 

--- a/ddsc/ddsclient.py
+++ b/ddsc/ddsclient.py
@@ -193,11 +193,10 @@ class DownloadCommand(BaseCommand):
         """
         project_name_or_id = self.create_project_name_or_id_from_args(args)
         folder = args.folder                # path to a folder to download data into
-        resume = args.resume                # are we resuming a download
         # Default to project name with spaces replaced with '_' if not specified
         if not folder:
             folder = replace_invalid_path_chars(project_name_or_id.value.replace(' ', '_'))
-        destination_path = format_destination_path(folder, must_be_empty=(not resume))
+        destination_path = format_destination_path(folder)
         path_filter = PathFilter(args.include_paths, args.exclude_paths)
         project = self.fetch_project(args, must_exist=True, include_children=True)
         project_download = ProjectDownload(self.remote_store, project, destination_path, path_filter)

--- a/ddsc/ddsclient.py
+++ b/ddsc/ddsclient.py
@@ -1,7 +1,6 @@
 """ Runs the appropriate command for a user based on arguments. """
 from __future__ import print_function, unicode_literals
 from builtins import input
-import os
 import sys
 import datetime
 import time

--- a/ddsc/tests/test_cmdparser.py
+++ b/ddsc/tests/test_cmdparser.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 from unittest import TestCase
-import argparse
-from ddsc.cmdparser import CommandParser, format_destination_path, DESTINATION_PATH_EXISTS_FMT
+from ddsc.cmdparser import CommandParser, format_destination_path
 from mock import Mock, patch
 
 
@@ -172,26 +171,9 @@ class TestCommandParser(TestCase):
         self.assertEqual(['download'], list(command_parser.subparsers.choices.keys()))
         command_parser.run_command(['download', '-p', 'mouse'])
         self.assertEqual('mouse', self.parsed_args.project_name)
-        self.assertEqual(False, self.parsed_args.resume)
-
-    def test_register_download_command_resume(self):
-        command_parser = CommandParser(version_str='1.0')
-        command_parser.register_download_command(self.set_parsed_args)
-        self.assertEqual(['download'], list(command_parser.subparsers.choices.keys()))
-        command_parser.run_command(['download', '-p', 'mouse', '--resume'])
-        self.assertEqual('mouse', self.parsed_args.project_name)
-        self.assertEqual(True, self.parsed_args.resume)
 
     @patch("ddsc.cmdparser.os")
-    def test_format_destination_path_raises_when_must_be_empty(self, mock_os):
+    def test_format_destination_path_ok_when_dir_empty(self, mock_os):
         mock_os.path.exists.return_value = True
         mock_os.listdir.return_value = ['stuff']
-        with self.assertRaises(argparse.ArgumentTypeError) as raisedException:
-            format_destination_path(path='/tmp/somepath', must_be_empty=True)
-        self.assertEqual(DESTINATION_PATH_EXISTS_FMT.format('/tmp/somepath'), str(raisedException.exception))
-
-    @patch("ddsc.cmdparser.os")
-    def test_format_destination_path_ok_when_can_be_empty(self, mock_os):
-        mock_os.path.exists.return_value = True
-        mock_os.listdir.return_value = ['stuff']
-        format_destination_path(path='/tmp/somepath', must_be_empty=False)
+        format_destination_path(path='/tmp/somepath')

--- a/ddsc/tests/test_ddsclient.py
+++ b/ddsc/tests/test_ddsclient.py
@@ -134,7 +134,6 @@ class TestDownloadCommand(TestCase):
         args.include_paths = None
         args.exclude_paths = None
         args.folder = '/tmp/stuff'
-        args.resume = False
         cmd.run(args)
         mock_remote_store.return_value.fetch_remote_project.assert_called()
         args, kwargs = mock_remote_store.return_value.fetch_remote_project.call_args

--- a/ddsc/tests/test_ddsclient.py
+++ b/ddsc/tests/test_ddsclient.py
@@ -134,6 +134,7 @@ class TestDownloadCommand(TestCase):
         args.include_paths = None
         args.exclude_paths = None
         args.folder = '/tmp/stuff'
+        args.resume = False
         cmd.run(args)
         mock_remote_store.return_value.fetch_remote_project.assert_called()
         args, kwargs = mock_remote_store.return_value.fetch_remote_project.call_args

--- a/ddsc/tests/test_ddsclient.py
+++ b/ddsc/tests/test_ddsclient.py
@@ -133,6 +133,7 @@ class TestDownloadCommand(TestCase):
         args.project_id = '123'
         args.include_paths = None
         args.exclude_paths = None
+        args.folder = '/tmp/stuff'
         cmd.run(args)
         mock_remote_store.return_value.fetch_remote_project.assert_called()
         args, kwargs = mock_remote_store.return_value.fetch_remote_project.call_args


### PR DESCRIPTION
Option to allow a user to resume a download by adding `--resume` or `-r` to the `download` command. Without this flag if the destination directory contains files/folders the download command will stop. This flag will allow the download command to continue.  Additionally we  will skips downloading files that already exist and have the same hash as the remote file.

