### PR TITLE
When downloading files validate their checksums

### DIFF
--- a/ddsc/core/download.py
+++ b/ddsc/core/download.py
@@ -518,8 +518,9 @@ class MD5FileHash(object):
 
     @staticmethod
     def get_hash_value(file_path):
-        _, hash_value = HashUtil().add_file(file_path).hexdigest()
-        return hash_value
+        hash_util = HashUtil()
+        hash_util.add_file(file_path)
+        return hash_util.hash.hexdigest()
 
 
 class FileHash(object):

--- a/ddsc/core/download.py
+++ b/ddsc/core/download.py
@@ -323,16 +323,15 @@ class FileUrlDownloader(object):
     @staticmethod
     def check_file_hash(project_file, local_path):
         local_hash_data = HashData.create_from_path(local_path)
-        hash_algorithm = local_hash_data.alg
-        remote_hash_data = project_file.get_hash(hash_algorithm)
-        if not remote_hash_data:
-            raise ValueError("File {} missing remote hash for algorithm: {}.".format(local_path, hash_algorithm))
-        remote_hash_value = remote_hash_data["value"]
+        remote_hash_dict = project_file.get_hash()
+        if not remote_hash_dict:
+            raise ValueError("File /tmp/fakepath.txt missing remote hash.")
+        remote_hash_value = remote_hash_dict["value"]
         if local_hash_data.value != remote_hash_value:
-            format_str = "File {} checksum mismatch: expected {} hash: '{}', downloaded file {} hash '{}'."
+            format_str = "File {} checksum mismatch: expected hash: '{}', downloaded file hash '{}'."
             msg = format_str.format(local_path,
-                                    hash_algorithm, remote_hash_value,
-                                    hash_algorithm, local_hash_data.value)
+                                    remote_hash_value,
+                                    local_hash_data.value)
             raise ValueError(msg)
 
 

--- a/ddsc/core/download.py
+++ b/ddsc/core/download.py
@@ -121,7 +121,7 @@ class ProjectDownload(object):
 
     def check_downloaded_files(self, files_to_download):
         """
-        Make sure the file contents are correct.
+        Make sure the file contents are correct by hashing file and comparing against hash provided by DukeDS.
         Raises ValueError if there is one or more problematic files.
         """
         invalid_hash_errors = []
@@ -143,7 +143,7 @@ class ProjectDownload(object):
         local_hash_data = HashData.create_from_path(local_path)
         remote_hash_dict = project_file.get_hash()
         if not remote_hash_dict:
-            raise ValueError("File /tmp/fakepath.txt missing remote hash.")
+            raise ValueError("File {} missing remote hash.".format(local_path))
         remote_hash_value = remote_hash_dict["value"]
         if local_hash_data.value != remote_hash_value:
             format_str = "File {} checksum mismatch: expected hash: '{}', downloaded file hash '{}'."

--- a/ddsc/core/remotestore.py
+++ b/ddsc/core/remotestore.py
@@ -679,8 +679,8 @@ class ProjectFile(object):
     def get_local_path(self, directory_path):
         return os.path.join(directory_path, self.path)
 
-    def get_hash(self, target_algorithm=HashUtil.HASH_NAME):
-        return RemoteFile.get_hash_from_upload(self.json_data, target_algorithm=target_algorithm)
+    def get_hash(self):
+        return RemoteFile.get_hash_from_upload(self.json_data)
 
 
 class RemoteFileUrl(object):

--- a/ddsc/core/remotestore.py
+++ b/ddsc/core/remotestore.py
@@ -679,8 +679,8 @@ class ProjectFile(object):
     def get_local_path(self, directory_path):
         return os.path.join(directory_path, self.path)
 
-    def get_hash(self):
-        return RemoteFile.get_hash_from_upload(self.json_data)
+    def get_hash(self, target_algorithm=HashUtil.HASH_NAME):
+        return RemoteFile.get_hash_from_upload(self.json_data, target_algorithm=target_algorithm)
 
 
 class RemoteFileUrl(object):

--- a/ddsc/core/tests/test_download.py
+++ b/ddsc/core/tests/test_download.py
@@ -334,9 +334,10 @@ class TestFileUrlDownloader(TestCase):
         with self.assertRaises(ValueError) as raised_exception:
             downloader.check_downloaded_files()
         exception_str = str(raised_exception.exception)
