### PR TITLE
improve user registration via email address

### DIFF
--- a/DukeDS/__init__.py
+++ b/DukeDS/__init__.py
@@ -7,7 +7,8 @@ download_file = DukeDS.download_file
 upload_file = DukeDS.upload_file
 delete_file = DukeDS.delete_file
 can_deliver_to_user_with_email = DukeDS.can_deliver_to_user_with_email
+can_deliver_to_user_with_username = DukeDS.can_deliver_to_user_with_username
 
 __all__ = ['list_projects', 'create_project', 'delete_project',
            'list_files', 'download_file', 'upload_file', 'delete_file',
-           'can_deliver_to_user_with_email']
+           'can_deliver_to_user_with_email', 'can_deliver_to_user_with_username']

--- a/DukeDS/__init__.py
+++ b/DukeDS/__init__.py
@@ -6,6 +6,8 @@ list_files = DukeDS.list_files
 download_file = DukeDS.download_file
 upload_file = DukeDS.upload_file
 delete_file = DukeDS.delete_file
+can_deliver_to_user_with_email = DukeDS.can_deliver_to_user_with_email
 
 __all__ = ['list_projects', 'create_project', 'delete_project',
-           'list_files', 'download_file', 'upload_file', 'delete_file']
+           'list_files', 'download_file', 'upload_file', 'delete_file',
+           'can_deliver_to_user_with_email']

--- a/ddsc/core/ddsapi.py
+++ b/ddsc/core/ddsapi.py
@@ -972,6 +972,18 @@ class DataServiceApi(object):
         """
         return self._get_single_item('/auth_providers/{}/'.format(auth_provider_id), {})
 
+    def get_default_auth_provider_id(self):
+        """
+        Get default auth provider.
+        :return: str: uuid of auth provider
+        """
+        response = self.get_auth_providers()
+        auth_providers = response.json()["results"]
+        for auth_provider in auth_providers:
+            if auth_provider["is_default"]:
+                return auth_provider["id"]
+        raise ValueError("Unable to find a default DukeDS auth provider.")
+
     def get_auth_provider_affiliates(self, auth_provider_id, full_name_contains=None, email=None, username=None):
         """
         List affiliates for a specific auth provider.

--- a/ddsc/core/ddsuserutil.py
+++ b/ddsc/core/ddsuserutil.py
@@ -1,0 +1,123 @@
+import re
+import logging
+
+DUKE_EMAIL_SUFFIX = "@duke.edu"
+
+
+class DDSUserUtil(object):
+    def __init__(self, data_service, logging_func=logging.info):
+        self.data_service = data_service
+        self.auth_provider_id = data_service.get_default_auth_provider_id()
+        self.logging_func = logging_func
+
+    def valid_dds_user_or_affiliate_exists_for_email(self, email_address):
+        lookup = LookupUserByEmail(self, email_address, self.logging_func)
+        if lookup.valid_dds_user_exists() or lookup.valid_affiliate_user_exists():
+            return True
+        else:
+            self.logging_func("No valid DukeDS/Affiliate user found for email address {}.".format(email_address))
+            return False
+
+    def find_dds_user_by_email(self, email_address):
+        response = self.data_service.get_users(email=email_address)
+        return self._get_single_user_or_none(response, email_address)
+
+    def find_dds_user_by_username(self, username):
+        response = self.data_service.get_users(username=username)
+        return self._get_single_user_or_none(response, username)
+
+    def find_affiliate_user_by_email(self, email_address):
+        response = self.data_service.get_auth_provider_affiliates(self.auth_provider_id, email=email_address)
+        return self._get_single_user_or_none(response, email_address)
+
+    def find_affiliate_user_by_username(self, username):
+        response = self.data_service.get_auth_provider_affiliates(self.auth_provider_id, username=username)
+        return self._get_single_user_or_none(response, username)
+
+    def register_dds_user_by_username(self, username):
+        response = self.data_service.auth_provider_add_user(self.auth_provider_id, username)
+        return response.json()
+
+    def register_user_with_email(self, email_address):
+        lookup = LookupUserByEmail(self, email_address, self.logging_func)
+        affiliate_user = lookup.get_affiliate_user_with_valid_email()
+        if affiliate_user:
+            return self.register_user_with_username(affiliate_user["uid"])
+        else:
+            raise ValueError("Unable to register user with email address {}".format(self.email_address))
+
+    @staticmethod
+    def _get_single_user_or_none(response, lookup_value):
+        results = response.json()['results']
+        if not results:
+            return None
+        if len(results) == 1:
+            return results[0]
+        raise ValueError("Found multiple users for {}.".format(lookup_value))
+
+
+class LookupUserByEmail(object):
+    def __init__(self, dds_user_util, email_address, logging_func):
+        self.dds_user_util = dds_user_util
+        self.email_address = email_address
+        self.logging_func = logging_func
+        self.possible_username = self._extract_username_or_none(email_address)
+
+    def valid_dds_user_exists(self):
+        if self.get_dds_user_with_valid_email():
+            return True
+        return False
+
+    def get_dds_user_with_valid_email(self):
+        dds_user = self.dds_user_util.find_dds_user_by_email(self.email_address)
+        if self._item_has_email(dds_user):
+            self.logging_func("Found valid DukeDS user for email address {}.".format(self.email_address))
+            return dds_user
+        if self.possible_username:
+            dds_user = self.dds_user_util.find_dds_user_by_username(self.possible_username)
+            if self._item_has_email(dds_user):
+                self.logging_func("Found valid DukeDS user for username {}.".format(self.possible_username))
+                return dds_user
+        return None
+
+    def valid_affiliate_user_exists(self):
+        if self.get_affiliate_user_with_valid_email():
+            return True
+        return False
+
+    def get_affiliate_user_with_valid_email(self):
+        affiliate_user = self.dds_user_util.find_affiliate_user_by_email(self.email_address)
+        if self._item_has_email(affiliate_user):
+            self.logging_func("Found valid affiliate user for email address {}.".format(self.email_address))
+            return affiliate_user
+        if self.possible_username:
+            affiliate_user = self.dds_user_util.find_affiliate_user_by_username(self.possible_username)
+            if self._item_has_email(affiliate_user):
+                self.logging_func("Found valid affiliate user for username {}.".format(self.possible_username))
+                return affiliate_user
+        return None
+
+    @staticmethod
+    def _item_has_email(item):
+        return item and item['email']
+
+    def _extract_username_or_none(self, email_address):
+        """
+        If email_address is a duke email address and the local part is a username return that username or None.
+        Duke emails take two forms one with the full name and another where the local part is the username.
+        Usernames must be only lowercase alphanumeric.
+        :param email_address: str
+        :return: bool: str or None
+        """
+        if self.is_duke_email():
+            local_part = self.strip_email_suffix(email_address)
+            if local_part.islower() and local_part.isalnum():
+                return local_part
+        return None
+
+    def is_duke_email(self):
+        return self.email_address.endswith(DUKE_EMAIL_SUFFIX)
+
+    @staticmethod
+    def strip_email_suffix(email_address):
+        return re.sub('@.*$', '', email_address)

--- a/ddsc/core/remotestore.py
+++ b/ddsc/core/remotestore.py
@@ -148,7 +148,6 @@ class RemoteStore(object):
         user_json = util.find_user_by_email(email)
         if user_json:
             return user_json
-        # Duke email addresses sometimes contain the username.
         potential_username = util.try_determine_username_from_email(email)
         if potential_username:
             user_json = util.find_user_by_username(potential_username)

--- a/ddsc/core/remotestore.py
+++ b/ddsc/core/remotestore.py
@@ -2,6 +2,7 @@ import os
 from ddsc.core.ddsapi import DataServiceApi, DataServiceError, DataServiceAuth
 from ddsc.core.util import KindType
 from ddsc.core.localstore import HashUtil
+from ddsc.core.ddsuserutil import DDSUserUtil
 
 FETCH_ALL_USERS_PAGE_SIZE = 25
 DOWNLOAD_FILE_CHUNK_SIZE = 20 * 1024 * 1024
@@ -94,8 +95,7 @@ class RemoteStore(object):
         if username:
             return self.get_or_register_user_by_username(username)
         else:
-            # API doesn't support registering user by email address yet
-            return self.lookup_user_by_email(email)
+            return self.get_or_register_user_by_email(email)
 
     def lookup_user_by_name(self, full_name):
         """
@@ -116,51 +116,50 @@ class RemoteStore(object):
             raise NotFoundError("User not found:" + full_name)
         return user
 
-    def lookup_user_by_username(self, username):
-        """
-        Finds the single user who has this username or raises ValueError.
-        :param username: str username we are looking for
-        :return: RemoteUser: user we found
-        """
-        matches = self.fetch_users(username=username)
-        if not matches:
-            raise NotFoundError('Username not found: {}.'.format(username))
-        if len(matches) > 1:
-            raise ValueError('Multiple users with same username found: {}.'.format(username))
-        return matches[0]
-
     def get_or_register_user_by_username(self, username):
         """
         Try to lookup user by username. If not found try registering the user.
         :param username: str: username to lookup
         :return: RemoteUser: user we found
         """
-        try:
-            return self.lookup_user_by_username(username)
-        except NotFoundError:
-            return self.register_user_by_username(username)
+        util = DDSUserUtil(self.data_service)
+        user_json = util.find_dds_user_by_username(username)
+        if not user_json:
+            user_json = util.register_dds_user_by_username(username)
+        return RemoteUser(user_json)
+
+    def get_or_register_user_by_email(self, email):
+        """
+        Try to lookup user by email. If not found try registering the user.
+        :param username: str: username to lookup
+        :return: RemoteUser: user we found
+        """
+        util = DDSUserUtil(self.data_service)
+        user_json = util.find_dds_user_by_email(email)
+        if not user_json:
+            user_json = util.register_user_with_email(email)
+        return RemoteUser(user_json)
 
     def register_user_by_username(self, username):
         """
-        Tries to register user with the first non-deprecated auth provider.
+        Register user based on username.
         Raises ValueError if the data service doesn't have any non-deprecated providers.
         :param username: str: netid of the user we are trying to register
-        :return: RemoteUser: user that was created for our netid
+        :return: RemoteUser: user that was created for our username (netid)
         """
-        current_providers = [prov.id for prov in self.get_auth_providers() if not prov.is_deprecated]
-        if not current_providers:
-            raise ValueError("Unable to register user: no non-deprecated providers found!")
-        auth_provider_id = current_providers[0]
-        return self._register_user_by_username(auth_provider_id, username)
+        util = DDSUserUtil(self.data_service)
+        user_json = util.register_dds_user_with_username(username)
+        return RemoteUser(user_json)
 
-    def _register_user_by_username(self, auth_provider_id, username):
+    def register_user_by_email(self, email):
         """
-        Tries to register a user who has a valid netid but isn't registered with DukeDS yet under auth_provider_id.
-        :param auth_provider_id: str: id from RemoteAuthProvider to use for registering
-        :param username: str: netid of the user we are trying to register
-        :return: RemoteUser: user that was created for our netid
+        Register user based on email.
+        Raises ValueError if the data service doesn't have any non-deprecated providers.
+        :param email: str: email address we are trying to register a user with
+        :return: RemoteUser: user that was created for email
         """
-        user_json = self.data_service.auth_provider_add_user(auth_provider_id, username).json()
+        util = DDSUserUtil(self.data_service)
+        user_json = util.register_dds_user_with_email(email)
         return RemoteUser(user_json)
 
     def get_auth_providers(self):
@@ -173,19 +172,6 @@ class RemoteStore(object):
         for data in response['results']:
             providers.append(RemoteAuthProvider(data))
         return providers
-
-    def lookup_user_by_email(self, email):
-        """
-        Finds the single user who has this email or raises ValueError.
-        :param email: str email we are looking for
-        :return: RemoteUser user we found
-        """
-        matches = self.fetch_users(email=email)
-        if not matches:
-            raise NotFoundError('Email not found: {}.'.format(email))
-        if len(matches) > 1:
-            raise ValueError('Multiple users with same email found: {}.'.format(email))
-        return matches[0]
 
     def get_current_user(self):
         """

