### PR TITLE
Add leading slash to remote paths

### DIFF
--- a/ddsc/core/pathfilter.py
+++ b/ddsc/core/pathfilter.py
@@ -82,6 +82,11 @@ class PathFilterUtil(object):
 
     @staticmethod
     def normalize_slashes(paths):
+        """
+        Removes trailing slashes and make sure paths begin with a leading slash.
+        :param paths: [str]: paths to fix
+        :return: [str]: array of normalized paths
+        """
         normalized_paths = []
         for path in paths:
             path = path.rstrip(os.sep)

--- a/ddsc/core/pathfilter.py
+++ b/ddsc/core/pathfilter.py
@@ -81,13 +81,14 @@ class PathFilterUtil(object):
         return PathFilterUtil.is_child(path, some_path) or PathFilterUtil.is_child(some_path, path)
 
     @staticmethod
-    def strip_trailing_slash(paths):
-        """
-        Remove trailing slash from a list of paths
-        :param paths: [str]: paths to fix
-        :return: [str]: stripped paths
-        """
-        return [path.rstrip(os.sep) for path in paths]
+    def normalize_slashes(paths):
+        normalized_paths = []
+        for path in paths:
+            path = path.rstrip(os.sep)
+            if not path.startswith(os.sep):
+                path = os.sep + path
+            normalized_paths.append(path)
+        return normalized_paths
 
 
 class IncludeAll(object):
@@ -109,7 +110,7 @@ class IncludeFilter(object):
     Path filter that will include paths that are parent/children/equal to include_paths.
     """
     def __init__(self, paths):
-        self.paths = PathFilterUtil.strip_trailing_slash(paths)
+        self.paths = PathFilterUtil.normalize_slashes(paths)
 
     def include(self, some_path):
         if some_path in self.paths:
@@ -125,7 +126,7 @@ class ExcludeFilter(object):
     Path filter that will exclude paths that are children/equal to include_paths.
     """
     def __init__(self, paths):
-        self.paths = PathFilterUtil.strip_trailing_slash(paths)
+        self.paths = PathFilterUtil.normalize_slashes(paths)
 
     def include(self, some_path):
         if some_path in self.paths:

--- a/ddsc/core/pathfilter.py
+++ b/ddsc/core/pathfilter.py
@@ -3,7 +3,7 @@ Classes for filtering a list of paths based on either a list of paths to include
 """
 
 import os
-from ddsc.core.util import FilteredProject
+from ddsc.core.util import FilteredProject, REMOTE_PATH_SEP
 
 
 class PathFilter(object):
@@ -89,9 +89,9 @@ class PathFilterUtil(object):
         """
         normalized_paths = []
         for path in paths:
-            path = path.rstrip(os.sep)
-            if not path.startswith(os.sep):
-                path = os.sep + path
+            path = path.rstrip(REMOTE_PATH_SEP)
+            if not path.startswith(REMOTE_PATH_SEP):
+                path = REMOTE_PATH_SEP + path
             normalized_paths.append(path)
         return normalized_paths
 

--- a/ddsc/core/remotestore.py
+++ b/ddsc/core/remotestore.py
@@ -633,20 +633,32 @@ class ProjectFile(object):
         self.json_data = json_data
         self.kind = KindType.file_str
 
+    @staticmethod
+    def add_leading_slash(path):
+        return '{}{}'.format(os.sep, path)
+
+    @staticmethod
+    def strip_leading_slash(path):
+        return path.lstrip(os.sep)
+
     @property
     def path(self):
         names = self._get_remote_parent_folder_names()
         names.append(self.name)
-        return os.sep.join(names)
+        return self.add_leading_slash(os.sep.join(names))
 
     def get_remote_parent_path(self):
-        return os.sep.join(self._get_remote_parent_folder_names())
+        parent_folders_path = os.sep.join(self._get_remote_parent_folder_names())
+        return self.add_leading_slash(parent_folders_path)
 
     def _get_remote_parent_folder_names(self):
         return [item['name'] for item in self.ancestors if item['kind'] == KindType.folder_str]
 
     def get_local_path(self, directory_path):
-        return os.path.join(directory_path, self.path)
+        # Removing leading slash from self.path because os.path.join ignores preceding paths if it encounters an
+        # absolute path.
+        path_without_leading_slash = self.strip_leading_slash(self.path)
+        return os.path.join(directory_path, path_without_leading_slash)
 
     def get_hash(self):
         return RemoteFile.get_hash_from_upload(self.json_data)

