### PR TITLE
changes to support s3 provider

### DIFF
--- a/ddsc/config.py
+++ b/ddsc/config.py
@@ -73,6 +73,7 @@ class Config(object):
     D4S2_URL = 'd4s2_url'                              # url for use with the D4S2 (share/deliver service)
     FILE_EXCLUDE_REGEX = 'file_exclude_regex'          # allows customization of which filenames will be uploaded
     GET_PAGE_SIZE = 'get_page_size'                    # page size used for GET pagination requests
+    STORAGE_PROVIDER_ID = 'storage_provider_id'        # setting to override the default storage provider
 
     def __init__(self):
         self.values = {}
@@ -215,3 +216,11 @@ class Config(object):
         :return:
         """
         return self.values.get(Config.GET_PAGE_SIZE, GET_PAGE_SIZE_DEFAULT)
+
+    @property
+    def storage_provider_id(self):
+        """
+        Returns storage provider id from /api/v1/storage_providers DukeDS API or None to use default.
+        :return: str: uuid of storage provider
+        """
+        return self.values.get(Config.STORAGE_PROVIDER_ID, None)

--- a/ddsc/core/ddsapi.py
+++ b/ddsc/core/ddsapi.py
@@ -470,7 +470,7 @@ class DataServiceApi(object):
         return self._get_collection(url_prefix, data)
 
     def create_upload(self, project_id, filename, content_type, size,
-                      hash_value, hash_alg):
+                      hash_value, hash_alg, storage_provider=None):
         """
         Post to /projects/{project_id}/uploads to create a uuid for uploading chunks.
         NOTE: The optional hash_value and hash_alg parameters are being removed from the DukeDS API.
@@ -480,6 +480,7 @@ class DataServiceApi(object):
         :param size: int size of the file in bytes
         :param hash_value: str hash value of the entire file
         :param hash_alg: str algorithm used to create hash_value
+        :param storage_provider: str optional storage provider id
         :return: requests.Response containing the successful result
         """
         data = {
@@ -489,8 +490,12 @@ class DataServiceApi(object):
             "hash": {
                 "value": hash_value,
                 "algorithm": hash_alg
-            }
+            },
         }
+        if storage_provider:
+            data['storage_provider'] = {
+                'id': storage_provider
+            }
         return self._post("/projects/" + project_id + "/uploads", data)
 
     def create_upload_url(self, upload_id, number, size, hash_value, hash_alg):

--- a/ddsc/core/ddsapi.py
+++ b/ddsc/core/ddsapi.py
@@ -470,7 +470,7 @@ class DataServiceApi(object):
         return self._get_collection(url_prefix, data)
 
     def create_upload(self, project_id, filename, content_type, size,
-                      hash_value, hash_alg, storage_provider=None):
+                      hash_value, hash_alg, storage_provider_id=None):
         """
         Post to /projects/{project_id}/uploads to create a uuid for uploading chunks.
         NOTE: The optional hash_value and hash_alg parameters are being removed from the DukeDS API.
@@ -480,7 +480,7 @@ class DataServiceApi(object):
         :param size: int size of the file in bytes
         :param hash_value: str hash value of the entire file
         :param hash_alg: str algorithm used to create hash_value
-        :param storage_provider: str optional storage provider id
+        :param storage_provider_id: str optional storage provider id
         :return: requests.Response containing the successful result
         """
         data = {
@@ -492,10 +492,8 @@ class DataServiceApi(object):
                 "algorithm": hash_alg
             },
         }
-        if storage_provider:
-            data['storage_provider'] = {
-                'id': storage_provider
-            }
+        if storage_provider_id:
+            data['storage_provider'] = {'id': storage_provider_id}
         return self._post("/projects/" + project_id + "/uploads", data)
 
     def create_upload_url(self, upload_id, number, size, hash_value, hash_alg):

--- a/ddsc/core/ddsapi.py
+++ b/ddsc/core/ddsapi.py
@@ -500,12 +500,14 @@ class DataServiceApi(object):
         """
         Given an upload created by create_upload retrieve a url where we can upload a chunk.
         :param upload_id: uuid of the upload
-        :param number: int incrementing number of the upload
+        :param number: int incrementing number of the upload (1-based index)
         :param size: int size of the chunk in bytes
         :param hash_value: str hash value of chunk
         :param hash_alg: str algorithm used to create hash
         :return: requests.Response containing the successful result
         """
+        if number < 1:
+            raise ValueError("Chunk number must be > 0")
         data = {
             "number": number,
             "size": size,

--- a/ddsc/core/fileuploader.py
+++ b/ddsc/core/fileuploader.py
@@ -124,15 +124,17 @@ class FileUploadOperations(object):
         """
         Create a url for uploading a particular chunk to the datastore.
         :param upload_id: str: uuid of the upload this chunk is for
