### PR TITLE
Fix 403 S3 errors when downloading

### DIFF
--- a/ddsc/core/download.py
+++ b/ddsc/core/download.py
@@ -12,6 +12,8 @@ from ddsc.core.remotestore import RemoteStore, ProjectFile, RemoteFileUrl
 FETCH_EXTERNAL_PUT_RETRY_TIMES = 5
 FETCH_EXTERNAL_RETRY_SECONDS = 20
 RESOURCE_NOT_CONSISTENT_RETRY_SECONDS = 2
+SWIFT_EXPIRED_STATUS_CODE = 401
+S3_EXPIRED_STATUS_CODE = 403
 
 
 class ProjectDownload(object):
@@ -421,7 +423,8 @@ class RetryChunkDownloader(object):
         headers = self.get_range_headers()
         if file_download.http_headers:
             headers.update(file_download.http_headers)
-        url = '{}/{}'.format(file_download.host, file_download.url)
+        # The DukeDS API 'url' field always starts with a slash so none needed here.
+        url = '{}{}'.format(file_download.host, file_download.url)
         return url, headers
 
     def get_range_headers(self):
@@ -436,7 +439,8 @@ class RetryChunkDownloader(object):
         :param headers: dict: headers used to download this file chunk
         """
         response = requests.get(url, headers=headers, stream=True)
-        if response.status_code == 401:
+        if response.status_code == SWIFT_EXPIRED_STATUS_CODE \
+                or response.status_code == S3_EXPIRED_STATUS_CODE:
             raise DownloadInconsistentError(response.text)
         response.raise_for_status()
         self.actual_bytes_read = 0

--- a/ddsc/core/download.py
+++ b/ddsc/core/download.py
@@ -423,8 +423,10 @@ class RetryChunkDownloader(object):
         headers = self.get_range_headers()
         if file_download.http_headers:
             headers.update(file_download.http_headers)
-        # The DukeDS API 'url' field always starts with a slash so none needed here.
-        url = '{}{}'.format(file_download.host, file_download.url)
+        separator = ""
+        if not file_download.url.startswith("/"):
+            separator = "/"
+        url = '{}{}{}'.format(file_download.host, separator, file_download.url)
         return url, headers
 
     def get_range_headers(self):

--- a/ddsc/core/tests/test_download.py
+++ b/ddsc/core/tests/test_download.py
@@ -438,6 +438,20 @@ class TestRetryChunkDownloader(TestCase):
         with self.assertRaises(DownloadInconsistentError):
             downloader.retry_download_loop()
 
+    def test_get_url_and_headers_for_range_with_no_slashes(self):
+        mock_context = Mock()
+        mock_file_download = Mock(host='somehost', url='someurl')
+        mock_file_download.http_headers = {}
+        downloader = RetryChunkDownloader(project_file=None, local_path=None, seek_amt=None,
+                                          bytes_to_read=None, download_context=mock_context)
+
+        downloader.get_range_headers = Mock()
+        downloader.get_range_headers.return_value = {'Range': 'bytes=100-200'}
+
+        url, headers = downloader.get_url_and_headers_for_range(mock_file_download)
+
+        self.assertEqual(url, 'somehost/someurl')
+
     def test_get_url_and_headers_for_range(self):
         mock_context = Mock()
         mock_file_download = Mock(host='somehost', url='/someurl')


### PR DESCRIPTION
Handles two more differences when working against the new DukeDS S3 backend.
Previously DukeDSClient added a `/` between the `host` and `url` fields that needed to be combined to download a file. We stop doing so due to this causing errors in S3.
Another issue is retrying expired urls.
Swift returns 401 status code when a url is expired.
S3 returns a 403 status code when a url is expired.

Fixes #229 