### PR TITLE
Displays file hash when listing project with long option

### DIFF
--- a/ddsc/core/util.py
+++ b/ddsc/core/util.py
@@ -265,7 +265,7 @@ class ProjectDetailsList(object):
     def visit_file(self, item, parent):
         name = self.get_name(item, parent)
         if self.long_format:
-            self.details.append('{}\t{} ({}:{})'.format(item.id, name, item.hash_alg, item.file_hash))
+            self.details.append('{}\t{}\t({}:{})'.format(item.id, name, item.hash_alg, item.file_hash))
         else:
             self.details.append(name)
 

--- a/ddsc/core/util.py
+++ b/ddsc/core/util.py
@@ -265,7 +265,7 @@ class ProjectDetailsList(object):
     def visit_file(self, item, parent):
         name = self.get_name(item, parent)
         if self.long_format:
-            self.details.append('{}\t{}'.format(item.id, name))
+            self.details.append('{}\t{} ({}:{})'.format(item.id, name, item.hash_alg, item.file_hash))
         else:
             self.details.append(name)
 

--- a/ddsc/tests/test_util.py
+++ b/ddsc/tests/test_util.py
@@ -94,6 +94,8 @@ class TestProjectDetailsList(TestCase):
         self.mock_file_item = Mock()
         self.mock_file_item.id = '789'
         self.mock_file_item.name = 'results.csv'
+        self.mock_file_item.hash_alg = 'md5'
+        self.mock_file_item.file_hash = 'abcdefg'
 
     def test_visit_methods_short_format(self):
         project_details_list = ProjectDetailsList(long_format=False)
@@ -115,6 +117,6 @@ class TestProjectDetailsList(TestCase):
         expected_details = [
             '123 - Project mouse Contents:',
             '456\tdata',
-            '789\tdata/results.csv',
+            '789\tdata/results.csv\t(md5:abcdefg)',
         ]
         self.assertEqual(expected_details, project_details_list.details)


### PR DESCRIPTION
Implements showing file's hash value requested in #228.

When a project contents are listed with long option like so:
```
ddsclient list -p <projectName> -l
```

Example output:
```
b10fe5b7-5021-4094-a687-f6442411d4ab - Project <projectName> Contents:
1f0e2240-892b-4a12-bb16-b6165c923b52	requirements.txt	(md5:8d3e8765edb0c97bb59c43c93864e36d)
d38b28d8-1e12-410a-99ae-d4e8f8715494	mushroom.svg	(md5:803283746359c515be00450aa3b16da6)
```