### PR TITLE
fix python3 encoding for publishing helmod module

### DIFF
--- a/deploy/onpublish.py
+++ b/deploy/onpublish.py
@@ -26,7 +26,7 @@ if resp.status_code == 404:
       "path": "rpmbuild/SPECS/{}".format(target_filename),
       "message": commit_msg,
       "committer": {"name": commit_user, "email": commit_email},
-      "content": str(base64_content),
+      "content": base64_content.decode("utf-8"),
       "branch": commit_branch
     }
     resp = requests.put(url, headers=headers, json=data)


### PR DESCRIPTION
Fixes #223 
The call to str() resulted in a string starting with `b'`.
Fixes here to properly encode the helmod module specfile.

The other issue here was an incorrectly configured github token. 
The token needs the repo scope permissions.