### PR TITLE
Prevent share or delivery to user with no email

### DIFF
--- a/ddsc/core/tests/test_d4s2.py
+++ b/ddsc/core/tests/test_d4s2.py
@@ -37,8 +37,7 @@ class TestD4S2Project(TestCase):
                           force_send=False,
                           auth_role='project_viewer',
                           user_message='This is a test.')
-        self.assertEqual(raised_error.exception.message,
-                         USER_WITHOUT_EMAIL_MESSAGE.format('share', 'share'))
+        self.assertEqual(str(raised_error.exception), USER_WITHOUT_EMAIL_MESSAGE.format('share', 'share'))
 
     @patch('ddsc.core.d4s2.D4S2Api')
     @patch('ddsc.core.d4s2.requests')
@@ -73,8 +72,7 @@ class TestD4S2Project(TestCase):
                             force_send=False,
                             path_filter='',
                             user_message='Yet Another Message.')
-        self.assertEqual(raised_error.exception.message,
-                         USER_WITHOUT_EMAIL_MESSAGE.format('deliver', 'deliver'))
+        self.assertEqual(str(raised_error.exception), USER_WITHOUT_EMAIL_MESSAGE.format('deliver', 'deliver'))
 
     @patch('ddsc.core.d4s2.ProjectDownload')
     @patch('ddsc.core.d4s2.ProjectUpload')

--- a/ddsc/core/tests/test_d4s2.py
+++ b/ddsc/core/tests/test_d4s2.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 from unittest import TestCase
-from ddsc.core.d4s2 import D4S2Project, CopyActivity, DownloadedFileRelations, UploadedFileRelations
+from ddsc.core.d4s2 import D4S2Project, CopyActivity, DownloadedFileRelations, UploadedFileRelations, \
+    UserMissingEmailError, USER_WITHOUT_EMAIL_MESSAGE
 from ddsc.core.util import KindType
 from ddsc.core.pathfilter import PathFilter
 from mock import patch, MagicMock, Mock
@@ -27,6 +28,20 @@ class TestD4S2Project(TestCase):
 
     @patch('ddsc.core.d4s2.D4S2Api')
     @patch('ddsc.core.d4s2.requests')
+    def test_share_to_bad_email(self, mock_requests, mock_d4s2api):
+        mock_d4s2api().get_existing_item.return_value = Mock(json=Mock(return_value=[]))
+        project = D4S2Project(config=MagicMock(), remote_store=MagicMock(), print_func=MagicMock())
+        with self.assertRaises(UserMissingEmailError) as raised_error:
+            project.share(project=Mock(name='mouserna'),
+                          to_user=MagicMock(id='123', email=None),
+                          force_send=False,
+                          auth_role='project_viewer',
+                          user_message='This is a test.')
+        self.assertEqual(raised_error.exception.message,
+                         USER_WITHOUT_EMAIL_MESSAGE.format('share', 'share'))
+
+    @patch('ddsc.core.d4s2.D4S2Api')
+    @patch('ddsc.core.d4s2.requests')
     def test_deliver(self, mock_requests, mock_d4s2api):
         mock_d4s2api().get_existing_item.return_value = Mock(json=Mock(return_value=[]))
         project = D4S2Project(config=MagicMock(), remote_store=MagicMock(), print_func=MagicMock())
@@ -44,6 +59,22 @@ class TestD4S2Project(TestCase):
         self.assertEqual('Yet Another Message.', item.user_message)
         self.assertEqual(['777', '888'], item.share_user_ids)
         mock_d4s2api().send_item.assert_called()
+
+    @patch('ddsc.core.d4s2.D4S2Api')
+    @patch('ddsc.core.d4s2.requests')
+    def test_deliver_to_bad_email(self, mock_requests, mock_d4s2api):
+        mock_d4s2api.return_value.get_existing_item.return_value = Mock(json=Mock(return_value=[]))
+        project = D4S2Project(config=MagicMock(), remote_store=MagicMock(), print_func=MagicMock())
+        with self.assertRaises(UserMissingEmailError) as raised_error:
+            project.deliver(project=Mock(name='mouserna'),
+                            new_project_name=None,
+                            to_user=MagicMock(id='456', email=None),
+                            share_users=[Mock(id='777'), Mock(id='888')],
+                            force_send=False,
+                            path_filter='',
+                            user_message='Yet Another Message.')
+        self.assertEqual(raised_error.exception.message,
+                         USER_WITHOUT_EMAIL_MESSAGE.format('deliver', 'deliver'))
 
     @patch('ddsc.core.d4s2.ProjectDownload')
     @patch('ddsc.core.d4s2.ProjectUpload')


### PR DESCRIPTION
Raises exception if trying to run share or deliver command
to a user that doesn't have an email. Obviously this will only
be a problem when user the --user <userid> option.

Fixes #191 