-        :param chunk_num: int: where in the file does this chunk go
+        :param chunk_num: int: where in the file does this chunk go (0-based index)
         :param chunk: bytes: data we are going to upload
         :return:
         """
         chunk_len = len(chunk)
         hash_data = HashData.create_from_chunk(chunk)
+        one_based_index = chunk_num + 1
 
         def func():
-            return self.data_service.create_upload_url(upload_id, chunk_num, chunk_len, hash_data.value, hash_data.alg)
+            return self.data_service.create_upload_url(upload_id, one_based_index, chunk_len,
+                                                       hash_data.value, hash_data.alg)
 
         resp = retry_until_resource_is_consistent(func, self.waiting_monitor)
         return resp.json()

--- a/ddsc/core/projectuploader.py
+++ b/ddsc/core/projectuploader.py
@@ -409,7 +409,7 @@ def create_small_file(upload_context):
     # Talk to data service uploading chunk and creating the file.
     upload_operations = FileUploadOperations(data_service, upload_context)
     upload_id = upload_operations.create_upload(upload_context.project_id, path_data, hash_data,
-                                                upload_context.config.storage_provider_id)
+                                                storage_provider_id=upload_context.config.storage_provider_id)
     url_info = upload_operations.create_file_chunk_url(upload_id, chunk_num, chunk)
     upload_operations.send_file_external(url_info, chunk)
     return upload_operations.finish_upload(upload_id, hash_data, parent_data, remote_file_id)

--- a/ddsc/core/projectuploader.py
+++ b/ddsc/core/projectuploader.py
@@ -408,7 +408,8 @@ def create_small_file(upload_context):
 
     # Talk to data service uploading chunk and creating the file.
     upload_operations = FileUploadOperations(data_service, upload_context)
-    upload_id = upload_operations.create_upload(upload_context.project_id, path_data, hash_data)
+    upload_id = upload_operations.create_upload(upload_context.project_id, path_data, hash_data,
+                                                upload_context.config.storage_provider_id)
     url_info = upload_operations.create_file_chunk_url(upload_id, chunk_num, chunk)
     upload_operations.send_file_external(url_info, chunk)
     return upload_operations.finish_upload(upload_id, hash_data, parent_data, remote_file_id)

--- a/ddsc/core/projectuploader.py
+++ b/ddsc/core/projectuploader.py
@@ -402,7 +402,7 @@ def create_small_file(upload_context):
     parent_data, path_data, remote_file_id = upload_context.params
 
     # The small file will fit into one chunk so read into memory and hash it.
-    chunk_num = 1
+    chunk_num = 0
     chunk = path_data.read_whole_file()
     hash_data = path_data.get_hash()
 

--- a/ddsc/core/tests/test_ddsapi.py
+++ b/ddsc/core/tests/test_ddsapi.py
@@ -680,6 +680,29 @@ class TestDataServiceApi(TestCase):
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0]['id'], '8593aeac-9999-11e8-9eb6-529269fb1459')
 
+    def test_put_create_upload_url(self):
+        mock_requests = MagicMock()
+        api = DataServiceApi(auth=self.create_mock_auth(config_page_size=100),
+                             url="something.com/v1",
+                             http=mock_requests)
+        mock_response = {
+            "id": "8593aeac-9999-11e8-9eb6-529269fb1459"
+        }
+        mock_requests.put.side_effect = [
+            fake_response(status_code=200, json_return_value=mock_response),
+        ]
+        resp = api.create_upload_url(upload_id='someId', number=1, size=200, hash_value='somehash', hash_alg='md5')
+        self.assertEqual(resp.json(), mock_response)
+
+    def test_put_create_upload_url_invalid_number(self):
+        mock_requests = MagicMock()
+        api = DataServiceApi(auth=self.create_mock_auth(config_page_size=100),
+                             url="something.com/v1",
+                             http=mock_requests)
+        with self.assertRaises(ValueError) as raised_exception:
+            api.create_upload_url(upload_id='someId', number=0, size=200, hash_value='somehash', hash_alg='md5')
+        self.assertEqual(str(raised_exception.exception), "Chunk number must be > 0")
+
 
 class TestDataServiceAuth(TestCase):
     @patch('ddsc.core.ddsapi.get_user_agent_str')

--- a/ddsc/core/tests/test_ddsapi.py
+++ b/ddsc/core/tests/test_ddsapi.py
@@ -711,7 +711,7 @@ class TestDataServiceApi(TestCase):
                              http=mock_requests)
         mock_requests.post.return_value = fake_response(status_code=201, json_return_value={})
         api.create_upload(project_id='123', filename='data.txt', content_type='sometype', size=10,
-                      hash_value='somehash', hash_alg='md5', storage_provider_id='abc456')
+                          hash_value='somehash', hash_alg='md5', storage_provider_id='abc456')
         expected_data = json.dumps({
             "name": "data.txt",
             "content_type": "sometype",

--- a/ddsc/sdk/client.py
+++ b/ddsc/sdk/client.py
@@ -190,7 +190,8 @@ class DDSConnection(object):
         hash_data = path_data.get_hash()
         file_upload_operations = FileUploadOperations(self.data_service, None)
         upload_id = file_upload_operations.create_upload(project_id, path_data, hash_data,
-                                                         remote_filename=remote_filename)
+                                                         remote_filename=remote_filename,
+                                                         storage_provider=self.config.storage_provider_id)
         context = UploadContext(self.config, self.data_service, upload_id, path_data)
         ParallelChunkProcessor(context).run()
         remote_file_data = file_upload_operations.finish_upload(upload_id, hash_data, parent_data, existing_file_id)

--- a/ddsc/sdk/tests/test_client.py
+++ b/ddsc/sdk/tests/test_client.py
@@ -248,17 +248,25 @@ class TestDDSConnection(TestCase):
         }
         mock_file_upload_operations.return_value.finish_upload.return_value = response
 
-        dds_connection = DDSConnection(Mock())
+        mock_config = Mock()
+        dds_connection = DDSConnection(mock_config)
         file_info = dds_connection.upload_file(
             local_path='/tmp/data.dat',
             project_id='123',
-            parent_data=Mock()
+            parent_data=Mock(),
+            remote_filename='data.dat'
         )
 
         self.assertEqual(file_info.id, '456')
         self.assertEqual(file_info.name, 'data.dat')
         self.assertEqual(file_info.project_id, '123')
-        mock_file_upload_operations.return_value.create_upload.assert_called()
+        mock_file_upload_operations.return_value.create_upload.assert_called_with(
+            '123',
+            mock_path_data.return_value,
+            mock_path_data.return_value.get_hash.return_value,
+            remote_filename='data.dat',
+            storage_provider=mock_config.storage_provider_id
+        )
         mock_parallel_chunk_processor.return_value.run.assert_called()
         mock_file_upload_operations.return_value.finish_upload.assert_called()
 

--- a/ddsc/tests/test_config.py
+++ b/ddsc/tests/test_config.py
@@ -14,6 +14,7 @@ class TestConfig(TestCase):
         self.assertEqual(config.auth, None)
         self.assertEqual(config.upload_bytes_per_chunk, ddsc.config.DDS_DEFAULT_UPLOAD_CHUNKS)
         self.assertEqual(config.upload_workers, min(multiprocessing.cpu_count(), ddsc.config.MAX_DEFAULT_WORKERS))
+        self.assertEqual(config.storage_provider_id, None)
 
     def test_global_then_local(self):
         config = ddsc.config.Config()
@@ -145,3 +146,13 @@ class TestConfig(TestCase):
         }
         config.update_properties(some_config)
         self.assertEqual(config.page_size, 200)
+
+    @patch('ddsc.config.os')
+    def test_storage_provider_id(self, mock_os):
+        config = ddsc.config.Config()
+        self.assertEqual(config.storage_provider_id, None)
+        some_config = {
+            'storage_provider_id': '123456',
+        }
+        config.update_properties(some_config)
+        self.assertEqual(config.storage_provider_id, '123456')


### PR DESCRIPTION
Adds config file setting `storage_provider_id` to specify a particular storage provider id.
This storage provider id is specified when creating a file upload 
[POST /api/v1/projects/{project_id}/uploads](https://apiuatest.dataservice.duke.edu/apiexplorer#!/projects/postApiV1ProjectsProjectIdUploads)
This is not intended to be used by end users but just for developers testing various DukeDS backends.

Adds retry around create upload URL requests. 
Previously this never failed with the 404 with a retry hint but does so with the new provider.

Adds change to send chunk numbers > 0. The swift DukeDS backend supported 0 based chunk indexing, however the S3 DukeDS backend does not. For multi part files we sent chunk indexes starting with index 0 since this is easier to reason about related to the file we are reading. Changes here increment the chunk number before sending it to DukeDS API.