### PR TITLE
Retry DukeDS API requests for ConnectionErrors

### DIFF
--- a/ddsc/core/tests/test_ddsapi.py
+++ b/ddsc/core/tests/test_ddsapi.py
@@ -820,6 +820,15 @@ class TestDataServiceApi(TestCase):
         self.assertEqual(resp, api._put.return_value)
         api._put.assert_called_with('/folders/abc123/move', {'parent': {'kind': 'dds-folder', 'id': 'def456'}})
 
+    @patch('ddsc.core.ddsapi.print')
+    def test_implements_set_status_message(self, mock_print):
+        mock_requests = MagicMock()
+        api = DataServiceApi(auth=self.create_mock_auth(config_page_size=100),
+                             url="something.com/v1",
+                             http=mock_requests)
+        api.set_status_message('Connection error')
+        mock_print.assert_called_with('Connection error')
+
 
 class TestDataServiceAuth(TestCase):
     @patch('ddsc.core.ddsapi.get_user_agent_str')
@@ -870,6 +879,13 @@ class TestDataServiceAuth(TestCase):
         error_message = str(err.exception)
         self.assertIn('500', error_message)
         self.assertIn('service down', error_message)
+
+    @patch('ddsc.core.ddsapi.print')
+    def test_implements_set_status_message(self, mock_print):
+        config = Mock(url='', user_key='', agent_key='abc')
+        auth = DataServiceAuth(config)
+        auth.set_status_message('Connection error')
+        mock_print.assert_called_with('Connection error')
 
 
 class TestMissingInitialSetupError(TestCase):

--- a/ddsc/core/tests/test_ddsapi.py
+++ b/ddsc/core/tests/test_ddsapi.py
@@ -6,7 +6,7 @@ from ddsc.core.ddsapi import MultiJSONResponse, DataServiceApi, DataServiceAuth,
 from ddsc.core.ddsapi import MissingInitialSetupError, SoftwareAgentNotFoundError, AuthTokenCreationError, \
     UnexpectedPagingReceivedError, DataServiceError, DSResourceNotConsistentError, \
     retry_until_resource_is_consistent, retry_when_service_unavailable, CONNECTION_RETRY_MESSAGE, \
-    CONNECTION_RETRY_SECONDS, SERVICE_DOWN_RETRY_SECONDS
+    CONNECTION_RETRY_SECONDS, SERVICE_DOWN_RETRY_SECONDS, CONNECTION_RETRY_TIMES
 from mock import MagicMock, Mock, patch, ANY
 
 
@@ -1026,7 +1026,7 @@ class TestRetryWhenServiceUnavailable(TestCase):
             self.assertEqual('result123', self.func('123'))
         except requests.exceptions.ConnectionError:
             pass
-        self.assertEqual(5, mock_time.sleep.call_count)
+        self.assertEqual(CONNECTION_RETRY_TIMES, mock_time.sleep.call_count)
         mock_time.sleep.assert_called_with(CONNECTION_RETRY_SECONDS)
         self.assertEqual(1, len(self.status_messages))
         self.assertEqual(CONNECTION_RETRY_MESSAGE, self.status_messages[0])

--- a/ddsc/core/tests/test_ddsapi.py
+++ b/ddsc/core/tests/test_ddsapi.py
@@ -5,8 +5,9 @@ import json
 from ddsc.core.ddsapi import MultiJSONResponse, DataServiceApi, DataServiceAuth, SETUP_GUIDE_URL
 from ddsc.core.ddsapi import MissingInitialSetupError, SoftwareAgentNotFoundError, AuthTokenCreationError, \
     UnexpectedPagingReceivedError, DataServiceError, DSResourceNotConsistentError, \
-    retry_until_resource_is_consistent, retry_when_service_unavailable, CONNECTION_RETRY_MESSAGE
-from mock import MagicMock, Mock, patch, ANY
+    retry_until_resource_is_consistent, retry_when_service_unavailable, CONNECTION_RETRY_MESSAGE, \
+    CONNECTION_RETRY_SECONDS, SERVICE_DOWN_RETRY_SECONDS
+from mock import MagicMock, Mock, patch, ANY, call
 
 
 def fake_response_with_pages(status_code, json_return_value, num_pages=1):
@@ -1004,6 +1005,7 @@ class TestRetryWhenServiceUnavailable(TestCase):
         self.raise_error_once = DataServiceError(mock_response, '', '')
         self.assertEqual('result123', self.func('123'))
         self.assertEqual(1, mock_time.sleep.call_count)
+        mock_time.sleep.assert_called_with(SERVICE_DOWN_RETRY_SECONDS)
         self.assertEqual(2, len(self.status_messages))
         self.assertIn('Duke Data Service is currently unavailable', self.status_messages[0])
         self.assertEqual('', self.status_messages[1])
@@ -1025,6 +1027,7 @@ class TestRetryWhenServiceUnavailable(TestCase):
         except requests.exceptions.ConnectionError:
             pass
         self.assertEqual(5, mock_time.sleep.call_count)
+        mock_time.sleep.assert_called_with(CONNECTION_RETRY_SECONDS)
         self.assertEqual(1, len(self.status_messages))
         self.assertEqual(CONNECTION_RETRY_MESSAGE, self.status_messages[0])
 

--- a/ddsc/core/tests/test_ddsapi.py
+++ b/ddsc/core/tests/test_ddsapi.py
@@ -7,7 +7,7 @@ from ddsc.core.ddsapi import MissingInitialSetupError, SoftwareAgentNotFoundErro
     UnexpectedPagingReceivedError, DataServiceError, DSResourceNotConsistentError, \
     retry_until_resource_is_consistent, retry_when_service_unavailable, CONNECTION_RETRY_MESSAGE, \
     CONNECTION_RETRY_SECONDS, SERVICE_DOWN_RETRY_SECONDS
-from mock import MagicMock, Mock, patch, ANY, call
+from mock import MagicMock, Mock, patch, ANY
 
 
 def fake_response_with_pages(status_code, json_return_value, num_pages=1):


### PR DESCRIPTION
Changes logic that communicates with DukeDS API to retry a few times when a connection error occurs. There will be 5 retries after waiting a second before each retry.

This is similar to logic that already exists to [retry sending to  Swift/S3](https://github.com/Duke-GCB/DukeDSClient/blob/441a151167f6c827e824a3b546fd269e48c67f08/ddsc/core/fileuploader.py#L201-L209)


Fixes #253 

This was tested by changing `/etc/hosts` while running `ddsclient upload ...`. I was able to see the warnings and the ddsclient recover.