--- a/ddsc/core/remotestore.py
+++ b/ddsc/core/remotestore.py
@@ -135,26 +135,15 @@ class RemoteStore(object):
         :param email: str: email to lookup or register a user for
         :return: RemoteUser: user we found
         """
-        return RemoteUser(self._get_or_register_user_by_email_internal(email))
-
-    def _get_or_register_user_by_email_internal(self, email):
-        """
-        Try to find or register a user based on the specified email.
-        Raises ValueError when unable to find/register a user for the email.
-        :param email: str: email to lookup or register a user for
-        :return: dict: DukeDS API user response
-        """
         util = UserUtil(self.data_service)
         user_json = util.find_user_by_email(email)
-        if user_json:
-            return user_json
-        potential_username = util.try_determine_username_from_email(email)
-        if potential_username:
-            user_json = util.find_user_by_username(potential_username)
-            if user_json:
-                return user_json
-            return util.register_user_by_username(potential_username)
-        raise ValueError("Unable to find or register a user with email {}".format(email))
+        if not user_json:
+            affiliate = util.find_affiliate_by_email(email)
+            if affiliate:
+                user_json = util.register_user_by_username(affiliate['uid'])
+            else:
+                raise ValueError("Unable to find or register a user with email {}".format(email))
+        return RemoteUser(user_json)
 
     def get_auth_providers(self):
         """

--- a/ddsc/core/remotestore.py
+++ b/ddsc/core/remotestore.py
@@ -137,7 +137,7 @@ class RemoteStore(object):
         util = UserUtil(self.data_service)
         user_json = util.find_dds_user_by_email(email)
         if not user_json:
-            user_json = util.register_user_with_email(email)
+            user_json = util.register_dds_user_with_email(email)
         return RemoteUser(user_json)
 
     def get_auth_providers(self):

--- a/ddsc/core/remotestore.py
+++ b/ddsc/core/remotestore.py
@@ -87,7 +87,7 @@ class RemoteStore(object):
     def lookup_or_register_user_by_email_or_username(self, email, username):
         """
         Lookup user by email or username. Only fill in one field.
-        For username it will try to register if not found.
+        For both cases it will try to register if not found.
         :param email: str: email address of the user
         :param username: netid of the user to find
         :return: RemoteUser

--- a/ddsc/core/remotestore.py
+++ b/ddsc/core/remotestore.py
@@ -2,7 +2,7 @@ import os
 from ddsc.core.ddsapi import DataServiceApi, DataServiceError, DataServiceAuth
 from ddsc.core.util import KindType
 from ddsc.core.localstore import HashUtil
-from ddsc.core.ddsuserutil import DDSUserUtil
+from ddsc.core.userutil import UserUtil
 
 FETCH_ALL_USERS_PAGE_SIZE = 25
 DOWNLOAD_FILE_CHUNK_SIZE = 20 * 1024 * 1024
@@ -122,7 +122,7 @@ class RemoteStore(object):
         :param username: str: username to lookup
         :return: RemoteUser: user we found
         """
-        util = DDSUserUtil(self.data_service)
+        util = UserUtil(self.data_service)
         user_json = util.find_dds_user_by_username(username)
         if not user_json:
             user_json = util.register_dds_user_by_username(username)