--- a/ddsc/core/remotestore.py
+++ b/ddsc/core/remotestore.py
@@ -338,7 +338,7 @@ class RemoteProject(object):
         self.description = json_data['description']
         self.is_deleted = json_data['is_deleted']
         self.children = []
-        self.remote_path = ''
+        self.remote_path = os.sep
 
     def add_child(self, child):
         """
@@ -530,7 +530,7 @@ class RemoteProjectChildren(object):
         Return array of RemoteFolders(with appropriate children)/RemoteFiles based on the values from constructor.
         :return: [RemoteFolder/RemoteFile]
         """
-        return self.get_tree_recur(self.project_id, '')
+        return self.get_tree_recur(self.project_id, os.sep)
 
     def get_tree_recur(self, parent_id, parent_path):
         """

--- a/ddsc/core/remotestore.py
+++ b/ddsc/core/remotestore.py
@@ -1,6 +1,6 @@
 import os
 from ddsc.core.ddsapi import DataServiceApi, DataServiceError, DataServiceAuth
-from ddsc.core.util import KindType
+from ddsc.core.util import KindType, REMOTE_PATH_SEP
 from ddsc.core.localstore import HashUtil
 from ddsc.core.userutil import UserUtil
 
@@ -338,7 +338,7 @@ class RemoteProject(object):
         self.description = json_data['description']
         self.is_deleted = json_data['is_deleted']
         self.children = []
-        self.remote_path = os.sep
+        self.remote_path = REMOTE_PATH_SEP
 
     def add_child(self, child):
         """
@@ -530,7 +530,7 @@ class RemoteProjectChildren(object):
         Return array of RemoteFolders(with appropriate children)/RemoteFiles based on the values from constructor.
         :return: [RemoteFolder/RemoteFile]
         """
-        return self.get_tree_recur(self.project_id, os.sep)
+        return self.get_tree_recur(self.project_id, REMOTE_PATH_SEP)
 
     def get_tree_recur(self, parent_id, parent_path):
         """
@@ -635,20 +635,20 @@ class ProjectFile(object):
 
     @staticmethod
     def add_leading_slash(path):
-        return '{}{}'.format(os.sep, path)
+        return '{}{}'.format(REMOTE_PATH_SEP, path)
 
     @staticmethod
     def strip_leading_slash(path):
-        return path.lstrip(os.sep)
+        return path.lstrip(REMOTE_PATH_SEP)
 
     @property
     def path(self):
         names = self._get_remote_parent_folder_names()
         names.append(self.name)
-        return self.add_leading_slash(os.sep.join(names))
+        return self.add_leading_slash(REMOTE_PATH_SEP.join(names))
 
     def get_remote_parent_path(self):
-        parent_folders_path = os.sep.join(self._get_remote_parent_folder_names())
+        parent_folders_path = REMOTE_PATH_SEP.join(self._get_remote_parent_folder_names())
         return self.add_leading_slash(parent_folders_path)
 
     def _get_remote_parent_folder_names(self):

--- a/ddsc/core/tests/test_pathfilter.py
+++ b/ddsc/core/tests/test_pathfilter.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from ddsc.core.pathfilter import PathFilter, IncludeFilter, ExcludeFilter, PathFilteredProject
+from ddsc.core.pathfilter import PathFilter, IncludeFilter, ExcludeFilter, PathFilteredProject, PathFilterUtil
 from ddsc.core.remotestore import RemoteProject, RemoteFolder, RemoteFile
 
 
@@ -7,6 +7,25 @@ class TestPathFilter(TestCase):
     def test_invalid_path_setup(self):
         with self.assertRaises(ValueError):
             PathFilter(include_paths=['data'], exclude_paths=['results'])
+
+
+class TestPathFilterUtil(TestCase):
+    def test_normalize_slashes(self):
+        paths = [
+            'path/no/leading/slash.txt',
+            '/path/with/leading_slash.txt',
+            'directory/with/trailing/slashes/',
+            '/directory/with/slashes/',
+            '/directory/with/no/trailing/slash',
+        ]
+        fixed_paths = PathFilterUtil.normalize_slashes(paths)
+        self.assertEqual(fixed_paths, [
+            '/path/no/leading/slash.txt',
+            '/path/with/leading_slash.txt',
+            '/directory/with/trailing/slashes',
+            '/directory/with/slashes',
+            '/directory/with/no/trailing/slash'
+        ])
 
 
 class TestPathFilteredProject(TestCase):

