### PR TITLE
Adds first_name, last_name to RemoteUser

### DIFF
--- a/ddsc/core/remotestore.py
+++ b/ddsc/core/remotestore.py
@@ -476,6 +476,8 @@ class RemoteUser(object):
         self.username = json_data['username']
         self.full_name = json_data['full_name']
         self.email = json_data['email']
+        self.first_name = json_data['first_name']
+        self.last_name = json_data['last_name']
 
     def __str__(self):
         return 'id:{} username:{} full_name:{}'.format(self.id, self.username, self.full_name)

--- a/ddsc/core/tests/test_remotestore.py
+++ b/ddsc/core/tests/test_remotestore.py
@@ -239,7 +239,9 @@ class TestRemoteUser(TestCase):
               "id": "12789123897123978",
               "username": "js123",
               "full_name": "John Smith",
-              "email": "john.smith@duke.edu"
+              "email": "john.smith@duke.edu",
+              "first_name" : "John",
+              "last_name" : "Smith"
             }
             ]
         }
@@ -250,6 +252,8 @@ class TestRemoteUser(TestCase):
         self.assertEqual('12789123897123978', user.id)
         self.assertEqual('js123', user.username)
         self.assertEqual('John Smith', user.full_name)
+        self.assertEqual('John', user.first_name)
+        self.assertEqual('Smith', user.last_name)
         self.assertEqual('id:12789123897123978 username:js123 full_name:John Smith', str(user))
 
 
@@ -662,6 +666,8 @@ class TestRemoteAuthProvider(TestCase):
             "username": "joe",
             "full_name": "Joe Shoe",
             "email": "",
+            "first_name": "Joe",
+            "last_name": "Shoe",
         }
         mock_data_service_api().get_auth_providers.return_value = providers_response
         mock_data_service_api().auth_provider_add_user.return_value = add_user_response


### PR DESCRIPTION
In support of https://github.com/Duke-GCB/D4S2/issues/162, adds fields to the RemoteUser class, to avoid fetching these separately.

