### PR TITLE
Adds move command

### DIFF
--- a/ddsc/cmdparser.py
+++ b/ddsc/cmdparser.py
@@ -476,6 +476,24 @@ class CommandParser(object):
         list_auth_roles_parser = self.subparsers.add_parser('list-auth-roles', description=description)
         list_auth_roles_parser.set_defaults(func=list_auth_roles_func)
 
+    def register_move_command(self, move_func):
+        """
+        Add 'move' command to move a file/folder within a remote project.
+        :param move_func: function: run when user choses this option.
+        """
+        description = "Move/rename a file/folder within a project."
+        parser = self.subparsers.add_parser('move', description=description)
+        add_project_name_or_id_arg(parser, help_text_suffix="move")
+        parser.add_argument("source_remote_path",
+                            metavar='SourceRemotePath',
+                            type=to_unicode,
+                            help='remote path specifying the file/folder to be moved')
+        parser.add_argument("target_remote_path",
+                            metavar='TargetRemotePath',
+                            type=to_unicode,
+                            help='remote path specifying where to move the file/folder to')
+        parser.set_defaults(func=move_func)
+
     def run_command(self, args):
         """
         Parse command line arguments and run function registered for the appropriate command.

--- a/ddsc/cmdparser.py
+++ b/ddsc/cmdparser.py
@@ -481,15 +481,18 @@ class CommandParser(object):
         Add 'move' command to move a file/folder within a remote project.
         :param move_func: function: run when user choses this option.
         """
-        description = "Move/rename a file/folder within a project."
+        description = "Moves and/or renames a file or folder within a project. \n" \
+                      "When Target is a directory Source will be moved into it that directory. " \
+                      "Otherwise Source will be renamed to the filename of Target and moved into the parent" \
+                      " directory of Target. Target and Source are remote paths that must start with a '/'."
         parser = self.subparsers.add_parser('move', description=description)
         add_project_name_or_id_arg(parser, help_text_suffix="move")
         parser.add_argument("source_remote_path",
-                            metavar='SourceRemotePath',
+                            metavar='Source',
                             type=to_unicode,
                             help='remote path specifying the file/folder to be moved')
         parser.add_argument("target_remote_path",
-                            metavar='TargetRemotePath',
+                            metavar='Target',
                             type=to_unicode,
                             help='remote path specifying where to move the file/folder to')
         parser.set_defaults(func=move_func)

--- a/ddsc/cmdparser.py
+++ b/ddsc/cmdparser.py
@@ -486,7 +486,7 @@ class CommandParser(object):
                       "Otherwise Source will be renamed to the filename of Target and moved into the parent" \
                       " directory of Target. Target and Source are remote paths that must start with a '/'."
         parser = self.subparsers.add_parser('move', description=description)
-        add_project_name_or_id_arg(parser, help_text_suffix="move")
+        add_project_name_or_id_arg(parser, help_text_suffix="containing a file/folder to move")
         parser.add_argument("source_remote_path",
                             metavar='Source',
                             type=to_unicode,

--- a/ddsc/tests/test_cmdparser.py
+++ b/ddsc/tests/test_cmdparser.py
@@ -187,6 +187,15 @@ class TestCommandParser(TestCase):
         command_parser.run_command(['download', '-p', 'mouse'])
         self.assertEqual('mouse', self.parsed_args.project_name)
 
+    def test_register_move_command(self):
+        command_parser = CommandParser(version_str='1.0')
+        command_parser.register_move_command(self.set_parsed_args)
+        self.assertEqual(['move'], list(command_parser.subparsers.choices.keys()))
+        command_parser.run_command(['move', '-p', 'mouse', '/data/file1.txt', '/data/file1_bak.txt'])
+        self.assertEqual('mouse', self.parsed_args.project_name)
+        self.assertEqual('/data/file1.txt', self.parsed_args.source_remote_path)
+        self.assertEqual('/data/file1_bak.txt', self.parsed_args.target_remote_path)
+
     @patch("ddsc.cmdparser.os")
     def test_format_destination_path_ok_when_dir_empty(self, mock_os):
         mock_os.path.exists.return_value = True


### PR DESCRIPTION
Adds `move` command to move and rename files within a DukeDS project.

CLI help for `move`:
```
usage: ddsclient move [-h] (-p ProjectName | -i ProjectUUID) Source Target

Moves and/or renames a file or folder within a project. When Target is a
directory Source will be moved into it that directory. Otherwise Source will
be renamed to the filename of Target and moved into the parent directory of
Target. Target and Source are remote paths that must start with a '/'.

positional arguments:
  Source                remote path specifying the file/folder to be moved
  Target                remote path specifying where to move the file/folder
                        to

optional arguments:
  -h, --help            show this help message and exit
  -p ProjectName, --project-name ProjectName
                        Name of the project to containing a file/folder to
                        move.
  -i ProjectUUID, --project-id ProjectUUID
                        ID of the project to containing a file/folder to move.
```

Example command to rename a top level file in the project `mouse` from `file1.txt` to `file1.txt.sv`.
```
ddsclient move -p mouse /file1.txt /file1.txt.sv
```