--- a/ddsc/core/tests/test_pathfilter.py
+++ b/ddsc/core/tests/test_pathfilter.py
@@ -68,15 +68,15 @@ class TestPathFilteredProject(TestCase):
         }
 
         self.project = RemoteProject(project_fields)
-        folder1 = RemoteFolder(folder1_fields, "")
+        folder1 = RemoteFolder(folder1_fields, "/")
         self.project.add_child(folder1)
-        folder2 = RemoteFolder(folder2_fields, "data")
+        folder2 = RemoteFolder(folder2_fields, "/data")
         folder1.add_child(folder2)
-        file1 = RemoteFile(file1_fields, "data")
+        file1 = RemoteFile(file1_fields, "/data")
         self.project.add_child(file1)
-        file2 = RemoteFile(file2_fields, "data/results")
+        file2 = RemoteFile(file2_fields, "/data/results")
         folder2.add_child(file2)
-        file3 = RemoteFile(file3_fields, "data/results")
+        file3 = RemoteFile(file3_fields, "/data/results")
         folder2.add_child(file3)
 
     def test_no_filter(self):
@@ -85,12 +85,12 @@ class TestPathFilteredProject(TestCase):
         path_filtered_project = PathFilteredProject(path_filter, collector)
         path_filtered_project.run(self.project)
         expected = [
-            '',
-            'data',
-            'data/rg45.txt',
-            'data/results',
-            'data/results/results.doc',
-            'data/results/results.csv',
+            '/',
+            '/data',
+            '/data/rg45.txt',
+            '/data/results',
+            '/data/results/results.doc',
+            '/data/results/results.csv',
         ]
         self.assertEqual(set(expected), set(collector.visited_paths))
 
@@ -100,9 +100,9 @@ class TestPathFilteredProject(TestCase):
         path_filtered_project = PathFilteredProject(path_filter, collector)
         path_filtered_project.run(self.project)
         expected = [
-            '',
-            'data',
-            'data/rg45.txt',
+            '/',
+            '/data',
+            '/data/rg45.txt',
         ]
         self.assertEqual(set(expected), set(collector.visited_paths))
 
@@ -112,10 +112,10 @@ class TestPathFilteredProject(TestCase):
         path_filtered_project = PathFilteredProject(path_filter, collector)
         path_filtered_project.run(self.project)
         expected = [
-            '',
+            '/',
         ]
         self.assertEqual(set(expected), set(collector.visited_paths))
-        self.assertEqual(["stuff"], path_filter.get_unused_paths())
+        self.assertEqual(["/stuff"], path_filter.get_unused_paths())
 
     def test_nested_dir_include_filter(self):
         path_filter = PathFilter(include_paths=['data/results'], exclude_paths=[])
@@ -123,11 +123,11 @@ class TestPathFilteredProject(TestCase):
         path_filtered_project = PathFilteredProject(path_filter, collector)
         path_filtered_project.run(self.project)
         expected = [
-            '',
-            'data',
-            'data/results',
-            'data/results/results.doc',
-            'data/results/results.csv',
+            '/',
+            '/data',
+            '/data/results',
+            '/data/results/results.doc',
+            '/data/results/results.csv',
         ]
         self.assertEqual(set(expected), set(collector.visited_paths))
 
@@ -137,10 +137,10 @@ class TestPathFilteredProject(TestCase):
         path_filtered_project = PathFilteredProject(path_filter, collector)
         path_filtered_project.run(self.project)
         expected = [
-            '',
-            'data',
-            'data/results',
-            'data/results/results.csv',
+            '/',
+            '/data',
+            '/data/results',
+            '/data/results/results.csv',
         ]
         self.assertEqual(set(expected), set(collector.visited_paths))
 
@@ -150,9 +150,9 @@ class TestPathFilteredProject(TestCase):
         path_filtered_project = PathFilteredProject(path_filter, collector)
         path_filtered_project.run(self.project)
         expected = [
-            '',
-            'data',
-            'data/rg45.txt',
+            '/',
+            '/data',
+            '/data/rg45.txt',
         ]
         self.assertEqual(set(expected), set(collector.visited_paths))
 