@@ -134,32 +134,10 @@ class RemoteStore(object):
         :param username: str: username to lookup
         :return: RemoteUser: user we found
         """
-        util = DDSUserUtil(self.data_service)
+        util = UserUtil(self.data_service)
         user_json = util.find_dds_user_by_email(email)
         if not user_json:
             user_json = util.register_user_with_email(email)
-        return RemoteUser(user_json)
-
-    def register_user_by_username(self, username):
-        """
-        Register user based on username.
-        Raises ValueError if the data service doesn't have any non-deprecated providers.
-        :param username: str: netid of the user we are trying to register
-        :return: RemoteUser: user that was created for our username (netid)
-        """
-        util = DDSUserUtil(self.data_service)
-        user_json = util.register_dds_user_with_username(username)
-        return RemoteUser(user_json)
-
-    def register_user_by_email(self, email):
-        """
-        Register user based on email.
-        Raises ValueError if the data service doesn't have any non-deprecated providers.
-        :param email: str: email address we are trying to register a user with
-        :return: RemoteUser: user that was created for email
-        """
-        util = DDSUserUtil(self.data_service)
-        user_json = util.register_dds_user_with_email(email)
         return RemoteUser(user_json)
 
     def get_auth_providers(self):

--- a/ddsc/core/tests/test_remotestore.py
+++ b/ddsc/core/tests/test_remotestore.py
@@ -579,57 +579,87 @@ class TestRemoteStore(TestCase):
 
     @patch('ddsc.core.remotestore.UserUtil', autospec=True)
     @patch('ddsc.core.remotestore.RemoteUser')
-    def test_get_or_register_user_by_username_finds_user(self, mock_remote_user, mock_user_util):
-        mock_user_util.return_value.find_dds_user_by_username.return_value = {"id": "123"}
+    def test_get_or_register_user_by_username__finds_user(self, mock_remote_user, mock_user_util):
+        mock_user_util.return_value.find_user_by_username.return_value = {"id": "123"}
 
         remote_store = RemoteStore(config=MagicMock())
         result = remote_store.get_or_register_user_by_username("user123")
         self.assertEqual(result, mock_remote_user.return_value)
         mock_remote_user.assert_called_with({"id": "123"})
         mock_util = mock_user_util.return_value
-        mock_util.find_dds_user_by_username.assert_called_with("user123")
-        mock_util.register_dds_user_by_username.assert_not_called()
+        mock_util.find_user_by_username.assert_called_with("user123")
+        mock_util.register_user_by_username.assert_not_called()
 
     @patch('ddsc.core.remotestore.UserUtil', autospec=True)
     @patch('ddsc.core.remotestore.RemoteUser')
-    def test_get_or_register_user_by_username_registers_user(self, mock_remote_user, mock_user_util):
-        mock_user_util.return_value.find_dds_user_by_username.return_value = None
-        mock_user_util.return_value.register_dds_user_by_username.return_value = {"id": "456"}
+    def test_get_or_register_user_by_username__registers_user(self, mock_remote_user, mock_user_util):
+        mock_user_util.return_value.find_user_by_username.return_value = None
+        mock_user_util.return_value.register_user_by_username.return_value = {"id": "456"}
 
         remote_store = RemoteStore(config=MagicMock())
         result = remote_store.get_or_register_user_by_username("user123")
         self.assertEqual(result, mock_remote_user.return_value)
         mock_remote_user.assert_called_with({"id": "456"})
         mock_util = mock_user_util.return_value
-        mock_util.find_dds_user_by_username.assert_called_with("user123")
-        mock_util.register_dds_user_by_username.assert_called_with("user123")
+        mock_util.find_user_by_username.assert_called_with("user123")
+        mock_util.register_user_by_username.assert_called_with("user123")
 
     @patch('ddsc.core.remotestore.UserUtil', autospec=True)
     @patch('ddsc.core.remotestore.RemoteUser')
-    def test_get_or_register_user_by_email_finds_user(self, mock_remote_user, mock_user_util):
-        mock_user_util.return_value.find_dds_user_by_email.return_value = {"id": "123"}
+    def test_get_or_register_user_by_email__finds_user_by_email(self, mock_remote_user, mock_user_util):
+        mock_user_util.return_value.find_user_by_email.return_value = {"id": "123"}
 
         remote_store = RemoteStore(config=MagicMock())
         result = remote_store.get_or_register_user_by_email("user@user.user")
         self.assertEqual(result, mock_remote_user.return_value)
         mock_remote_user.assert_called_with({"id": "123"})
         mock_util = mock_user_util.return_value
-        mock_util.find_dds_user_by_email.assert_called_with("user@user.user")
-        mock_util.register_dds_user_by_username.assert_not_called()
+        mock_util.find_user_by_email.assert_called_with("user@user.user")
+        mock_util.register_user_by_username.assert_not_called()
 
     @patch('ddsc.core.remotestore.UserUtil', autospec=True)
     @patch('ddsc.core.remotestore.RemoteUser')
-    def test_get_or_register_user_by_email_registers_user(self, mock_remote_user, mock_user_util):
-        mock_user_util.return_value.find_dds_user_by_email.return_value = None
-        mock_user_util.return_value.register_dds_user_with_email.return_value = {"id": "456"}
+    def test_get_or_register_user_by_email__unable_to_find_user(self, mock_remote_user, mock_user_util):
+        mock_user_util.return_value.find_user_by_email.return_value = None
+        mock_user_util.return_value.try_determine_username_from_email.return_value = None
 
         remote_store = RemoteStore(config=MagicMock())
-        result = remote_store.get_or_register_user_by_email("user@user.user")
-        self.assertEqual(result, mock_remote_user.return_value)
-        mock_remote_user.assert_called_with({"id": "456"})
+        with self.assertRaises(ValueError) as raised_exception:
+            remote_store.get_or_register_user_by_email("user@user.user")
+        self.assertEqual(str(raised_exception.exception), 'Unable to find or register a user with email user@user.user')
         mock_util = mock_user_util.return_value
-        mock_util.find_dds_user_by_email.assert_called_with("user@user.user")
-        mock_util.register_dds_user_with_email.assert_called_with("user@user.user")
+        mock_util.find_user_by_email.assert_called_with("user@user.user")
+        mock_util.try_determine_username_from_email.assert_called_with("user@user.user")
+
+    @patch('ddsc.core.remotestore.UserUtil', autospec=True)
+    @patch('ddsc.core.remotestore.RemoteUser')
+    def test_get_or_register_user_by_email__finds_user_by_username(self, mock_remote_user, mock_user_util):
+        mock_user_util.return_value.find_user_by_email.return_value = None
+        mock_user_util.return_value.try_determine_username_from_email.return_value = 'user'
+        mock_user_util.return_value.find_user_by_username.return_value = {"id": "123"}
+
+        remote_store = RemoteStore(config=MagicMock())
+        self.assertTrue(remote_store.get_or_register_user_by_email("user@user.user"))
+        mock_util = mock_user_util.return_value
+        mock_util.find_user_by_email.assert_called_with("user@user.user")
+        mock_util.try_determine_username_from_email.assert_called_with("user@user.user")
+        mock_util.find_user_by_username.assert_called_with("user")
+
+    @patch('ddsc.core.remotestore.UserUtil', autospec=True)
+    @patch('ddsc.core.remotestore.RemoteUser')
+    def test_get_or_register_user_by_email__registers_user_by_username(self, mock_remote_user, mock_user_util):
+        mock_user_util.return_value.find_user_by_email.return_value = None
+        mock_user_util.return_value.try_determine_username_from_email.return_value = 'user'
+        mock_user_util.return_value.find_user_by_username.return_value = None
+        mock_user_util.return_value.register_user_by_username.return_value = {"id": "123"}
+
+        remote_store = RemoteStore(config=MagicMock())
+        self.assertTrue(remote_store.get_or_register_user_by_email("user@user.user"))
+        mock_util = mock_user_util.return_value
+        mock_util.find_user_by_email.assert_called_with("user@user.user")
+        mock_util.try_determine_username_from_email.assert_called_with("user@user.user")
+        mock_util.find_user_by_username.assert_called_with("user")
+        mock_util.register_user_by_username.assert_called_with("user")
 
 
 class TestRemoteProjectChildren(TestCase):

--- a/ddsc/core/tests/test_remotestore.py
+++ b/ddsc/core/tests/test_remotestore.py
@@ -577,32 +577,59 @@ class TestRemoteStore(TestCase):
         remote_store.get_or_register_user_by_username.assert_not_called()
         remote_store.get_or_register_user_by_email.assert_called_with("fakemail@duke.edu")
 
-    @patch('ddsc.core.remotestore.DDSUserUtil')
+    @patch('ddsc.core.remotestore.UserUtil')
     @patch('ddsc.core.remotestore.RemoteUser')
-    def test_get_or_register_user_by_username_finds_user(self, mock_remote_user, mock_dds_user_util):
-        mock_dds_user_util.return_value.find_dds_user_by_username.return_value = {"id": "123"}
+    def test_get_or_register_user_by_username_finds_user(self, mock_remote_user, mock_user_util):
+        mock_user_util.return_value.find_dds_user_by_username.return_value = {"id": "123"}
 
         remote_store = RemoteStore(config=MagicMock())
         result = remote_store.get_or_register_user_by_username("user123")
         self.assertEqual(result, mock_remote_user.return_value)
         mock_remote_user.assert_called_with({"id": "123"})
-        mock_util = mock_dds_user_util.return_value
-        mock_util.register_dds_user_by_username.find_dds_user_by_username("user123")
+        mock_util = mock_user_util.return_value
+        mock_util.find_dds_user_by_username.assert_called_with("user123")
         mock_util.register_dds_user_by_username.assert_not_called()
 
-    @patch('ddsc.core.remotestore.DDSUserUtil')
+    @patch('ddsc.core.remotestore.UserUtil')
     @patch('ddsc.core.remotestore.RemoteUser')
-    def test_get_or_register_user_by_username_registers_user(self, mock_remote_user, mock_dds_user_util):
-        mock_dds_user_util.return_value.find_dds_user_by_username.return_value = None
-        mock_dds_user_util.return_value.register_dds_user_by_username.return_value = {"id": "456"}
+    def test_get_or_register_user_by_username_registers_user(self, mock_remote_user, mock_user_util):
+        mock_user_util.return_value.find_dds_user_by_username.return_value = None
+        mock_user_util.return_value.register_dds_user_by_username.return_value = {"id": "456"}
 
         remote_store = RemoteStore(config=MagicMock())
         result = remote_store.get_or_register_user_by_username("user123")
         self.assertEqual(result, mock_remote_user.return_value)
         mock_remote_user.assert_called_with({"id": "456"})
-        mock_util = mock_dds_user_util.return_value
-        mock_util.register_dds_user_by_username.find_dds_user_by_username("user123")
+        mock_util = mock_user_util.return_value
+        mock_util.find_dds_user_by_username.assert_called_with("user123")
         mock_util.register_dds_user_by_username.assert_called_with("user123")
+
+    @patch('ddsc.core.remotestore.UserUtil')
+    @patch('ddsc.core.remotestore.RemoteUser')
+    def test_get_or_register_user_by_email_finds_user(self, mock_remote_user, mock_user_util):
+        mock_user_util.return_value.find_dds_user_by_email.return_value = {"id": "123"}
+
+        remote_store = RemoteStore(config=MagicMock())
+        result = remote_store.get_or_register_user_by_email("user@user.user")
+        self.assertEqual(result, mock_remote_user.return_value)
+        mock_remote_user.assert_called_with({"id": "123"})
+        mock_util = mock_user_util.return_value
+        mock_util.find_dds_user_by_email.assert_called_with("user@user.user")
+        mock_util.register_dds_user_by_username.assert_not_called()
+
+    @patch('ddsc.core.remotestore.UserUtil')
+    @patch('ddsc.core.remotestore.RemoteUser')
+    def test_get_or_register_user_by_email_registers_user(self, mock_remote_user, mock_user_util):
+        mock_user_util.return_value.find_dds_user_by_email.return_value = None
+        mock_user_util.return_value.register_user_with_email.return_value = {"id": "456"}
+
+        remote_store = RemoteStore(config=MagicMock())
+        result = remote_store.get_or_register_user_by_email("user@user.user")
+        self.assertEqual(result, mock_remote_user.return_value)
+        mock_remote_user.assert_called_with({"id": "456"})
+        mock_util = mock_user_util.return_value
+        mock_util.find_dds_user_by_email.assert_called_with("user@user.user")
+        mock_util.register_user_with_email.assert_called_with("user@user.user")
 
 
 class TestRemoteProjectChildren(TestCase):

--- a/ddsc/core/tests/test_remotestore.py
+++ b/ddsc/core/tests/test_remotestore.py
@@ -577,7 +577,7 @@ class TestRemoteStore(TestCase):
         remote_store.get_or_register_user_by_username.assert_not_called()
         remote_store.get_or_register_user_by_email.assert_called_with("fakemail@duke.edu")
 
-    @patch('ddsc.core.remotestore.UserUtil')
+    @patch('ddsc.core.remotestore.UserUtil', autospec=True)
     @patch('ddsc.core.remotestore.RemoteUser')
     def test_get_or_register_user_by_username_finds_user(self, mock_remote_user, mock_user_util):
         mock_user_util.return_value.find_dds_user_by_username.return_value = {"id": "123"}
@@ -590,7 +590,7 @@ class TestRemoteStore(TestCase):
         mock_util.find_dds_user_by_username.assert_called_with("user123")
         mock_util.register_dds_user_by_username.assert_not_called()
 
-    @patch('ddsc.core.remotestore.UserUtil')
+    @patch('ddsc.core.remotestore.UserUtil', autospec=True)
     @patch('ddsc.core.remotestore.RemoteUser')
     def test_get_or_register_user_by_username_registers_user(self, mock_remote_user, mock_user_util):
         mock_user_util.return_value.find_dds_user_by_username.return_value = None
@@ -604,7 +604,7 @@ class TestRemoteStore(TestCase):
         mock_util.find_dds_user_by_username.assert_called_with("user123")
         mock_util.register_dds_user_by_username.assert_called_with("user123")
 
-    @patch('ddsc.core.remotestore.UserUtil')
+    @patch('ddsc.core.remotestore.UserUtil', autospec=True)
     @patch('ddsc.core.remotestore.RemoteUser')
     def test_get_or_register_user_by_email_finds_user(self, mock_remote_user, mock_user_util):
         mock_user_util.return_value.find_dds_user_by_email.return_value = {"id": "123"}
@@ -617,11 +617,11 @@ class TestRemoteStore(TestCase):
         mock_util.find_dds_user_by_email.assert_called_with("user@user.user")
         mock_util.register_dds_user_by_username.assert_not_called()
 
-    @patch('ddsc.core.remotestore.UserUtil')
+    @patch('ddsc.core.remotestore.UserUtil', autospec=True)
     @patch('ddsc.core.remotestore.RemoteUser')
     def test_get_or_register_user_by_email_registers_user(self, mock_remote_user, mock_user_util):
         mock_user_util.return_value.find_dds_user_by_email.return_value = None
-        mock_user_util.return_value.register_user_with_email.return_value = {"id": "456"}
+        mock_user_util.return_value.register_dds_user_with_email.return_value = {"id": "456"}
 
         remote_store = RemoteStore(config=MagicMock())
         result = remote_store.get_or_register_user_by_email("user@user.user")
@@ -629,7 +629,7 @@ class TestRemoteStore(TestCase):
         mock_remote_user.assert_called_with({"id": "456"})
         mock_util = mock_user_util.return_value
         mock_util.find_dds_user_by_email.assert_called_with("user@user.user")
-        mock_util.register_user_with_email.assert_called_with("user@user.user")
+        mock_util.register_dds_user_with_email.assert_called_with("user@user.user")
 
 
 class TestRemoteProjectChildren(TestCase):

--- a/ddsc/core/tests/test_remotestore.py
+++ b/ddsc/core/tests/test_remotestore.py
@@ -559,44 +559,6 @@ class TestRemoteStore(TestCase):
         self.assertEqual(users[0], mock_remote_user.return_value)
         mock_remote_user.assert_called_with(user_dict)
 
-    def test_lookup_user_by_username(self):
-        mock_user = Mock()
-        mock_user2 = Mock()
-        remote_store = RemoteStore(config=MagicMock())
-        remote_store.fetch_users = Mock()
-
-        remote_store.fetch_users.return_value = []
-        with self.assertRaises(NotFoundError) as raised_exception:
-            remote_store.lookup_user_by_username('joe')
-        self.assertEqual(str(raised_exception.exception), 'Username not found: joe.')
-
-        remote_store.fetch_users.return_value = [mock_user]
-        self.assertEqual(remote_store.lookup_user_by_username('joe'), mock_user)
-
-        remote_store.fetch_users.return_value = [mock_user, mock_user2]
-        with self.assertRaises(ValueError) as raised_exception:
-            remote_store.lookup_user_by_username('joe')
-        self.assertEqual(str(raised_exception.exception), 'Multiple users with same username found: joe.')
-
-    def test_lookup_user_by_email(self):
-        mock_user = Mock()
-        mock_user2 = Mock()
-        remote_store = RemoteStore(config=MagicMock())
-        remote_store.fetch_users = Mock()
-
-        remote_store.fetch_users.return_value = []
-        with self.assertRaises(NotFoundError) as raised_exception:
-            remote_store.lookup_user_by_email('joe@joe.com')
-        self.assertEqual(str(raised_exception.exception), 'Email not found: joe@joe.com.')
-
-        remote_store.fetch_users.return_value = [mock_user]
-        self.assertEqual(remote_store.lookup_user_by_email('joe@joe.com'), mock_user)
-
-        remote_store.fetch_users.return_value = [mock_user, mock_user2]
-        with self.assertRaises(ValueError) as raised_exception:
-            remote_store.lookup_user_by_email('joe@joe.com')
-        self.assertEqual(str(raised_exception.exception), 'Multiple users with same email found: joe@joe.com.')
-
 
 class TestRemoteProjectChildren(TestCase):
     def test_simple_case(self):
@@ -775,48 +737,6 @@ class TestRemoteAuthProvider(TestCase):
         providers = remote_store.get_auth_providers()
         self.assertEqual(len(providers), 1)
         self.assertEqual(providers[0].name, "Duke Authentication Service")
-
-    @patch("ddsc.core.remotestore.DataServiceApi")
-    def test_register_user_by_username(self, mock_data_service_api):
-        providers_response = MagicMock()
-        providers_response.json.return_value = {
-            "results": [self.provider_data1]
-        }
-        add_user_response = MagicMock()
-        add_user_response.json.return_value = {
-            "id": "123",
-            "username": "joe",
-            "full_name": "Joe Shoe",
-            "email": "",
-            "first_name": "Joe",
-            "last_name": "Shoe",
-        }
-        mock_data_service_api().get_auth_providers.return_value = providers_response
-        mock_data_service_api().auth_provider_add_user.return_value = add_user_response
-        remote_store = RemoteStore(MagicMock())
-        user = remote_store.register_user_by_username("joe")
-        self.assertEqual(user.id, "123")
-        self.assertEqual(user.username, "joe")
-        mock_data_service_api().auth_provider_add_user.assert_called_with(self.provider_data1['id'], 'joe')
-
-    @patch("ddsc.core.remotestore.DataServiceApi")
-    def test_register_user_by_username_with_no_default_provider(self, mock_data_service_api):
-        providers_response = MagicMock()
-        providers_response.json.return_value = {
-            "results": []
-        }
-        add_user_response = MagicMock()
-        add_user_response.json.return_value = {
-            "id": "123",
-            "username": "joe",
-            "full_name": "Joe Shoe",
-            "email": "",
-        }
-        mock_data_service_api().get_auth_providers.return_value = providers_response
-        mock_data_service_api().auth_provider_add_user.return_value = add_user_response
-        remote_store = RemoteStore(MagicMock())
-        with self.assertRaises(ValueError):
-            remote_store.register_user_by_username("joe")
 
 
 class TestProjectNameOrId(TestCase):

--- a/ddsc/core/tests/test_userutil.py
+++ b/ddsc/core/tests/test_userutil.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 from mock import Mock, patch
-from ddsc.core.userutil import UserUtil, LookupUserByEmail
+from ddsc.core.userutil import UserUtil, EmailUtil
 
 
 class UserUtilTestCase(TestCase):
@@ -13,77 +13,81 @@ class UserUtilTestCase(TestCase):
         self.assertEqual(self.user_util.auth_provider_id,
                          self.data_service.get_default_auth_provider_id.return_value)
 
-    @patch('ddsc.core.userutil.LookupUserByEmail')
-    def test_valid_dds_user_or_affiliate_exists_for_email__valid_dds_user_exists(self, mock_lookup):
-        mock_lookup.return_value.get_dds_user_with_valid_email.return_value = {"id": "123"}
-        mock_lookup.return_value.get_affiliate_user_with_valid_email.return_value = None
-        result = self.user_util.valid_dds_user_or_affiliate_exists_for_email("fakeuser@duke.edu")
-        self.assertEqual(result, True)
-        mock_lookup.assert_called_with(self.user_util, "fakeuser@duke.edu", self.logging_func)
-        self.logging_func.assert_not_called()
-
-    @patch('ddsc.core.userutil.LookupUserByEmail')
-    def test_valid_dds_user_or_affiliate_exists_for_email__valid_affiliate_exists(self, mock_lookup):
-        mock_lookup.return_value.get_dds_user_with_valid_email.return_value = None
-        mock_lookup.return_value.get_affiliate_user_with_valid_email.return_value = {"id": "123"}
-        result = self.user_util.valid_dds_user_or_affiliate_exists_for_email("fakeuser@duke.edu")
-        self.assertEqual(result, True)
-        mock_lookup.assert_called_with(self.user_util, "fakeuser@duke.edu", self.logging_func)
-        self.logging_func.assert_not_called()
-
-    @patch('ddsc.core.userutil.LookupUserByEmail')
-    def test_valid_dds_user_or_affiliate_exists_for_email__no_valid_user_exists(self, mock_lookup_user_by_email):
-        mock_lookup_user_by_email.return_value.get_dds_user_with_valid_email.return_value = None
-        mock_lookup_user_by_email.return_value.get_affiliate_user_with_valid_email.return_value = None
-        result = self.user_util.valid_dds_user_or_affiliate_exists_for_email("fakeuser@duke.edu")
-        self.assertEqual(result, False)
-        mock_lookup_user_by_email.assert_called_with(self.user_util, "fakeuser@duke.edu", self.logging_func)
-        self.logging_func.assert_called_with(
-            "No valid DukeDS/Affiliate user found for email address fakeuser@duke.edu.")
-
-    def test_find_dds_user_by_email(self):
+    def test_find_user_by_username(self):
         self.data_service.get_users.return_value.json.return_value = {"results": [{"id": "123"}]}
-        result = self.user_util.find_dds_user_by_email("fakeuser@duke.edu")
-        self.assertEqual(result, {"id": "123"})
-        self.data_service.get_users.assert_called_with(email="fakeuser@duke.edu")
-
-    def test_find_dds_user_by_username(self):
-        self.data_service.get_users.return_value.json.return_value = {"results": [{"id": "123"}]}
-        result = self.user_util.find_dds_user_by_username("fakeuser")
+        result = self.user_util.find_user_by_username("fakeuser")
         self.assertEqual(result, {"id": "123"})
         self.data_service.get_users.assert_called_with(username="fakeuser")
 
-    def test_find_affiliate_user_by_email(self):
+    def test_register_user_by_username(self):
+        self.data_service.auth_provider_add_user.return_value.json.return_value = {"id": "123"}
+        result = self.user_util.register_user_by_username("fakeuser")
+        self.assertEqual(result, {"id": "123"})
+        self.data_service.auth_provider_add_user.assert_called_with(self.user_util.auth_provider_id, "fakeuser")
+
+    def test_find_user_by_email(self):
+        self.data_service.get_users.return_value.json.return_value = {"results": [{"id": "123"}]}
+        result = self.user_util.find_user_by_email("fakeuser@duke.edu")
+        self.assertEqual(result, {"id": "123"})
+        self.data_service.get_users.assert_called_with(email="fakeuser@duke.edu")
+
+    def test_find_affiliate_by_email(self):
         self.data_service.get_auth_provider_affiliates.return_value.json.return_value = {"results": [{"id": "123"}]}
-        result = self.user_util.find_affiliate_user_by_email("fakeuser@duke.edu")
+        result = self.user_util.find_affiliate_by_email("fakeuser@duke.edu")
         self.assertEqual(result, {"id": "123"})
         self.data_service.get_auth_provider_affiliates.assert_called_with(self.user_util.auth_provider_id,
                                                                           email="fakeuser@duke.edu")
 
-    def test_register_dds_user_by_username(self):
-        self.data_service.auth_provider_add_user.return_value.json.return_value = {"id": "123"}
-        result = self.user_util.register_dds_user_by_username("fakeuser")
-        self.assertEqual(result, {"id": "123"})
-        self.data_service.auth_provider_add_user.assert_called_with(self.user_util.auth_provider_id, "fakeuser")
+    def test_user_or_affiliate_exists_for_email__dds_user_exists(self):
+        self.user_util.find_user_by_email = Mock()
+        self.user_util.find_user_by_email.return_value = {"id": "123"}
 
-    @patch('ddsc.core.userutil.LookupUserByEmail')
-    def test_register_dds_user_with_email__finds_affiliate(self, mock_lookup):
-        mock_lookup.return_value.get_affiliate_user_with_valid_email.return_value = {"uid": "fakeuser"}
-        self.data_service.auth_provider_add_user.return_value.json.return_value = {"id": "123"}
-        result = self.user_util.register_dds_user_with_email("fakeuser@duke.edu")
-        self.assertEqual(result, {"id": "123"})
-        mock_lookup.assert_called_with(self.user_util, "fakeuser@duke.edu", self.logging_func)
-        self.data_service.auth_provider_add_user.assert_called_with(self.user_util.auth_provider_id, "fakeuser")
+        self.assertTrue(self.user_util.user_or_affiliate_exists_for_email("fakeuser@duke.edu"))
+        self.user_util.find_user_by_email.assert_called_with("fakeuser@duke.edu")
+        self.logging_func.assert_called_with(
+            "Found DukeDS user for email address fakeuser@duke.edu.")
 
-    @patch('ddsc.core.userutil.LookupUserByEmail')
-    def test_register_dds_user_with_email__no_affiliate_found(self, mock_lookup):
-        mock_lookup.return_value.get_affiliate_user_with_valid_email.return_value = None
-        self.data_service.auth_provider_add_user.return_value.json.return_value = {"id": "123"}
-        with self.assertRaises(ValueError) as raised_exception:
-            self.user_util.register_dds_user_with_email("fakeuser@duke.edu")
-        self.assertEqual(str(raised_exception.exception), 'Unable to register user with email address fakeuser@duke.edu')
-        mock_lookup.assert_called_with(self.user_util, "fakeuser@duke.edu", self.logging_func)
-        self.data_service.auth_provider_add_user.assert_not_called()
+    def test_user_or_affiliate_exists_for_email__valid_affiliate_exists(self):
+        self.user_util.find_user_by_email = Mock()
+        self.user_util.find_user_by_email.return_value = None
+        self.user_util.find_affiliate_by_email = Mock()
+        self.user_util.find_affiliate_by_email.return_value = {"id": "123"}
+
+        self.assertTrue(self.user_util.user_or_affiliate_exists_for_email("fakeuser@duke.edu"))
+        self.user_util.find_user_by_email.assert_called_with("fakeuser@duke.edu")
+        self.user_util.find_affiliate_by_email.assert_called_with("fakeuser@duke.edu")
+        self.logging_func.assert_called_with(
+            "Found affiliate for email address fakeuser@duke.edu.")
+
+    def test_user_or_affiliate_exists_for_emaill__fallback_username_exists(self):
+        self.user_util.find_user_by_email = Mock()
+        self.user_util.find_user_by_email.return_value = None
+        self.user_util.find_affiliate_by_email = Mock()
+        self.user_util.find_affiliate_by_email.return_value = None
+        self.user_util.find_affiliate_by_username = Mock()
+        self.user_util.find_affiliate_by_username.return_value = {"id": "123"}
+
+        self.assertTrue(self.user_util.user_or_affiliate_exists_for_email("fakeuser@duke.edu"))
+        self.user_util.find_user_by_email.assert_called_with("fakeuser@duke.edu")
+        self.user_util.find_affiliate_by_email.assert_called_with("fakeuser@duke.edu")
+        self.user_util.find_affiliate_by_username.assert_called_with("fakeuser")
+        self.logging_func.assert_called_with(
+            "Found DukeDS user for username fakeuser.")
+
+    def test_valid_dds_user_or_affiliate_exists_for_email__no_user_found(self):
+        self.user_util.find_user_by_email = Mock()
+        self.user_util.find_user_by_email.return_value = None
+        self.user_util.find_affiliate_by_email = Mock()
+        self.user_util.find_affiliate_by_email.return_value = None
+        self.user_util.find_affiliate_by_username = Mock()
+        self.user_util.find_affiliate_by_username.return_value = None
+
+        self.assertFalse(self.user_util.user_or_affiliate_exists_for_email("fakeuser@duke.edu"))
+        self.user_util.find_user_by_email.assert_called_with("fakeuser@duke.edu")
+        self.user_util.find_affiliate_by_email.assert_called_with("fakeuser@duke.edu")
+        self.user_util.find_affiliate_by_username.assert_called_with("fakeuser")
+        self.logging_func.assert_called_with(
+            "No valid DukeDS user or affiliate found for email address fakeuser@duke.edu.")
 
     def test__get_single_user_or_none(self):
         response = Mock()
@@ -105,82 +109,16 @@ class UserUtilTestCase(TestCase):
         self.assertEqual(str(raised_exception.exception), 'Found multiple users for fakeuser@duke.edu.')
 
 
-class LookupUserByEmailTestCase(TestCase):
-    def setUp(self):
-        self.dds_user_util = Mock()
-        self.logging_func = Mock()
-        self.lookup = LookupUserByEmail(self.dds_user_util, "fakeuser@duke.edu", self.logging_func)
-
-    def test_constructor(self):
-        self.assertEqual(self.lookup.possible_username, self.lookup._extract_username_or_none("fakeuser@duke.edu"))
-
-    def test_get_dds_user_with_valid_email__dds_user_has_email(self):
-        self.dds_user_util.find_dds_user_by_email.return_value = {"email": "fakeuser@duke.edu"}
-        dds_user = self.lookup.get_dds_user_with_valid_email()
-        self.assertEqual(dds_user, {"email": "fakeuser@duke.edu"})
-        self.logging_func.assert_called_with('Found valid DukeDS user for email address fakeuser@duke.edu.')
-        self.dds_user_util.find_dds_user_by_email.assert_called_with("fakeuser@duke.edu")
-        self.dds_user_util.find_dds_user_by_username.assert_not_called()
-
-    def test_get_dds_user_with_valid_email__affiliate_has_email(self):
-        self.dds_user_util.find_dds_user_by_email.return_value = None
-        self.dds_user_util.find_dds_user_by_username.return_value = {"email": "fakeuser@duke.edu"}
-        dds_user = self.lookup.get_dds_user_with_valid_email()
-        self.assertEqual(dds_user, {"email": "fakeuser@duke.edu"})
-        self.logging_func.assert_called_with('Found valid DukeDS user for username fakeuser.')
-        self.dds_user_util.find_dds_user_by_email.assert_called_with("fakeuser@duke.edu")
-        self.dds_user_util.find_dds_user_by_username.assert_called_with("fakeuser")
-
-    def test_get_dds_user_with_valid_email__not_found(self):
-        self.dds_user_util.find_dds_user_by_email.return_value = None
-        self.dds_user_util.find_dds_user_by_username.return_value = None
-        dds_user = self.lookup.get_dds_user_with_valid_email()
-        self.assertEqual(dds_user, None)
-        self.logging_func.assert_not_called()
-        self.dds_user_util.find_dds_user_by_email.assert_called_with("fakeuser@duke.edu")
-        self.dds_user_util.find_dds_user_by_username.assert_called_with("fakeuser")
-
-    def test_get_affiliate_user_with_valid_email__affiliate_has_email(self):
-        self.dds_user_util.find_affiliate_user_by_email.return_value = {"email": "fakeuser@duke.edu"}
-        affiliate_user = self.lookup.get_affiliate_user_with_valid_email()
-        self.assertEqual(affiliate_user, {"email": "fakeuser@duke.edu"})
-        self.logging_func.assert_called_with('Found valid affiliate user for email address fakeuser@duke.edu.')
-        self.dds_user_util.find_affiliate_user_by_email.assert_called_with("fakeuser@duke.edu")
-        self.dds_user_util.find_affiliate_user_by_username.assert_not_called()
-
-    def test_get_affiliate_user_with_valid_email__affiliate_username_has_email(self):
-        self.dds_user_util.find_affiliate_user_by_email.return_value = None
-        self.dds_user_util.find_affiliate_user_by_username.return_value = {"email": "fakeuser@duke.edu"}
-        affiliate_user = self.lookup.get_affiliate_user_with_valid_email()
-        self.assertEqual(affiliate_user, {"email": "fakeuser@duke.edu"})
-        self.logging_func.assert_called_with('Found valid affiliate user for username fakeuser.')
-        self.dds_user_util.find_affiliate_user_by_email.assert_called_with("fakeuser@duke.edu")
-        self.dds_user_util.find_affiliate_user_by_username.assert_called_with("fakeuser")
-
-    def test_get_affiliate_user_with_valid_email__not_found(self):
-        self.dds_user_util.find_affiliate_user_by_email.return_value = None
-        self.dds_user_util.find_affiliate_user_by_username.return_value = None
-        affiliate_user = self.lookup.get_affiliate_user_with_valid_email()
-        self.assertEqual(affiliate_user, None)
-        self.logging_func.assert_not_called()
-        self.dds_user_util.find_affiliate_user_by_email.assert_called_with("fakeuser@duke.edu")
-        self.dds_user_util.find_affiliate_user_by_username.assert_called_with("fakeuser")
-
-    def test__item_has_email(self):
-        self.assertFalse(self.lookup._item_has_email(None))
-        self.assertFalse(self.lookup._item_has_email({'email': None}))
-        self.assertFalse(self.lookup._item_has_email({'email': ''}))
-        self.assertTrue(self.lookup._item_has_email({'email': 'fakeuser@duke.edu'}))
-
+class EmailUtilTestCase(TestCase):
     def test__extract_username_or_none(self):
-        self.assertEqual(self.lookup._extract_username_or_none('fakeuser123@duke.edu'), 'fakeuser123')
-        self.assertEqual(self.lookup._extract_username_or_none('Fake.User@duke.edu'), None)
-        self.assertEqual(self.lookup._extract_username_or_none('Fakeuser123@duke.edu'), None)
-        self.assertEqual(self.lookup._extract_username_or_none('fakeuser123@fake.com'), None)
+        self.assertEqual(EmailUtil.try_get_username_from_email('fakeuser123@duke.edu'), 'fakeuser123')
+        self.assertEqual(EmailUtil.try_get_username_from_email('Fake.User@duke.edu'), None)
+        self.assertEqual(EmailUtil.try_get_username_from_email('Fakeuser123@duke.edu'), None)
+        self.assertEqual(EmailUtil.try_get_username_from_email('fakeuser123@fake.com'), None)
 
     def test_is_duke_email(self):
-        self.assertEqual(LookupUserByEmail.is_duke_email('fakeuser@fake.com'), False)
-        self.assertEqual(LookupUserByEmail.is_duke_email('fakeuser@duke.edu'), True)
+        self.assertEqual(EmailUtil.is_duke_email('fakeuser@fake.com'), False)
+        self.assertEqual(EmailUtil.is_duke_email('fakeuser@duke.edu'), True)
 
     def test_strip_email_suffix(self):
-        self.assertEqual(LookupUserByEmail.strip_email_suffix('fakeuser@fake.com'), 'fakeuser')
+        self.assertEqual(EmailUtil.strip_email_suffix('fakeuser@fake.com'), 'fakeuser')

--- a/ddsc/core/tests/test_userutil.py
+++ b/ddsc/core/tests/test_userutil.py
@@ -1,0 +1,186 @@
+from unittest import TestCase
+from mock import Mock, patch, call
+from ddsc.core.userutil import UserUtil, LookupUserByEmail
+
+
+class UserUtilTestCase(TestCase):
+    def setUp(self):
+        self.data_service = Mock()
+        self.logging_func = Mock()
+        self.user_util = UserUtil(self.data_service, self.logging_func)
+
+    def test_constructor(self):
+        self.assertEqual(self.user_util.auth_provider_id,
+                         self.data_service.get_default_auth_provider_id.return_value)
+
+    @patch('ddsc.core.userutil.LookupUserByEmail')
+    def test_valid_dds_user_or_affiliate_exists_for_email__valid_user_exists(self, mock_lookup):
+        mock_lookup.return_value.get_dds_user_with_valid_email.return_value = {"id": "123"}
+        mock_lookup.return_value.get_affiliate_user_with_valid_email.return_value = None
+        result = self.user_util.valid_dds_user_or_affiliate_exists_for_email("fakeuser@duke.edu")
+        self.assertEqual(result, True)
+        mock_lookup.assert_called_with(self.user_util, "fakeuser@duke.edu", self.logging_func)
+        self.logging_func.assert_not_called()
+
+    @patch('ddsc.core.userutil.LookupUserByEmail')
+    def test_valid_dds_user_or_affiliate_exists_for_email__valid_user_exists(self, mock_lookup):
+        mock_lookup.return_value.get_dds_user_with_valid_email.return_value = None
+        mock_lookup.return_value.get_affiliate_user_with_valid_email.return_value = {"id": "123"}
+        result = self.user_util.valid_dds_user_or_affiliate_exists_for_email("fakeuser@duke.edu")
+        self.assertEqual(result, True)
+        mock_lookup.assert_called_with(self.user_util, "fakeuser@duke.edu", self.logging_func)
+        self.logging_func.assert_not_called()
+
+    @patch('ddsc.core.userutil.LookupUserByEmail')
+    def test_valid_dds_user_or_affiliate_exists_for_email__valid_user_exists(self, mock_lookup_user_by_email):
+        mock_lookup_user_by_email.return_value.get_dds_user_with_valid_email.return_value = None
+        mock_lookup_user_by_email.return_value.get_affiliate_user_with_valid_email.return_value = None
+        result = self.user_util.valid_dds_user_or_affiliate_exists_for_email("fakeuser@duke.edu")
+        self.assertEqual(result, False)
+        mock_lookup_user_by_email.assert_called_with(self.user_util, "fakeuser@duke.edu", self.logging_func)
+        self.logging_func.assert_called_with(
+            "No valid DukeDS/Affiliate user found for email address fakeuser@duke.edu.")
+
+    def test_find_dds_user_by_email(self):
+        self.data_service.get_users.return_value.json.return_value = {"results": [{"id": "123"}]}
+        result = self.user_util.find_dds_user_by_email("fakeuser@duke.edu")
+        self.assertEqual(result, {"id": "123"})
+        self.data_service.get_users.assert_called_with(email="fakeuser@duke.edu")
+
+    def test_find_dds_user_by_username(self):
+        self.data_service.get_users.return_value.json.return_value = {"results": [{"id": "123"}]}
+        result = self.user_util.find_dds_user_by_username("fakeuser")
+        self.assertEqual(result, {"id": "123"})
+        self.data_service.get_users.assert_called_with(username="fakeuser")
+
+    def test_find_affiliate_user_by_email(self):
+        self.data_service.get_auth_provider_affiliates.return_value.json.return_value = {"results": [{"id": "123"}]}
+        result = self.user_util.find_affiliate_user_by_email("fakeuser@duke.edu")
+        self.assertEqual(result, {"id": "123"})
+        self.data_service.get_auth_provider_affiliates.assert_called_with(self.user_util.auth_provider_id,
+                                                                          email="fakeuser@duke.edu")
+
+    def test_register_dds_user_by_username(self):
+        self.data_service.auth_provider_add_user.return_value.json.return_value = {"id": "123"}
+        result = self.user_util.register_dds_user_by_username("fakeuser")
+        self.assertEqual(result, {"id": "123"})
+        self.data_service.auth_provider_add_user.assert_called_with(self.user_util.auth_provider_id, "fakeuser")
+
+    @patch('ddsc.core.userutil.LookupUserByEmail')
+    def test_register_dds_user_with_email__finds_affiliate(self, mock_lookup):
+        mock_lookup.return_value.get_affiliate_user_with_valid_email.return_value = {"uid": "fakeuser"}
+        self.data_service.auth_provider_add_user.return_value.json.return_value = {"id": "123"}
+        result = self.user_util.register_dds_user_with_email("fakeuser@duke.edu")
+        self.assertEqual(result, {"id": "123"})
+        mock_lookup.assert_called_with(self.user_util, "fakeuser@duke.edu", self.logging_func)
+        self.data_service.auth_provider_add_user.assert_called_with(self.user_util.auth_provider_id, "fakeuser")
+
+    @patch('ddsc.core.userutil.LookupUserByEmail')
+    def test_register_dds_user_with_email__no_affiliate_found(self, mock_lookup):
+        mock_lookup.return_value.get_affiliate_user_with_valid_email.return_value = None
+        self.data_service.auth_provider_add_user.return_value.json.return_value = {"id": "123"}
+        with self.assertRaises(ValueError) as raised_exception:
+            result = self.user_util.register_dds_user_with_email("fakeuser@duke.edu")
+        self.assertEqual(str(raised_exception.exception), 'Unable to register user with email address fakeuser@duke.edu')
+        mock_lookup.assert_called_with(self.user_util, "fakeuser@duke.edu", self.logging_func)
+        self.data_service.auth_provider_add_user.assert_not_called()
+
+    def test__get_single_user_or_none(self):
+        response = Mock()
+
+        # When no items found should return None
+        response.json.return_value = {"results": []}
+        result = self.user_util._get_single_user_or_none(response, lookup_value="fakeuser@duke.edu")
+        self.assertEqual(result, None)
+
+        # When one item found should return first (only) item
+        response.json.return_value = {"results": [{"id": "123"}]}
+        result = self.user_util._get_single_user_or_none(response, lookup_value="fakeuser@duke.edu")
+        self.assertEqual(result, {"id": "123"})
+
+        # When multiple found raise exception
+        response.json.return_value = {"results": [{"id": "123"}, {"id": "456"}]}
+        with self.assertRaises(ValueError) as raised_exception:
+            self.user_util._get_single_user_or_none(response, lookup_value="fakeuser@duke.edu")
+        self.assertEqual(str(raised_exception.exception), 'Found multiple users for fakeuser@duke.edu.')
+
+
+class LookupUserByEmailTestCase(TestCase):
+    def setUp(self):
+        self.dds_user_util = Mock()
+        self.logging_func = Mock()
+        self.lookup = LookupUserByEmail(self.dds_user_util, "fakeuser@duke.edu", self.logging_func)
+
+    def test_constructor(self):
+        self.assertEqual(self.lookup.possible_username, self.lookup._extract_username_or_none("fakeuser@duke.edu"))
+
+    def test_get_dds_user_with_valid_email__dds_user_has_email(self):
+        self.dds_user_util.find_dds_user_by_email.return_value = {"email": "fakeuser@duke.edu"}
+        dds_user = self.lookup.get_dds_user_with_valid_email()
+        self.assertEqual(dds_user, {"email": "fakeuser@duke.edu"})
+        self.logging_func.assert_called_with('Found valid DukeDS user for email address fakeuser@duke.edu.')
+        self.dds_user_util.find_dds_user_by_email.assert_called_with("fakeuser@duke.edu")
+        self.dds_user_util.find_dds_user_by_username.assert_not_called()
+
+    def test_get_dds_user_with_valid_email__affiliate_has_email(self):
+        self.dds_user_util.find_dds_user_by_email.return_value = None
+        self.dds_user_util.find_dds_user_by_username.return_value = {"email": "fakeuser@duke.edu"}
+        dds_user = self.lookup.get_dds_user_with_valid_email()
+        self.assertEqual(dds_user, {"email": "fakeuser@duke.edu"})
+        self.logging_func.assert_called_with('Found valid DukeDS user for username fakeuser.')
+        self.dds_user_util.find_dds_user_by_email.assert_called_with("fakeuser@duke.edu")
+        self.dds_user_util.find_dds_user_by_username.assert_called_with("fakeuser")
+
+    def test_get_dds_user_with_valid_email__not_found(self):
+        self.dds_user_util.find_dds_user_by_email.return_value = None
+        self.dds_user_util.find_dds_user_by_username.return_value = None
+        dds_user = self.lookup.get_dds_user_with_valid_email()
+        self.assertEqual(dds_user, None)
+        self.logging_func.assert_not_called()
+        self.dds_user_util.find_dds_user_by_email.assert_called_with("fakeuser@duke.edu")
+        self.dds_user_util.find_dds_user_by_username.assert_called_with("fakeuser")
+
+    def test_get_affiliate_user_with_valid_email__affiliate_has_email(self):
+        self.dds_user_util.find_affiliate_user_by_email.return_value = {"email": "fakeuser@duke.edu"}
+        affiliate_user = self.lookup.get_affiliate_user_with_valid_email()
+        self.assertEqual(affiliate_user, {"email": "fakeuser@duke.edu"})
+        self.logging_func.assert_called_with('Found valid affiliate user for email address fakeuser@duke.edu.')
+        self.dds_user_util.find_affiliate_user_by_email.assert_called_with("fakeuser@duke.edu")
+        self.dds_user_util.find_affiliate_user_by_username.assert_not_called()
+
+    def test_get_affiliate_user_with_valid_email__affiliate_username_has_email(self):
+        self.dds_user_util.find_affiliate_user_by_email.return_value = None
+        self.dds_user_util.find_affiliate_user_by_username.return_value = {"email": "fakeuser@duke.edu"}
+        affiliate_user = self.lookup.get_affiliate_user_with_valid_email()
+        self.assertEqual(affiliate_user, {"email": "fakeuser@duke.edu"})
+        self.logging_func.assert_called_with('Found valid affiliate user for username fakeuser.')
+        self.dds_user_util.find_affiliate_user_by_email.assert_called_with("fakeuser@duke.edu")
+        self.dds_user_util.find_affiliate_user_by_username.assert_called_with("fakeuser")
+
+    def test_get_affiliate_user_with_valid_email__not_found(self):
+        self.dds_user_util.find_affiliate_user_by_email.return_value = None
+        self.dds_user_util.find_affiliate_user_by_username.return_value = None
+        affiliate_user = self.lookup.get_affiliate_user_with_valid_email()
+        self.assertEqual(affiliate_user, None)
+        self.logging_func.assert_not_called()
+        self.dds_user_util.find_affiliate_user_by_email.assert_called_with("fakeuser@duke.edu")
+        self.dds_user_util.find_affiliate_user_by_username.assert_called_with("fakeuser")
+
+    def test__item_has_email(self):
+        self.assertFalse(self.lookup._item_has_email(None))
+        self.assertFalse(self.lookup._item_has_email({'email': None}))
+        self.assertFalse(self.lookup._item_has_email({'email': ''}))
+        self.assertTrue(self.lookup._item_has_email({'email': 'fakeuser@duke.edu'}))
+
+    def test__extract_username_or_none(self):
+        self.assertEqual(self.lookup._extract_username_or_none('fakeuser123@duke.edu'), 'fakeuser123')
+        self.assertEqual(self.lookup._extract_username_or_none('Fake.User@duke.edu'), None)
+        self.assertEqual(self.lookup._extract_username_or_none('Fakeuser123@duke.edu'), None)
+        self.assertEqual(self.lookup._extract_username_or_none('fakeuser123@fake.com'), None)
+
+    def test_is_duke_email(self):
+        self.assertEqual(LookupUserByEmail.is_duke_email('fakeuser@fake.com'), False)
+        self.assertEqual(LookupUserByEmail.is_duke_email('fakeuser@duke.edu'), True)
+
+    def test_strip_email_suffix(self):
+        self.assertEqual(LookupUserByEmail.strip_email_suffix('fakeuser@fake.com'), 'fakeuser')

--- a/ddsc/core/tests/test_userutil.py
+++ b/ddsc/core/tests/test_userutil.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 from mock import Mock
-from ddsc.core.userutil import UserUtil, EmailUtil
+from ddsc.core.userutil import UserUtil
 
 
 class UserUtilTestCase(TestCase):
@@ -51,7 +51,7 @@ class UserUtilTestCase(TestCase):
         self.user_util.find_user_by_email = Mock()
         self.user_util.find_user_by_email.return_value = None
         self.user_util.find_affiliate_by_email = Mock()
-        self.user_util.find_affiliate_by_email.return_value = {"id": "123"}
+        self.user_util.find_affiliate_by_email.return_value = {"uid": "123"}
 
         self.assertTrue(self.user_util.user_or_affiliate_exists_for_email("fakeuser@duke.edu"))
         self.user_util.find_user_by_email.assert_called_with("fakeuser@duke.edu")
@@ -59,33 +59,15 @@ class UserUtilTestCase(TestCase):
         self.logging_func.assert_called_with(
             "Found affiliate for email address fakeuser@duke.edu.")
 
-    def test_user_or_affiliate_exists_for_emaill__fallback_username_exists(self):
-        self.user_util.find_user_by_email = Mock()
-        self.user_util.find_user_by_email.return_value = None
-        self.user_util.find_affiliate_by_email = Mock()
-        self.user_util.find_affiliate_by_email.return_value = None
-        self.user_util.find_affiliate_by_username = Mock()
-        self.user_util.find_affiliate_by_username.return_value = {"id": "123"}
-
-        self.assertTrue(self.user_util.user_or_affiliate_exists_for_email("fakeuser@duke.edu"))
-        self.user_util.find_user_by_email.assert_called_with("fakeuser@duke.edu")
-        self.user_util.find_affiliate_by_email.assert_called_with("fakeuser@duke.edu")
-        self.user_util.find_affiliate_by_username.assert_called_with("fakeuser")
-        self.logging_func.assert_called_with(
-            "Found DukeDS user for username fakeuser.")
-
     def test_valid_dds_user_or_affiliate_exists_for_email__no_user_found(self):
         self.user_util.find_user_by_email = Mock()
         self.user_util.find_user_by_email.return_value = None
         self.user_util.find_affiliate_by_email = Mock()
         self.user_util.find_affiliate_by_email.return_value = None
-        self.user_util.find_affiliate_by_username = Mock()
-        self.user_util.find_affiliate_by_username.return_value = None
 
         self.assertFalse(self.user_util.user_or_affiliate_exists_for_email("fakeuser@duke.edu"))
         self.user_util.find_user_by_email.assert_called_with("fakeuser@duke.edu")
         self.user_util.find_affiliate_by_email.assert_called_with("fakeuser@duke.edu")
-        self.user_util.find_affiliate_by_username.assert_called_with("fakeuser")
         self.logging_func.assert_called_with(
             "No valid DukeDS user or affiliate found for email address fakeuser@duke.edu.")
 
@@ -107,18 +89,3 @@ class UserUtilTestCase(TestCase):
         with self.assertRaises(ValueError) as raised_exception:
             self.user_util._get_single_user_or_none(response, lookup_value="fakeuser@duke.edu")
         self.assertEqual(str(raised_exception.exception), 'Found multiple users for fakeuser@duke.edu.')
-
-
-class EmailUtilTestCase(TestCase):
-    def test__extract_username_or_none(self):
-        self.assertEqual(EmailUtil.try_get_username_from_email('fakeuser123@duke.edu'), 'fakeuser123')
-        self.assertEqual(EmailUtil.try_get_username_from_email('Fake.User@duke.edu'), None)
-        self.assertEqual(EmailUtil.try_get_username_from_email('Fakeuser123@duke.edu'), None)
-        self.assertEqual(EmailUtil.try_get_username_from_email('fakeuser123@fake.com'), None)
-
-    def test_is_duke_email(self):
-        self.assertEqual(EmailUtil.is_duke_email('fakeuser@fake.com'), False)
-        self.assertEqual(EmailUtil.is_duke_email('fakeuser@duke.edu'), True)
-
-    def test_strip_email_suffix(self):
-        self.assertEqual(EmailUtil.strip_email_suffix('fakeuser@fake.com'), 'fakeuser')

--- a/ddsc/core/tests/test_userutil.py
+++ b/ddsc/core/tests/test_userutil.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from mock import Mock, patch, call
+from mock import Mock, patch
 from ddsc.core.userutil import UserUtil, LookupUserByEmail
 
 
@@ -14,7 +14,7 @@ class UserUtilTestCase(TestCase):
                          self.data_service.get_default_auth_provider_id.return_value)
 
     @patch('ddsc.core.userutil.LookupUserByEmail')
-    def test_valid_dds_user_or_affiliate_exists_for_email__valid_user_exists(self, mock_lookup):
+    def test_valid_dds_user_or_affiliate_exists_for_email__valid_dds_user_exists(self, mock_lookup):
         mock_lookup.return_value.get_dds_user_with_valid_email.return_value = {"id": "123"}
         mock_lookup.return_value.get_affiliate_user_with_valid_email.return_value = None
         result = self.user_util.valid_dds_user_or_affiliate_exists_for_email("fakeuser@duke.edu")
@@ -23,7 +23,7 @@ class UserUtilTestCase(TestCase):
         self.logging_func.assert_not_called()
 
     @patch('ddsc.core.userutil.LookupUserByEmail')
-    def test_valid_dds_user_or_affiliate_exists_for_email__valid_user_exists(self, mock_lookup):
+    def test_valid_dds_user_or_affiliate_exists_for_email__valid_affiliate_exists(self, mock_lookup):
         mock_lookup.return_value.get_dds_user_with_valid_email.return_value = None
         mock_lookup.return_value.get_affiliate_user_with_valid_email.return_value = {"id": "123"}
         result = self.user_util.valid_dds_user_or_affiliate_exists_for_email("fakeuser@duke.edu")
@@ -32,7 +32,7 @@ class UserUtilTestCase(TestCase):
         self.logging_func.assert_not_called()
 
     @patch('ddsc.core.userutil.LookupUserByEmail')
-    def test_valid_dds_user_or_affiliate_exists_for_email__valid_user_exists(self, mock_lookup_user_by_email):
+    def test_valid_dds_user_or_affiliate_exists_for_email__no_valid_user_exists(self, mock_lookup_user_by_email):
         mock_lookup_user_by_email.return_value.get_dds_user_with_valid_email.return_value = None
         mock_lookup_user_by_email.return_value.get_affiliate_user_with_valid_email.return_value = None
         result = self.user_util.valid_dds_user_or_affiliate_exists_for_email("fakeuser@duke.edu")
@@ -80,7 +80,7 @@ class UserUtilTestCase(TestCase):
         mock_lookup.return_value.get_affiliate_user_with_valid_email.return_value = None
         self.data_service.auth_provider_add_user.return_value.json.return_value = {"id": "123"}
         with self.assertRaises(ValueError) as raised_exception:
-            result = self.user_util.register_dds_user_with_email("fakeuser@duke.edu")
+            self.user_util.register_dds_user_with_email("fakeuser@duke.edu")
         self.assertEqual(str(raised_exception.exception), 'Unable to register user with email address fakeuser@duke.edu')
         mock_lookup.assert_called_with(self.user_util, "fakeuser@duke.edu", self.logging_func)
         self.data_service.auth_provider_add_user.assert_not_called()

--- a/ddsc/core/tests/test_userutil.py
+++ b/ddsc/core/tests/test_userutil.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from mock import Mock, patch
+from mock import Mock
 from ddsc.core.userutil import UserUtil, EmailUtil
 
 

--- a/ddsc/core/userutil.py
+++ b/ddsc/core/userutil.py
@@ -12,7 +12,8 @@ class UserUtil(object):
 
     def valid_dds_user_or_affiliate_exists_for_email(self, email_address):
         lookup = LookupUserByEmail(self, email_address, self.logging_func)
-        if lookup.valid_dds_user_exists() or lookup.valid_affiliate_user_exists():
+        if lookup.get_dds_user_with_valid_email() or \
+                lookup.get_affiliate_user_with_valid_email():
             return True
         else:
             self.logging_func("No valid DukeDS/Affiliate user found for email address {}.".format(email_address))
@@ -38,13 +39,13 @@ class UserUtil(object):
         response = self.data_service.auth_provider_add_user(self.auth_provider_id, username)
         return response.json()
 
-    def register_user_with_email(self, email_address):
+    def register_dds_user_with_email(self, email_address):
         lookup = LookupUserByEmail(self, email_address, self.logging_func)
         affiliate_user = lookup.get_affiliate_user_with_valid_email()
         if affiliate_user:
-            return self.register_user_with_username(affiliate_user["uid"])
+            return self.register_dds_user_by_username(affiliate_user["uid"])
         else:
-            raise ValueError("Unable to register user with email address {}".format(self.email_address))
+            raise ValueError("Unable to register user with email address {}".format(email_address))
 
     @staticmethod
     def _get_single_user_or_none(response, lookup_value):
@@ -63,11 +64,6 @@ class LookupUserByEmail(object):
         self.logging_func = logging_func
         self.possible_username = self._extract_username_or_none(email_address)
 
-    def valid_dds_user_exists(self):
-        if self.get_dds_user_with_valid_email():
-            return True
-        return False
-
     def get_dds_user_with_valid_email(self):
         dds_user = self.dds_user_util.find_dds_user_by_email(self.email_address)
         if self._item_has_email(dds_user):
@@ -79,11 +75,6 @@ class LookupUserByEmail(object):
                 self.logging_func("Found valid DukeDS user for username {}.".format(self.possible_username))
                 return dds_user
         return None
-
-    def valid_affiliate_user_exists(self):
-        if self.get_affiliate_user_with_valid_email():
-            return True
-        return False
 
     def get_affiliate_user_with_valid_email(self):
         affiliate_user = self.dds_user_util.find_affiliate_user_by_email(self.email_address)
@@ -109,14 +100,15 @@ class LookupUserByEmail(object):
         :param email_address: str
         :return: bool: str or None
         """
