### PR TITLE
api: add ability to list project permissions

### DIFF
--- a/ddsc/core/ddsapi.py
+++ b/ddsc/core/ddsapi.py
@@ -644,17 +644,23 @@ class DataServiceApi(object):
         Send GET request to /projects/{project_id}/permissions/{user_id/.
         :param project_id: str uuid of the project
         :param user_id: str uuid of the user
-        :param auth_role: str project role eg 'project_admin'
         :return: requests.Response containing the successful result
         """
         return self._get_single_item("/projects/" + project_id + "/permissions/" + user_id, {})
+
+    def get_project_permissions(self, project_id):
+        """
+        Send GET request to /projects/{project_id}/permissions/.
+        :param project_id: str uuid of the project
+        :return: requests.Response containing the successful result
+        """
+        return self._get_collection("/projects/" + project_id + "/permissions/", {})
 
     def revoke_user_project_permission(self, project_id, user_id):
         """
         Send DELETE request to /projects/{project_id}/permissions/{user_id so they will no longer have permissions.
         :param project_id: str uuid of the project
         :param user_id: str uuid of the user
-        :param auth_role: str project role eg 'project_admin'
         :return: requests.Response containing the successful result
         """
         return self._delete("/projects/" + project_id + "/permissions/" + user_id, {})

--- a/ddsc/core/tests/test_ddsapi.py
+++ b/ddsc/core/tests/test_ddsapi.py
@@ -527,6 +527,39 @@ class TestDataServiceApi(TestCase):
         args, kwargs = mock_requests.get.call_args
         self.assertEqual(args[0], 'something.com/v1/projects/123/files')
 
+    def test_get_project_permissions(self):
+        mock_requests = MagicMock()
+        page1 = {
+            "results": [
+                {
+                    "project": {
+                        "id": "8593ab3c-9999-11e8-9eb6-529269fb1459",
+                    },
+                    "user": {
+                        "id": "8593aeac-9999-11e8-9eb6-529269fb1459",
+                    },
+                    "auth_role": {
+                        "id": "project_admin",
+                    }
+                }
+            ]
+        }
+        mock_requests.get.side_effect = [
+            fake_response_with_pages(status_code=200, json_return_value=page1, num_pages=1),
+        ]
+        api = DataServiceApi(auth=self.create_mock_auth(config_page_size=100), url="something.com/v1",
+                             http=mock_requests)
+
+        response = api.get_project_permissions(project_id='123')
+
+        args, kwargs = mock_requests.get.call_args
+        self.assertEqual(args[0], 'something.com/v1/projects/123/permissions/')
+        results = response.json()['results']
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]['project']['id'], '8593ab3c-9999-11e8-9eb6-529269fb1459')
+        self.assertEqual(results[0]['user']['id'], '8593aeac-9999-11e8-9eb6-529269fb1459')
+        self.assertEqual(results[0]['auth_role']['id'], 'project_admin')
+
 
 class TestDataServiceAuth(TestCase):
     @patch('ddsc.core.ddsapi.get_user_agent_str')


### PR DESCRIPTION
Adds get_project_permissions to DataServiceApi.
For use by https://github.com/Duke-GCB/D4S2/pull/170