### PR TITLE
fix portal url

### DIFF
--- a/ddsc/core/tests/test_upload.py
+++ b/ddsc/core/tests/test_upload.py
@@ -3,7 +3,7 @@ from unittest import TestCase
 from ddsc.core.upload import ProjectUpload, LocalOnlyCounter
 from ddsc.core.localstore import LocalFile
 from ddsc.core.remotestore import ProjectNameOrId
-from mock import MagicMock, patch
+from mock import MagicMock, patch, Mock
 
 
 class TestUploadCommand(TestCase):
@@ -44,3 +44,14 @@ class TestLocalOnlyCounter(TestCase):
         f.size = 200
         counter.visit_file(f, None)
         self.assertEqual(3, counter.total_items())
+
+
+class TestProjectUpload(TestCase):
+    @patch("ddsc.core.upload.RemoteStore")
+    @patch("ddsc.core.upload.LocalProject")
+    def test_get_url_msg(self, mock_local_project, mock_remote_store):
+        project_upload = ProjectUpload(config=Mock(), project_name_or_id=Mock(), folders=Mock(),
+                                       follow_symlinks=False, file_upload_post_processor=None)
+        project_upload.local_project = Mock(remote_id='123')
+        project_upload.config.get_portal_url_base.return_value = '127.0.0.1'
+        self.assertEqual(project_upload.get_url_msg(), 'URL to view project: https://127.0.0.1/#/project/123')

--- a/ddsc/core/upload.py
+++ b/ddsc/core/upload.py
@@ -103,7 +103,7 @@ class ProjectUpload(object):
         """
         msg = 'URL to view project'
         project_id = self.local_project.remote_id
-        url = '{}: https://{}/portal/#/project/{}'.format(msg, self.config.get_portal_url_base(), project_id)
+        url = '{}: https://{}/#/project/{}'.format(msg, self.config.get_portal_url_base(), project_id)
         return url
 
 


### PR DESCRIPTION
When a project is uploaded the url to the portal is printed out to the command line.
The url displayed on the command line resulted in a 404.
Removes `portal/` from the url to match the updated DukeDS website.

Fixes #206 