-        if self.is_duke_email():
+        if self.is_duke_email(email_address):
             local_part = self.strip_email_suffix(email_address)
             if local_part.islower() and local_part.isalnum():
                 return local_part
         return None
 
-    def is_duke_email(self):
-        return self.email_address.endswith(DUKE_EMAIL_SUFFIX)
+    @staticmethod
+    def is_duke_email(email_address):
+        return email_address.endswith(DUKE_EMAIL_SUFFIX)
 
     @staticmethod
     def strip_email_suffix(email_address):

--- a/ddsc/core/userutil.py
+++ b/ddsc/core/userutil.py
@@ -25,6 +25,10 @@ class UserUtil(object):
         response = self.data_service.get_auth_provider_affiliates(self.auth_provider_id, email=email_address)
         return self._get_single_user_or_none(response, email_address)
 
+    def find_affiliate_by_username(self, username):
+        response = self.data_service.get_auth_provider_affiliates(self.auth_provider_id, username=username)
+        return self._get_single_user_or_none(response, username)
+
     def user_or_affiliate_exists_for_email(self, email_address):
         if self.find_user_by_email(email_address):
             self.logging_func("Found DukeDS user for email address {}.".format(email_address))
@@ -33,6 +37,16 @@ class UserUtil(object):
             self.logging_func("Found affiliate for email address {}.".format(email_address))
             return True
         self.logging_func("No valid DukeDS user or affiliate found for email address {}.".format(email_address))