@@ -181,80 +181,112 @@ class TestIncludeFilter(TestCase):
     def test_include_top_level_file(self):
         path_filter = IncludeFilter(["123.txt"])
         yes_values = [
-            "123.txt"
+            "/123.txt"
         ]
         no_values = [
-            "data",
-            ".txt",
-            "123",
-            "data/123.txt",
-            "results/123.txt"
+            "/data",
+            "/.txt",
+            "/123",
+            "/data/123.txt",
+            "/results/123.txt"
+        ]
+        self.check_filter(path_filter, yes_values, no_values)
+
+    def test_include_top_level_file_with_leading_slash(self):
+        path_filter = IncludeFilter(["/123.txt"])
+        yes_values = [
+            "/123.txt"
+        ]
+        no_values = [
+            "/data",
+            "/.txt",
+            "/123",
+            "/data/123.txt",
+            "/results/123.txt"
         ]
         self.check_filter(path_filter, yes_values, no_values)
 
     def test_include_top_level_dir(self):
         path_filter = IncludeFilter(["data"])
         yes_values = [
-            "data",
-            "data/raw_files",
-            "data/123.txt",
+            "/data",
+            "/data/raw_files",
+            "/data/123.txt",
         ]
         no_values = [
-            "123.txt"
-            ".txt",
-            "123",
-            "results/123.txt"
-            "results/data"
+            "/123.txt"
+            "/.txt",
+            "/123",
+            "/results/123.txt"
+            "/results/data"
         ]
         self.check_filter(path_filter, yes_values, no_values)
 
     def test_include_nested_dir(self):
         path_filter = IncludeFilter(["data/raw_files"])
         yes_values = [
-            "data",
-            "data/raw_files",
-            "data/raw_files/123.txt",
-            "data/raw_files/data",
-            "data/raw_files/one/two",
+            "/data",
+            "/data/raw_files",
+            "/data/raw_files/123.txt",
+            "/data/raw_files/data",
+            "/data/raw_files/one/two",
         ]
         no_values = [
-            "data/123.txt",
-            "some/raw_files"
-            "raw_files"
-            "raw_files/data.txt"
+            "/data/123.txt",
+            "/some/raw_files"
+            "/raw_files"
+            "/raw_files/data.txt"
         ]
         self.check_filter(path_filter, yes_values, no_values)
 
     def test_include_nested_file(self):
         path_filter = IncludeFilter(["data/raw_files/mine.txt"])
         yes_values = [
-            "data",
-            "data/raw_files",
-            "data/raw_files/mine.txt",
+            "/data",
+            "/data/raw_files",
+            "/data/raw_files/mine.txt",
         ]
         no_values = [
-            "mine.txt",
-            "raw_files/mine.txt",
-            "dat/raw_files/mine.txt"
-            "data/raw_files/other.txt",
+            "/mine.txt",
+            "/raw_files/mine.txt",
+            "/dat/raw_files/mine.txt"
+            "/data/raw_files/other.txt",
         ]
         self.check_filter(path_filter, yes_values, no_values)
 
     def test_include_multiple(self):
         path_filter = IncludeFilter(["data", "stuff/info.txt"])
         yes_values = [
-            "data",
-            "data/raw_files",
-            "data/raw_files/mine.txt",
-            "stuff",
-            "stuff/info.txt"
+            "/data",
+            "/data/raw_files",
+            "/data/raw_files/mine.txt",
+            "/stuff",
+            "/stuff/info.txt"
         ]
         no_values = [
-            "mine.txt",
-            "raw_files/mine.txt",
-            "dat/raw_files/mine.txt"
-            "data/raw_files/other.txt",
-            "stuff/other.txt"
+            "/mine.txt",
+            "/raw_files/mine.txt",
+            "/dat/raw_files/mine.txt"
+            "/data/raw_files/other.txt",
+            "/stuff/other.txt"
+        ]
+        self.check_filter(path_filter, yes_values, no_values)
+
+    def test_include_multiple_with_leading_slash(self):
+        path_filter = IncludeFilter(["/data", "/stuff/info.txt"])
+        yes_values = [
+            "/data",
+            "/data/raw_files",
+            "/data/raw_files/mine.txt",
+            "/stuff",
+            "/stuff/info.txt"
+        ]
+        no_values = [
+            "/mine.txt",
+            "/raw_files/mine.txt",
+            "/dat/raw_files/mine.txt"
+            "/data/raw_files/other.txt",
+            "/stuff/other.txt"
         ]
         self.check_filter(path_filter, yes_values, no_values)
 
