### PR TITLE
update requests requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-requests==2.13.0
+requests>=2.20.0
 PyYAML==3.12
 future==0.16.0
 six==1.10.0

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(name='DukeDSClient',
         license='MIT',
         packages=['ddsc', 'ddsc.core', 'ddsc.sdk', 'DukeDS'],
         install_requires=[
-          'requests',
+          'requests>=2.20.0',
           'PyYAML',
           'pytz',
           'future',


### PR DESCRIPTION
This is to fix a vulnerability found by github:
```
Remediation
Upgrade requests to version 2.20.0 or later. For example:

requests>=2.20.0
Always verify the validity and compatibility of suggestions with your codebase.

Details
CVE-2018-18074 More information
moderate severity
Vulnerable versions: <= 2.19.1
Patched version: 2.20.0
The Requests package through 2.19.1 before 2018-09-14 for Python sends an HTTP Authorization header to an http URI upon receiving a same-hostname https-to-http redirect, which makes it easier for remote attackers to discover credentials by sniffing the network.
```

Requests uses [semantic versioning](http://docs.python-requests.org/en/master/dev/philosophy/#semantic-versioning). 
Integration test passed running against DukeDS dev server.

Fixes #218 