+        return False
+
+    def user_or_affiliate_exists_for_username(self, username):
+        if self.find_user_by_username(username):
+            self.logging_func("Found DukeDS user for username {}.".format(username))
+            return True
+        if self.find_affiliate_by_username(username):
+            self.logging_func("Found affiliate for username {}.".format(username))
+            return True
+        self.logging_func("No valid DukeDS user or affiliate found for username {}.".format(username))
         return False
 
     @staticmethod

--- a/ddsc/core/userutil.py
+++ b/ddsc/core/userutil.py
@@ -1,4 +1,3 @@
-import re
 import logging
 
 DUKE_EMAIL_SUFFIX = "@duke.edu"

--- a/ddsc/core/userutil.py
+++ b/ddsc/core/userutil.py
@@ -26,20 +26,12 @@ class UserUtil(object):
         response = self.data_service.get_auth_provider_affiliates(self.auth_provider_id, email=email_address)
         return self._get_single_user_or_none(response, email_address)
 
-    def find_affiliate_by_username(self, username):
-        response = self.data_service.get_auth_provider_affiliates(self.auth_provider_id, username=username)
-        return self._get_single_user_or_none(response, username)
-
     def user_or_affiliate_exists_for_email(self, email_address):
         if self.find_user_by_email(email_address):
             self.logging_func("Found DukeDS user for email address {}.".format(email_address))
             return True
         if self.find_affiliate_by_email(email_address):
             self.logging_func("Found affiliate for email address {}.".format(email_address))