-        self.assertEqual(exception_str, "ERROR: Downloaded file(s) do not match the expected hashes.\n" \
-                         "File /tmp/data.txt checksum mismatch: " \
+        self.assertEqual(exception_str, "ERROR: Downloaded file(s) do not match the expected hashes.\n"
+                         "File /tmp/data.txt checksum mismatch: "
                          "expected md5 hash: 'abc', downloaded file md5 hash 'def'.")
+
 
 class TestDownloadFilePartCommand(TestCase):
     @patch('ddsc.core.download.DownloadContext')

--- a/ddsc/core/tests/test_download.py
+++ b/ddsc/core/tests/test_download.py
@@ -327,7 +327,7 @@ class TestFileUrlDownloader(TestCase):
             FileUrlDownloader.check_file_hash(project_file, local_path='/tmp/fakepath.txt')
         self.assertEqual(str(raised_exception.exception),
                          "File /tmp/fakepath.txt checksum mismatch: "
-                         "expected md5 hash: 'abc', downloaded file md5 hash 'def'.")
+                         "expected hash: 'abc', downloaded file hash 'def'.")
 
     @patch('ddsc.core.download.HashData')
     def test_check_file_hash_algorithm_mismatch(self, mock_hash_data):
@@ -337,7 +337,7 @@ class TestFileUrlDownloader(TestCase):
         with self.assertRaises(ValueError) as raised_exception:
             FileUrlDownloader.check_file_hash(project_file, local_path='/tmp/fakepath.txt')
         self.assertEqual(str(raised_exception.exception),
-                         "File /tmp/fakepath.txt missing remote hash for algorithm: md5.")
+                         "File /tmp/fakepath.txt missing remote hash.")
 
     @patch('ddsc.core.download.HashData')
     def test_check_downloaded_files_when_matching(self, mock_hash_data):
@@ -363,7 +363,7 @@ class TestFileUrlDownloader(TestCase):
         exception_str = str(raised_exception.exception)
         self.assertEqual(exception_str, "ERROR: Downloaded file(s) do not match the expected hashes.\n"
                          "File /tmp/data2/data.txt checksum mismatch: "
-                         "expected md5 hash: 'abc', downloaded file md5 hash 'def'.")
+                         "expected hash: 'abc', downloaded file hash 'def'.")
 
 
 class TestDownloadFilePartCommand(TestCase):

--- a/ddsc/ddsclient.py
+++ b/ddsc/ddsclient.py
@@ -198,6 +198,7 @@ class DownloadCommand(BaseCommand):
             folder = replace_invalid_path_chars(project_name_or_id.value.replace(' ', '_'))
         destination_path = format_destination_path(folder)
         path_filter = PathFilter(args.include_paths, args.exclude_paths)
+        print("Fetching list of files/folders.")
         project = self.fetch_project(args, must_exist=True)
         project_download = ProjectDownload(self.remote_store, project, destination_path, path_filter)
         project_download.run()

--- a/ddsc/sdk/client.py
+++ b/ddsc/sdk/client.py
@@ -5,7 +5,7 @@ from ddsc.config import create_config
 from ddsc.core.remotestore import DOWNLOAD_FILE_CHUNK_SIZE, RemoteFile
 from ddsc.core.fileuploader import FileUploadOperations, ParallelChunkProcessor, ParentData
 from ddsc.core.localstore import PathData
-from ddsc.core.download import ProjectDownload
+from ddsc.core.download import FileHash
 from ddsc.core.util import KindType
 from future.utils import python_2_unicode_compatible
 
@@ -390,7 +390,8 @@ class File(BaseResponseItem):
         if not path:
             path = self.name
         file_download.save_to_path(path)