@@ -269,58 +301,88 @@ class TestExcludeFilter(TestCase):
     def test_include_top_level_file(self):
         path_filter = ExcludeFilter(["123.txt"])
         yes_values = [
-            "data",
-            ".txt",
-            "123",
-            "data/123.txt",
-            "results/123.txt"
+            "/data",
+            "/.txt",
+            "/123",
+            "/data/123.txt",
+            "/results/123.txt"
         ]
         no_values = [
-            "123.txt"
+            "/123.txt"
+        ]
+        self.check_filter(path_filter, yes_values, no_values)
+
+    def test_include_top_level_file_with_leading_slash(self):
+        path_filter = ExcludeFilter(["/123.txt"])
+        yes_values = [
+            "/data",
+            "/.txt",
+            "/123",
+            "/data/123.txt",
+            "/results/123.txt"
+        ]
+        no_values = [
+            "/123.txt"
         ]
         self.check_filter(path_filter, yes_values, no_values)
 
     def test_include_top_level_dir(self):
         path_filter = ExcludeFilter(["data"])
         yes_values = [
-            "123.txt",
-            ".txt",
-            "123",
-            "results/123.txt"
+            "/123.txt",
+            "/.txt",
+            "/123",
+            "/results/123.txt"
         ]
         no_values = [
-            "data",
-            "data/123.txt",
-            "data/something",
-            "data/something/123.txt"
+            "/data",
+            "/data/123.txt",
+            "/data/something",
+            "/data/something/123.txt"
         ]
         self.check_filter(path_filter, yes_values, no_values)
 
     def test_nested_dir(self):
         path_filter = ExcludeFilter(["data/results"])
         yes_values = [
-            "data",
-            "results"
-            "results/123.txt",
+            "/data",
+            "/results"
+            "/results/123.txt",
         ]
         no_values = [
-            "data/results",
-            "data/results/123.txt"
+            "/data/results",
+            "/data/results/123.txt"
         ]
         self.check_filter(path_filter, yes_values, no_values)
 
     def test_include_multiple(self):
         path_filter = ExcludeFilter(["data/results", "test/data.txt"])
         yes_values = [
-            "data",
-            "results"
-            "results/123.txt",
-            "test",
-            "test/data.doc"
+            "/data",
+            "/results"
+            "/results/123.txt",
+            "/test",
+            "/test/data.doc"
         ]
         no_values = [
-            "data/results",
-            "data/results/123.txt",
-            "test/data.txt"
+            "/data/results",
+            "/data/results/123.txt",
+            "/test/data.txt"
+        ]
+        self.check_filter(path_filter, yes_values, no_values)
+
+    def test_include_multiple_with_leading_slash(self):
+        path_filter = ExcludeFilter(["/data/results", "/test/data.txt"])
+        yes_values = [
+            "/data",
+            "/results"
+            "/results/123.txt",
+            "/test",
+            "/test/data.doc"
+        ]
+        no_values = [
+            "/data/results",
+            "/data/results/123.txt",
+            "/test/data.txt"
         ]
         self.check_filter(path_filter, yes_values, no_values)

--- a/ddsc/core/tests/test_remotestore.py
+++ b/ddsc/core/tests/test_remotestore.py
@@ -887,11 +887,11 @@ class TestProjectFile(TestCase):
 
     def test_get_remote_parent_path(self):
         project_file = ProjectFile(self.project_file_dict)
-        self.assertEqual('data/docs', project_file.get_remote_parent_path())
+        self.assertEqual('/data/docs', project_file.get_remote_parent_path())
 
     def test_path(self):
         project_file = ProjectFile(self.project_file_dict)
-        self.assertEqual('data/docs/somefile', project_file.path)
+        self.assertEqual('/data/docs/somefile', project_file.path)
 
     def test_get_local_path(self):
         project_file = ProjectFile(self.project_file_dict)

--- a/ddsc/core/tests/test_remotestore.py
+++ b/ddsc/core/tests/test_remotestore.py
@@ -1,3 +1,4 @@
+import os
 import json
 from unittest import TestCase
 from ddsc.core.util import KindType
@@ -49,7 +50,7 @@ class TestProjectFolderFile(TestCase):
         self.assertEqual('test4', project.name)
         self.assertEqual('test4desc', project.description)
         self.assertEqual(False, project.is_deleted)