-            return True
-        potential_username = EmailUtil.try_get_username_from_email(email_address)
-        if potential_username and self.find_affiliate_by_username(potential_username):
-            self.logging_func("Found DukeDS user for username {}.".format(potential_username))
             return True
         self.logging_func("No valid DukeDS user or affiliate found for email address {}.".format(email_address))
         return False
@@ -52,42 +44,3 @@ class UserUtil(object):
         if len(results) == 1:
             return results[0]
         raise ValueError("Found multiple users for {}.".format(lookup_value))
-
-    def try_determine_username_from_email(self, email_address):
-        """
-        Tries to find a username based on an email address. First looks for an affiliate with that email address
-        and returns the 'uid' for that affiliate. Otherwise it tries to extract the username from the email address.
-        Returns None if no affiliate was found and the email address doesn't contain a username.
-        :param email_address: str: email address to find a username for
-        :return: str: username or None
-        """
-        affiliate = self.find_affiliate_by_email(email_address)
-        if affiliate:
-            return affiliate['uid']
-        else:
-            return EmailUtil.try_get_username_from_email(email_address)
-
-
-class EmailUtil(object):
-    @staticmethod
-    def try_get_username_from_email(email_address):
-        """
-        If email_address ends in @duke.edu and the local part is a username return that username otherwise return None.
-        Duke emails take two forms one with the full name and another where the local part is the username.
-        Usernames must be only lowercase alphanumeric.
-        :param email_address: str
-        :return: bool: str or None
-        """
-        if EmailUtil.is_duke_email(email_address):
-            local_part = EmailUtil.strip_email_suffix(email_address)
-            if local_part.islower() and local_part.isalnum():
-                return local_part
-        return None
-
-    @staticmethod
-    def is_duke_email(email_address):
-        return email_address.endswith(DUKE_EMAIL_SUFFIX)
-
-    @staticmethod
-    def strip_email_suffix(email_address):
-        return re.sub('@.*$', '', email_address)

