### PR TITLE
download too few bytes retrying fix

### DIFF
--- a/ddsc/core/download.py
+++ b/ddsc/core/download.py
@@ -439,6 +439,7 @@ class RetryChunkDownloader(object):
         if response.status_code == 401:
             raise DownloadInconsistentError(response.text)
         response.raise_for_status()
+        self.actual_bytes_read = 0
         self._write_response_to_file(response)
         self._verify_download_complete()
 

--- a/ddsc/core/tests/test_download.py
+++ b/ddsc/core/tests/test_download.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 from unittest import TestCase
 import os
-import ddsc.core.download
 from ddsc.core.download import ProjectDownload, RetryChunkDownloader, DownloadInconsistentError, \
     PartialChunkDownloadError, TooLargeChunkDownloadError, DownloadSettings, DownloadContext, \
     download_file_part_run, DownloadFilePartCommand, FileUrlDownloader
@@ -574,7 +573,7 @@ class TestRetryChunkDownloader(TestCase):
         downloader.get_url_and_headers_for_range.return_value = ('someurl', ['headers'])
         mock_requests.get.return_value.iter_content.side_effect = [
             ['X' * 10],  # only 10 bytes the first time
-            ['X' * 100], # all 100 bytes the second time
+            ['X' * 100],  # all 100 bytes the second time
         ]
         fake_open = mock_open()
         with patch('ddsc.core.download.open', fake_open, create=True):


### PR DESCRIPTION
Resets actual_bytes_read before trying/retrying download files.
On a retry _verify_download_complete will not erronously fail.

Fixes #214