-        self.assertEqual('', project.remote_path)
+        self.assertEqual(os.sep, project.remote_path)
 
     def test_folder_item(self):
         projects_id_children_sample_json = """

--- a/ddsc/core/util.py
+++ b/ddsc/core/util.py
@@ -279,6 +279,8 @@ class ProjectDetailsList(object):
 
     def get_name(self, item, parent):
         if parent:
+            if parent.kind == KindType.project_str:
+                return '{}{}'.format(os.sep, item.name)
             parent_name = self.id_to_path.get(parent.id)
             if parent_name:
                 return "{}/{}".format(parent_name, item.name)

--- a/ddsc/core/util.py
+++ b/ddsc/core/util.py
@@ -19,6 +19,8 @@ chmod 600 ~/.ddsclient
 
 """
 
+REMOTE_PATH_SEP = '/'
+
 
 class KindType(object):
     """
@@ -280,10 +282,10 @@ class ProjectDetailsList(object):
     def get_name(self, item, parent):
         if parent:
             if parent.kind == KindType.project_str:
-                return '{}{}'.format(os.sep, item.name)
+                return '{}{}'.format(REMOTE_PATH_SEP, item.name)
             parent_name = self.id_to_path.get(parent.id)
             if parent_name:
-                return "{}/{}".format(parent_name, item.name)
+                return "{}{}{}".format(parent_name, REMOTE_PATH_SEP, item.name)
         return item.name
 
 

--- a/ddsc/tests/test_util.py
+++ b/ddsc/tests/test_util.py
@@ -2,7 +2,7 @@ from unittest import TestCase
 import subprocess
 import os
 import tempfile
-from ddsc.core.util import mode_allows_group_or_other, verify_file_private, ProjectDetailsList
+from ddsc.core.util import mode_allows_group_or_other, verify_file_private, ProjectDetailsList, KindType
 from mock import patch, Mock
 
 
@@ -88,6 +88,7 @@ class TestProjectDetailsList(TestCase):
         self.mock_project_item = Mock()
         self.mock_project_item.id = '123'
         self.mock_project_item.name = 'mouse'
+        self.mock_project_item.kind = KindType.project_str
         self.mock_folder_item = Mock()
         self.mock_folder_item.id = '456'
         self.mock_folder_item.name = 'data'
@@ -104,8 +105,8 @@ class TestProjectDetailsList(TestCase):
         project_details_list.visit_file(self.mock_file_item, self.mock_folder_item)
         expected_details = [
             'Project mouse Contents:',
-            'data',
-            'data/results.csv',
+            '/data',
+            '/data/results.csv',
         ]
         self.assertEqual(expected_details, project_details_list.details)
 
@@ -116,7 +117,27 @@ class TestProjectDetailsList(TestCase):
         project_details_list.visit_file(self.mock_file_item, self.mock_folder_item)
         expected_details = [
             '123 - Project mouse Contents:',
-            '456\tdata',
-            '789\tdata/results.csv\t(md5:abcdefg)',
+            '456\t/data',
+            '789\t/data/results.csv\t(md5:abcdefg)',
         ]
         self.assertEqual(expected_details, project_details_list.details)
+
+    def test_get_name_with_project_parent(self):
+        item = Mock()
+        item.name = 'file1.txt'
+        parent = Mock()
+        parent.kind = KindType.project_str
+        parent.id = 'abc123'
+        project_details_list = ProjectDetailsList(long_format=True)
+        name = project_details_list.get_name(item, parent)
+        self.assertEqual(name, '/file1.txt')
+
+    def test_get_name_no_parent(self):
+        item = Mock()
+        item.name = 'file1.txt'
+        parent = Mock()
+        parent.kind = KindType.project_str
+        parent.id = 'abc123'
+        project_details_list = ProjectDetailsList(long_format=True)
+        name = project_details_list.get_name(item, parent)
+        self.assertEqual(name, '/file1.txt')


### PR DESCRIPTION
In support of #243 adds leading slash to remote paths.
This allows users to naturally specify the top level 'directory' of a remote project with '/'. 
Previously this leading slash was omitted to match the DukeDS web portal.

Changes the `download` and `deliver` commands' arguments include/exclude to allow leading slash or the current functionality of omitting the leading slash. The `list` command will now print leading slashes.