--- a/ddsc/core/userutil.py
+++ b/ddsc/core/userutil.py
@@ -66,26 +66,36 @@ class LookupUserByEmail(object):
 
     def get_dds_user_with_valid_email(self):
         dds_user = self.dds_user_util.find_dds_user_by_email(self.email_address)
-        if self._item_has_email(dds_user):
-            self.logging_func("Found valid DukeDS user for email address {}.".format(self.email_address))
-            return dds_user
-        if self.possible_username:
-            dds_user = self.dds_user_util.find_dds_user_by_username(self.possible_username)
+        if dds_user:
             if self._item_has_email(dds_user):
-                self.logging_func("Found valid DukeDS user for username {}.".format(self.possible_username))
+                self.logging_func("Found valid DukeDS user for email address {}.".format(self.email_address))
                 return dds_user
+        else:
+            # A user for the email address was not found. It could be the email is the format <username>@duke.edu.
+            # The <username>@duke.edu email is not typically stored in the DukeDS so we can try to find a user
+            # using the <username>.
+            if self.possible_username:
+                dds_user = self.dds_user_util.find_dds_user_by_username(self.possible_username)
+                if self._item_has_email(dds_user):
+                    self.logging_func("Found valid DukeDS user for username {}.".format(self.possible_username))
+                    return dds_user
         return None
 
     def get_affiliate_user_with_valid_email(self):
         affiliate_user = self.dds_user_util.find_affiliate_user_by_email(self.email_address)
-        if self._item_has_email(affiliate_user):
-            self.logging_func("Found valid affiliate user for email address {}.".format(self.email_address))
-            return affiliate_user
-        if self.possible_username:
-            affiliate_user = self.dds_user_util.find_affiliate_user_by_username(self.possible_username)
+        if affiliate_user:
             if self._item_has_email(affiliate_user):
-                self.logging_func("Found valid affiliate user for username {}.".format(self.possible_username))
+                self.logging_func("Found valid affiliate user for email address {}.".format(self.email_address))
                 return affiliate_user
+        else:
+            # An affiliate for the email address was not found. It could be the email is the format <username>@duke.edu.
+            # The <username>@duke.edu email is not typically stored in the affiliate list so we can try to find an
+            # affiliate using the <username>.
+            if self.possible_username:
+                affiliate_user = self.dds_user_util.find_affiliate_user_by_username(self.possible_username)
+                if self._item_has_email(affiliate_user):
+                    self.logging_func("Found valid affiliate user for username {}.".format(self.possible_username))
+                    return affiliate_user
         return None
 
     @staticmethod
@@ -94,7 +104,7 @@ class LookupUserByEmail(object):
 
     def _extract_username_or_none(self, email_address):
         """
-        If email_address is a duke email address and the local part is a username return that username or None.
+        If email_address ends in @duke.edu and the local part is a username return that username otherwise return None.
         Duke emails take two forms one with the full name and another where the local part is the username.
         Usernames must be only lowercase alphanumeric.
         :param email_address: str

--- a/ddsc/core/userutil.py
+++ b/ddsc/core/userutil.py
@@ -4,7 +4,7 @@ import logging
 DUKE_EMAIL_SUFFIX = "@duke.edu"
 
 
-class DDSUserUtil(object):
+class UserUtil(object):
     def __init__(self, data_service, logging_func=logging.info):
         self.data_service = data_service
         self.auth_provider_id = data_service.get_default_auth_provider_id()

--- a/ddsc/sdk/dukeds.py
+++ b/ddsc/sdk/dukeds.py
@@ -80,9 +80,9 @@ class DukeDS(object):
     def can_deliver_to_user_with_email(email_address, logging_func=logging.info):
         """
         Determine if we can deliver a project to a user
-        :param email_address:
-        :param logging_func:
-        :return:
+        :param email_address: str: email address to lookup
+        :param logging_func: func(str): function that will receive log messages
+        :return: boolean: True if the specified user can receive deliveries
         """
         return Session().can_deliver_to_user_with_email(email_address, logging_func)
 

--- a/ddsc/sdk/dukeds.py
+++ b/ddsc/sdk/dukeds.py
@@ -212,4 +212,4 @@ class Session(object):
     def can_deliver_to_user_with_email(self, email_address, logging_func):
         data_service = self.client.dds_connection.data_service
         dds_user_util = UserUtil(data_service, logging_func=logging_func)
-        return dds_user_util.valid_dds_user_or_affiliate_exists_for_email(email_address)
+        return dds_user_util.user_or_affiliate_exists_for_email(email_address)

--- a/ddsc/sdk/dukeds.py
+++ b/ddsc/sdk/dukeds.py
@@ -1,6 +1,8 @@
 from __future__ import absolute_import
+import logging
 from ddsc.sdk.client import Client, FileUpload, PathToFiles, ItemNotFound, DuplicateNameError
 from ddsc.config import create_config
+from ddsc.core.ddsuserutil import DDSUserUtil
 
 
 class DukeDS(object):
@@ -73,6 +75,16 @@ class DukeDS(object):
         :param remote_path: str: remote path specifying file to delete
         """
         Session().delete_file(project_name, remote_path)
+
+    @staticmethod
+    def can_deliver_to_user_with_email(email_address, logging_func=logging.info):
+        """
+        Determine if we can deliver a project to a user
+        :param email_address:
+        :param logging_func:
+        :return:
+        """
+        return Session().can_deliver_to_user_with_email(email_address, logging_func)
 
 
 class Session(object):
@@ -196,3 +208,8 @@ class Session(object):
         project = self._get_or_create_project(project_name)
         remote_file = project.get_child_for_path(remote_path)
         remote_file.delete()
+
+    def can_deliver_to_user_with_email(self, email_address, logging_func):
+        data_service = self.client.dds_connection.data_service
+        dds_user_util = DDSUserUtil(data_service, logging_func=logging_func)
+        return dds_user_util.valid_dds_user_or_affiliate_exists_for_email(email_address)

--- a/ddsc/sdk/dukeds.py
+++ b/ddsc/sdk/dukeds.py
@@ -86,6 +86,16 @@ class DukeDS(object):
         """
         return Session().can_deliver_to_user_with_email(email_address, logging_func)
 
+    @staticmethod
+    def can_deliver_to_user_with_username(username, logging_func=logging.info):
+        """
+        Determine if we can deliver a project to a user
+        :param username: str: username to lookup
+        :param logging_func: func(str): function that will receive log messages
+        :return: boolean: True if the specified user can receive deliveries
+        """
+        return Session().can_deliver_to_user_with_username(username, logging_func)
+
 
 class Session(object):
     """
@@ -213,3 +223,8 @@ class Session(object):
         data_service = self.client.dds_connection.data_service
         dds_user_util = UserUtil(data_service, logging_func=logging_func)
         return dds_user_util.user_or_affiliate_exists_for_email(email_address)
+
+    def can_deliver_to_user_with_username(self, username, logging_func):
+        data_service = self.client.dds_connection.data_service
+        dds_user_util = UserUtil(data_service, logging_func=logging_func)
+        return dds_user_util.user_or_affiliate_exists_for_username(username)

--- a/ddsc/sdk/dukeds.py
+++ b/ddsc/sdk/dukeds.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 import logging
 from ddsc.sdk.client import Client, FileUpload, PathToFiles, ItemNotFound, DuplicateNameError
 from ddsc.config import create_config
-from ddsc.core.ddsuserutil import DDSUserUtil
+from ddsc.core.userutil import UserUtil
 
 
 class DukeDS(object):
@@ -211,5 +211,5 @@ class Session(object):
 
     def can_deliver_to_user_with_email(self, email_address, logging_func):
         data_service = self.client.dds_connection.data_service