-        ProjectDownload.check_file_hash(self, path)
+        file_hash = FileHash.create_for_first_supported_algorithm(self.current_version['hashes'], path)
+        file_hash.raise_for_status()
 
     def delete(self):
         """

--- a/ddsc/sdk/client.py
+++ b/ddsc/sdk/client.py
@@ -2,7 +2,7 @@ import os
 from collections import OrderedDict
 from ddsc.core.ddsapi import DataServiceAuth, DataServiceApi
 from ddsc.config import create_config
-from ddsc.core.remotestore import DOWNLOAD_FILE_CHUNK_SIZE
+from ddsc.core.remotestore import DOWNLOAD_FILE_CHUNK_SIZE, RemoteFile
 from ddsc.core.fileuploader import FileUploadOperations, ParallelChunkProcessor, ParentData
 from ddsc.core.localstore import PathData, HashUtil
 from ddsc.core.download import FileUrlDownloader
@@ -409,9 +409,9 @@ class File(BaseResponseItem):
                                                existing_file_id=self.id)
 
     def get_hash(self, algorithm=HashUtil.HASH_NAME):
-        for hash_dict in self.current_version["upload"]["hashes"]:
-            if hash_dict["algorithm"] == algorithm:
-                return hash_dict["value"]
+        hash_value = RemoteFile.get_hash_from_upload(self.current_version["upload"], algorithm)
+        if hash_value:
+            return hash_value
         raise ValueError("No hash found for algorithm {}".format(algorithm))
 
     def __str__(self):

--- a/ddsc/sdk/client.py
+++ b/ddsc/sdk/client.py
@@ -408,11 +408,8 @@ class File(BaseResponseItem):
         return self.dds_connection.upload_file(file_path, project_id=self.project_id, parent_data=parent_data,
                                                existing_file_id=self.id)
 
-    def get_hash(self, algorithm=HashUtil.HASH_NAME):
-        hash_value = RemoteFile.get_hash_from_upload(self.current_version["upload"], algorithm)
-        if hash_value:
-            return hash_value
-        raise ValueError("No hash found for algorithm {}".format(algorithm))
+    def get_hash(self):
+        return RemoteFile.get_hash_from_upload(self.current_version["upload"])
 
     def __str__(self):
         return u'{} id:{} name:{}'.format(self.__class__.__name__, self.id, self.name)

--- a/ddsc/sdk/client.py
+++ b/ddsc/sdk/client.py
@@ -5,7 +5,7 @@ from ddsc.config import create_config
 from ddsc.core.remotestore import DOWNLOAD_FILE_CHUNK_SIZE, RemoteFile
 from ddsc.core.fileuploader import FileUploadOperations, ParallelChunkProcessor, ParentData
 from ddsc.core.localstore import PathData
-from ddsc.core.download import FileUrlDownloader
+from ddsc.core.download import ProjectDownload
 from ddsc.core.util import KindType
 from future.utils import python_2_unicode_compatible
 
@@ -390,7 +390,7 @@ class File(BaseResponseItem):
         if not path:
             path = self.name
         file_download.save_to_path(path)
-        FileUrlDownloader.check_file_hash(self, path)
+        ProjectDownload.check_file_hash(self, path)
 
     def delete(self):
         """

--- a/ddsc/sdk/client.py
+++ b/ddsc/sdk/client.py
@@ -4,7 +4,7 @@ from ddsc.core.ddsapi import DataServiceAuth, DataServiceApi
 from ddsc.config import create_config
 from ddsc.core.remotestore import DOWNLOAD_FILE_CHUNK_SIZE, RemoteFile
 from ddsc.core.fileuploader import FileUploadOperations, ParallelChunkProcessor, ParentData
-from ddsc.core.localstore import PathData, HashUtil
+from ddsc.core.localstore import PathData
 from ddsc.core.download import FileUrlDownloader
 from ddsc.core.util import KindType
 from future.utils import python_2_unicode_compatible

--- a/ddsc/sdk/tests/test_client.py
+++ b/ddsc/sdk/tests/test_client.py
@@ -461,10 +461,10 @@ class TestFile(TestCase):
             }
         }
 
-    @patch('ddsc.core.download.HashUtil', autospec=True)
+    @patch('ddsc.core.download.HashUtil')
     def test_download_to_path_with_valid_hash(self, mock_hash_util):
         mock_dds_connection = Mock()
-        mock_hash_util.return_value.add_file.return_value.hexdigest.return_value = 'md5', 'abcd'
+        mock_hash_util.return_value.hash.hexdigest.return_value = 'abcd'
 
         file = File(mock_dds_connection, self.file_dict)
         file.download_to_path('/tmp/data.dat')
@@ -473,10 +473,10 @@ class TestFile(TestCase):
         mock_dds_connection.get_file_download.return_value.save_to_path('/tmp/data.dat')
         mock_hash_util.return_value.add_file.assert_called_with('/tmp/data.dat')
 
-    @patch('ddsc.core.download.HashUtil', autospec=True)
+    @patch('ddsc.core.download.HashUtil')
     def test_download_to_path_with_invalid_hash(self, mock_hash_util):
         mock_dds_connection = Mock()
-        mock_hash_util.return_value.add_file.return_value.hexdigest.return_value = 'md5', 'efgh'
+        mock_hash_util.return_value.hash.hexdigest.return_value = 'md5', 'efgh'
 
         file = File(mock_dds_connection, self.file_dict)
         with self.assertRaises(ValueError) as raised_exception:

--- a/ddsc/sdk/tests/test_client.py
+++ b/ddsc/sdk/tests/test_client.py
@@ -453,8 +453,8 @@ class TestFile(TestCase):
             }
         }
 
-    @patch('ddsc.sdk.client.FileUrlDownloader')
-    def test_download_to_path(self, mock_file_url_downloader):
+    @patch('ddsc.sdk.client.ProjectDownload', autospec=True)
+    def test_download_to_path(self, mock_project_download):
         mock_dds_connection = Mock()
 
         file = File(mock_dds_connection, self.file_dict)
@@ -462,7 +462,7 @@ class TestFile(TestCase):
 
         mock_dds_connection.get_file_download.assert_called_with('456')
         mock_dds_connection.get_file_download.return_value.save_to_path('/tmp/data.dat')
-        mock_file_url_downloader.check_file_hash.assert_called_with(file, '/tmp/data.dat')
+        mock_project_download.check_file_hash.assert_called_with(file, '/tmp/data.dat')
 
     def test_delete(self):
         mock_dds_connection = Mock()

--- a/ddsc/sdk/tests/test_client.py
+++ b/ddsc/sdk/tests/test_client.py
@@ -453,7 +453,8 @@ class TestFile(TestCase):
             }
         }
 
-    def test_download_to_path(self):
+    @patch('ddsc.sdk.client.FileUrlDownloader')
+    def test_download_to_path(self, mock_file_url_downloader):
         mock_dds_connection = Mock()
 
         file = File(mock_dds_connection, self.file_dict)
@@ -461,6 +462,7 @@ class TestFile(TestCase):
 
         mock_dds_connection.get_file_download.assert_called_with('456')
         mock_dds_connection.get_file_download.return_value.save_to_path('/tmp/data.dat')
+        mock_file_url_downloader.check_file_hash.assert_called_with(file, '/tmp/data.dat')
 
     def test_delete(self):
         mock_dds_connection = Mock()

--- a/ddsc/tests/test_ddsclient.py
+++ b/ddsc/tests/test_ddsclient.py
@@ -108,21 +108,21 @@ class TestUploadCommand(TestCase):
 class TestDownloadCommand(TestCase):
     @patch('ddsc.ddsclient.RemoteStore')
     @patch("ddsc.ddsclient.ProjectDownload")
-    def test_run_project_name(self, mock_project_download, mock_remote_store):
-        @patch('ddsc.ddsclient.RemoteStore')
-        @patch('ddsc.ddsclient.ProjectDownload')
-        def test_run_project_id(self, mock_project_download, mock_remote_store):
-            cmd = DownloadCommand(MagicMock())
-            args = Mock()
-            args.project_name = 'mouse'
-            args.project_id = None
-            args.include_paths = None
-            args.exclude_paths = None
-            cmd.run(args)
-            mock_remote_store.return_value.fetch_remote_project.assert_called()
-            args, kwargs = mock_remote_store.return_value.fetch_remote_project.call_args
-            self.assertEqual('mouse', args[0].get_name_or_raise())
-            mock_project_download.return_value.run.assert_called()
+    @patch("ddsc.ddsclient.format_destination_path")
+    @patch("ddsc.ddsclient.print")
+    def test_run_project_name(self, mock_print, mock_format_destination_path, mock_project_download, mock_remote_store):
+        cmd = DownloadCommand(MagicMock())
+        args = Mock()
+        args.project_name = 'mouse'
+        args.project_id = None
+        args.include_paths = None
+        args.exclude_paths = None
+        cmd.run(args)
+        mock_remote_store.return_value.fetch_remote_project.assert_called()
+        args, kwargs = mock_remote_store.return_value.fetch_remote_project.call_args
+        self.assertEqual('mouse', args[0].get_name_or_raise())
+        mock_project_download.return_value.run.assert_called()
+        mock_print.assert_called_with('Fetching list of files/folders.')
 
     @patch('ddsc.ddsclient.RemoteStore')
     @patch('ddsc.ddsclient.ProjectDownload')


### PR DESCRIPTION
Changes downloading to verify the contents of files downloaded. This is done by calculating an MD5 sum for each file and comparing it against the value provided by DukeDS.

Also prints messages informing the user about progress download and checking files.
Example successful download messaging:
```
Fetching list of files/folders.
Downloading 1 files.
Done: 100%                         <- this line is where the download progress bar displays                         
Verifying contents of 1 downloaded files using file hashes.
All downloaded files have been verified successfully.
```

Fixes #240 