### PR TITLE
upgrade pyyaml requirement to 5.1

### DIFF
--- a/ddsc/config.py
+++ b/ddsc/config.py
@@ -86,7 +86,7 @@ class Config(object):
         filename = os.path.expanduser(filename)
         if os.path.exists(filename):
             with open(filename, 'r') as yaml_file:
-                self.update_properties(yaml.load(yaml_file))
+                self.update_properties(yaml.safe_load(yaml_file))
 
     def update_properties(self, new_values):
         """

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 requests>=2.20.0
-PyYAML==3.12
+PyYAML==5.1
 future==0.16.0
 six==1.10.0

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(name='DukeDSClient',
         packages=['ddsc', 'ddsc.core', 'ddsc.sdk', 'DukeDS'],
         install_requires=[
           'requests>=2.20.0',
-          'PyYAML',
+          'PyYAML>=5.1',
           'pytz',
           'future',
           'six',


### PR DESCRIPTION
Changes pyyaml to >= 5.1 in setup.py to resolve https://nvd.nist.gov/vuln/detail/CVE-2017-18342.

Fixes warning for new installations of DukeDSClient that pull in pyyaml 5.1:
```
/Users/jpb67/Documents/work/DukeDSClient/ddsc/config.py:86: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
  self.update_properties(yaml.load(yaml_file))
```