-        dds_user_util = DDSUserUtil(data_service, logging_func=logging_func)
+        dds_user_util = UserUtil(data_service, logging_func=logging_func)
         return dds_user_util.valid_dds_user_or_affiliate_exists_for_email(email_address)

--- a/ddsc/sdk/tests/test_dukeds.py
+++ b/ddsc/sdk/tests/test_dukeds.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 from ddsc import DukeDS, ItemNotFound, DuplicateNameError
-from mock import patch, Mock
+from mock import patch, Mock, ANY
 
 
 class TestDukeDS(TestCase):
@@ -154,3 +154,22 @@ class TestDukeDS(TestCase):
 
         self.mouse_rna_project.get_child_for_path.assert_called_with('data/file1.dat')
         mock_file1.delete.assert_called()
+
+    @patch('ddsc.sdk.dukeds.Client')
+    @patch('ddsc.sdk.dukeds.DDSUserUtil')
+    def test_can_deliver_to_user_with_email(self, mock_dds_user_util, mock_client):
+        DukeDS.can_deliver_to_user_with_email(email_address='fakeuser@duke.edu')
+        mock_dds_user_util.assert_called_with(mock_client.return_value.dds_connection.data_service,
+                                              logging_func=ANY)
+        dds_user_util = mock_dds_user_util.return_value
+        dds_user_util.valid_dds_user_or_affiliate_exists_for_email.assert_called_with("fakeuser@duke.edu")
+
+    @patch('ddsc.sdk.dukeds.Client')
+    @patch('ddsc.sdk.dukeds.DDSUserUtil')
+    def test_can_deliver_to_user_with_email_with_logging_func(self, mock_dds_user_util, mock_client):
+        mock_log_func = Mock()
+        DukeDS.can_deliver_to_user_with_email(email_address='fakeuser@duke.edu', logging_func=mock_log_func)
+        mock_dds_user_util.assert_called_with(mock_client.return_value.dds_connection.data_service,
+                                              logging_func=mock_log_func)
+        dds_user_util = mock_dds_user_util.return_value
+        dds_user_util.valid_dds_user_or_affiliate_exists_for_email.assert_called_with("fakeuser@duke.edu")

--- a/ddsc/sdk/tests/test_dukeds.py
+++ b/ddsc/sdk/tests/test_dukeds.py
@@ -174,3 +174,23 @@ class TestDukeDS(TestCase):
         dds_user_util = mock_user_util.return_value
         dds_user_util.user_or_affiliate_exists_for_email.assert_called_with("fakeuser@duke.edu")
         self.assertEqual(result, dds_user_util.user_or_affiliate_exists_for_email.return_value)
+
+    @patch('ddsc.sdk.dukeds.Client')
+    @patch('ddsc.sdk.dukeds.UserUtil')
+    def test_can_deliver_to_user_with_username(self, mock_user_util, mock_client):
+        result = DukeDS.can_deliver_to_user_with_username(username='fakeuser')
+        mock_user_util.assert_called_with(mock_client.return_value.dds_connection.data_service, logging_func=ANY)
+        dds_user_util = mock_user_util.return_value
+        dds_user_util.user_or_affiliate_exists_for_username.assert_called_with("fakeuser")
+        self.assertEqual(result, dds_user_util.user_or_affiliate_exists_for_username.return_value)
+
+    @patch('ddsc.sdk.dukeds.Client')
+    @patch('ddsc.sdk.dukeds.UserUtil')
+    def test_can_deliver_to_user_with_username_with_logging_func(self, mock_user_util, mock_client):
+        mock_log_func = Mock()
+        result = DukeDS.can_deliver_to_user_with_username(username='fakeuser', logging_func=mock_log_func)
+        mock_user_util.assert_called_with(mock_client.return_value.dds_connection.data_service,
+                                          logging_func=mock_log_func)
+        dds_user_util = mock_user_util.return_value
+        dds_user_util.user_or_affiliate_exists_for_username.assert_called_with("fakeuser")
+        self.assertEqual(result, dds_user_util.user_or_affiliate_exists_for_username.return_value)

--- a/ddsc/sdk/tests/test_dukeds.py
+++ b/ddsc/sdk/tests/test_dukeds.py
@@ -156,22 +156,22 @@ class TestDukeDS(TestCase):
         mock_file1.delete.assert_called()
 
     @patch('ddsc.sdk.dukeds.Client')
-    @patch('ddsc.sdk.dukeds.DDSUserUtil')
-    def test_can_deliver_to_user_with_email(self, mock_dds_user_util, mock_client):
+    @patch('ddsc.sdk.dukeds.UserUtil')
+    def test_can_deliver_to_user_with_email(self, mock_user_util, mock_client):
         result = DukeDS.can_deliver_to_user_with_email(email_address='fakeuser@duke.edu')
-        mock_dds_user_util.assert_called_with(mock_client.return_value.dds_connection.data_service,
+        mock_user_util.assert_called_with(mock_client.return_value.dds_connection.data_service,
                                               logging_func=ANY)
-        dds_user_util = mock_dds_user_util.return_value
+        dds_user_util = mock_user_util.return_value
         dds_user_util.valid_dds_user_or_affiliate_exists_for_email.assert_called_with("fakeuser@duke.edu")
         self.assertEqual(result, dds_user_util.valid_dds_user_or_affiliate_exists_for_email.return_value)
 
     @patch('ddsc.sdk.dukeds.Client')
-    @patch('ddsc.sdk.dukeds.DDSUserUtil')
-    def test_can_deliver_to_user_with_email_with_logging_func(self, mock_dds_user_util, mock_client):
+    @patch('ddsc.sdk.dukeds.UserUtil')
+    def test_can_deliver_to_user_with_email_with_logging_func(self, mock_user_util, mock_client):
         mock_log_func = Mock()
         result = DukeDS.can_deliver_to_user_with_email(email_address='fakeuser@duke.edu', logging_func=mock_log_func)
-        mock_dds_user_util.assert_called_with(mock_client.return_value.dds_connection.data_service,
+        mock_user_util.assert_called_with(mock_client.return_value.dds_connection.data_service,
                                               logging_func=mock_log_func)
-        dds_user_util = mock_dds_user_util.return_value
+        dds_user_util = mock_user_util.return_value
         dds_user_util.valid_dds_user_or_affiliate_exists_for_email.assert_called_with("fakeuser@duke.edu")
         self.assertEqual(result, dds_user_util.valid_dds_user_or_affiliate_exists_for_email.return_value)

--- a/ddsc/sdk/tests/test_dukeds.py
+++ b/ddsc/sdk/tests/test_dukeds.py
@@ -159,8 +159,7 @@ class TestDukeDS(TestCase):
     @patch('ddsc.sdk.dukeds.UserUtil')
     def test_can_deliver_to_user_with_email(self, mock_user_util, mock_client):
         result = DukeDS.can_deliver_to_user_with_email(email_address='fakeuser@duke.edu')
-        mock_user_util.assert_called_with(mock_client.return_value.dds_connection.data_service,
-                                              logging_func=ANY)
+        mock_user_util.assert_called_with(mock_client.return_value.dds_connection.data_service, logging_func=ANY)
         dds_user_util = mock_user_util.return_value
         dds_user_util.valid_dds_user_or_affiliate_exists_for_email.assert_called_with("fakeuser@duke.edu")
         self.assertEqual(result, dds_user_util.valid_dds_user_or_affiliate_exists_for_email.return_value)
@@ -171,7 +170,7 @@ class TestDukeDS(TestCase):
         mock_log_func = Mock()
         result = DukeDS.can_deliver_to_user_with_email(email_address='fakeuser@duke.edu', logging_func=mock_log_func)
         mock_user_util.assert_called_with(mock_client.return_value.dds_connection.data_service,
-                                              logging_func=mock_log_func)
+                                          logging_func=mock_log_func)
         dds_user_util = mock_user_util.return_value
         dds_user_util.valid_dds_user_or_affiliate_exists_for_email.assert_called_with("fakeuser@duke.edu")
         self.assertEqual(result, dds_user_util.valid_dds_user_or_affiliate_exists_for_email.return_value)

--- a/ddsc/sdk/tests/test_dukeds.py
+++ b/ddsc/sdk/tests/test_dukeds.py
@@ -158,18 +158,20 @@ class TestDukeDS(TestCase):
     @patch('ddsc.sdk.dukeds.Client')
     @patch('ddsc.sdk.dukeds.DDSUserUtil')
     def test_can_deliver_to_user_with_email(self, mock_dds_user_util, mock_client):
-        DukeDS.can_deliver_to_user_with_email(email_address='fakeuser@duke.edu')
+        result = DukeDS.can_deliver_to_user_with_email(email_address='fakeuser@duke.edu')
         mock_dds_user_util.assert_called_with(mock_client.return_value.dds_connection.data_service,
                                               logging_func=ANY)
         dds_user_util = mock_dds_user_util.return_value
         dds_user_util.valid_dds_user_or_affiliate_exists_for_email.assert_called_with("fakeuser@duke.edu")
+        self.assertEqual(result, dds_user_util.valid_dds_user_or_affiliate_exists_for_email.return_value)
 
     @patch('ddsc.sdk.dukeds.Client')
     @patch('ddsc.sdk.dukeds.DDSUserUtil')
     def test_can_deliver_to_user_with_email_with_logging_func(self, mock_dds_user_util, mock_client):
         mock_log_func = Mock()
-        DukeDS.can_deliver_to_user_with_email(email_address='fakeuser@duke.edu', logging_func=mock_log_func)
+        result = DukeDS.can_deliver_to_user_with_email(email_address='fakeuser@duke.edu', logging_func=mock_log_func)
         mock_dds_user_util.assert_called_with(mock_client.return_value.dds_connection.data_service,
                                               logging_func=mock_log_func)
         dds_user_util = mock_dds_user_util.return_value
         dds_user_util.valid_dds_user_or_affiliate_exists_for_email.assert_called_with("fakeuser@duke.edu")
+        self.assertEqual(result, dds_user_util.valid_dds_user_or_affiliate_exists_for_email.return_value)

--- a/ddsc/sdk/tests/test_dukeds.py
+++ b/ddsc/sdk/tests/test_dukeds.py
@@ -161,8 +161,8 @@ class TestDukeDS(TestCase):
         result = DukeDS.can_deliver_to_user_with_email(email_address='fakeuser@duke.edu')
         mock_user_util.assert_called_with(mock_client.return_value.dds_connection.data_service, logging_func=ANY)
         dds_user_util = mock_user_util.return_value
-        dds_user_util.valid_dds_user_or_affiliate_exists_for_email.assert_called_with("fakeuser@duke.edu")
-        self.assertEqual(result, dds_user_util.valid_dds_user_or_affiliate_exists_for_email.return_value)
+        dds_user_util.user_or_affiliate_exists_for_email.assert_called_with("fakeuser@duke.edu")
+        self.assertEqual(result, dds_user_util.user_or_affiliate_exists_for_email.return_value)
 
     @patch('ddsc.sdk.dukeds.Client')
     @patch('ddsc.sdk.dukeds.UserUtil')
@@ -172,5 +172,5 @@ class TestDukeDS(TestCase):
         mock_user_util.assert_called_with(mock_client.return_value.dds_connection.data_service,
                                           logging_func=mock_log_func)
         dds_user_util = mock_user_util.return_value
-        dds_user_util.valid_dds_user_or_affiliate_exists_for_email.assert_called_with("fakeuser@duke.edu")
-        self.assertEqual(result, dds_user_util.valid_dds_user_or_affiliate_exists_for_email.return_value)
+        dds_user_util.user_or_affiliate_exists_for_email.assert_called_with("fakeuser@duke.edu")
+        self.assertEqual(result, dds_user_util.user_or_affiliate_exists_for_email.return_value)


### PR DESCRIPTION
## Background
Before these changes DukeDSClient only allowed specifying a user by email for users already registered with DukeDS. The DukeDS API has added methods to lookup affiliates based on email address.

## Improves user registration with email address
For all commands that receive an email address use it to try and lookup an affiliate if the user is not already registered with DukeDS. Also includes changes to try looking up a user based on their username if the specified email looks like a <username>@duke.edu email address when not found by other means.

## SDK Method Additions
Adds `can_deliver_to_user_with_email` and  `can_deliver_to_user_with_username` methods to the DukeDSClient `sdk` to allow users to easily check if a project can be delivered to the user associated with an email address or username.

Fixes #234 