### PR TITLE
Support for multiple checksums

### DIFF
--- a/ddsc/core/download.py
+++ b/ddsc/core/download.py
@@ -142,7 +142,6 @@ class ProjectDownload(object):
                 print("All downloaded files have been verified successfully.")
 
 
-
 class DownloadSettings(object):
     """
     Settings used to download a project

--- a/ddsc/core/download.py
+++ b/ddsc/core/download.py
@@ -122,17 +122,25 @@ class ProjectDownload(object):
         Make sure the file contents are correct by hashing file and comparing against hash provided by DukeDS.
         Raises ValueError if there is one or more problematic files.
         """
-        had_hash_failures = False
+        had_failed_file_hashes = False
+        had_conflicted_file_hashes = False
         for file_to_download in files_to_download:
             local_path = file_to_download.get_local_path(self.dest_directory)
             file_hash_status = FileHashStatus.determine_for_hashes(file_to_download.hashes, local_path)
             print(file_hash_status.get_status_line())
             if not file_hash_status.has_a_valid_hash():
-                had_hash_failures = True
-        if had_hash_failures:
+                had_failed_file_hashes = True
+            if file_hash_status.status == FileHashStatus.STATUS_CONFLICTED:
+                had_conflicted_file_hashes = True
+        if had_failed_file_hashes:
             raise ValueError("ERROR: Downloaded file(s) do not match the expected hashes.")
         else:
-            print("All downloaded files have been verified successfully.")
+            if had_conflicted_file_hashes:
+                print("All downloaded files have at least one valid hash.")
+                print("\nWARNING: Some downloaded files also have invalid hashes.\n")
+            else:
+                print("All downloaded files have been verified successfully.")
+
 
 
 class DownloadSettings(object):

--- a/ddsc/core/download.py
+++ b/ddsc/core/download.py
@@ -15,7 +15,7 @@ RESOURCE_NOT_CONSISTENT_RETRY_SECONDS = 2
 SWIFT_EXPIRED_STATUS_CODE = 401
 S3_EXPIRED_STATUS_CODE = 403
 MISMATCHED_FILE_HASH_WARNING = """
-NOTICE: Data Service reports multiple hashes for {} files.
+NOTICE: Data Service reports multiple hashes for {}.
 The downloaded files have been verified and confirmed to match one of these hashes.
 You do not need to retry the download.
 For more information, visit https://github.com/Duke-GCB/DukeDSClient/wiki/MD5-Hash-Conflicts.
@@ -143,7 +143,11 @@ class ProjectDownload(object):
         else:
             print("All downloaded files have been verified successfully.")
             if mismatched_hashes_cnt:
-                print(MISMATCHED_FILE_HASH_WARNING.format(mismatched_hashes_cnt))
+                if mismatched_hashes_cnt == 1:
+                    file_cnt_str = '1 file'
+                else:
+                    file_cnt_str = '{} files'.format(mismatched_hashes_cnt)
+                print(MISMATCHED_FILE_HASH_WARNING.format(file_cnt_str))
 
 
 class DownloadSettings(object):

--- a/ddsc/core/download.py
+++ b/ddsc/core/download.py
@@ -545,7 +545,7 @@ class FileHash(object):
         self.expected_hash_value = expected_hash_value
         self.file_path = file_path
         self.status = self.determine_status()
-        self.conflicted = conflicted # True when there exist other hashes that have FAILED
+        self.conflicted = conflicted  # True when there exist other hashes that have FAILED
 
     def _get_hash_value(self):
         get_hash_value_func = self.algorithm_to_get_hash_value.get(self.algorithm)

--- a/ddsc/core/tests/test_download.py
+++ b/ddsc/core/tests/test_download.py
@@ -268,8 +268,8 @@ class TestProjectDownload(TestCase):
         downloader = ProjectDownload(None, None, dest_directory='/tmp/data2/', path_filter=None)
         downloader.check_downloaded_files([project_file])
         mock_print.assert_has_calls([
-            call('All downloaded files have a valid hash.'),
-            call("WARNING: Some files have invalid hashes in addition to their valid hashes.")
+            call('All downloaded files have at least one valid hash.'),
+            call("\nWARNING: Some downloaded files also have invalid hashes.\n")
         ])
 
 

--- a/ddsc/core/tests/test_download.py
+++ b/ddsc/core/tests/test_download.py
@@ -3,7 +3,8 @@ from unittest import TestCase
 import os
 from ddsc.core.download import ProjectDownload, RetryChunkDownloader, DownloadInconsistentError, \
     PartialChunkDownloadError, TooLargeChunkDownloadError, DownloadSettings, DownloadContext, \
-    download_file_part_run, DownloadFilePartCommand, FileDownloader, ProjectFile, FileHash, FileToDownload
+    download_file_part_run, DownloadFilePartCommand, FileDownloader, ProjectFile, FileHash, FileToDownload, \
+    FileHashStatus
 from mock import Mock, patch, mock_open, call, ANY
 
 
@@ -784,65 +785,124 @@ class TestRetryChunkDownloader(TestCase):
 
 
 class TestFileHash(TestCase):
-    def test_create_for_best_hash_no_supported_hash_found(self):
-        expected_error_msg = "Unable to validate: No supported hashes found for file /tmp/fakepath.dat"
+    def test_is_valid__no_supported_hash_found(self):
+        file_hash = FileHash(algorithm='sha1', expected_hash_value='abc', file_path='/tmp/fakepath.dat')
         with self.assertRaises(ValueError) as raised_exception:
-            FileHash.create_for_best_hash(dds_hashes=[], file_path='/tmp/fakepath.dat')
-        self.assertEqual(str(raised_exception.exception), expected_error_msg)
-        with self.assertRaises(ValueError) as raised_exception:
-            FileHash.create_for_best_hash(dds_hashes=[
-                {"algorithm": "sha1", "value": "abc"}
-            ], file_path='/tmp/fakepath.dat')
-        self.assertEqual(str(raised_exception.exception), expected_error_msg)
+            file_hash.is_valid()
+        self.assertEqual(str(raised_exception.exception), 'Unsupported algorithm sha1.')
 
     @patch('ddsc.core.download.HashUtil')
-    def test_create_for_best_hash_md5_hash_ok(self, mock_hash_util):
-        mock_hash_util.return_value.hash.hexdigest.return_value = 'def'
-        file_hash = FileHash.create_for_best_hash(dds_hashes=[
+    def test_is_valid__hash_matches(self, mock_hash_util):
+        mock_hash_util.return_value.hash.hexdigest.return_value = 'abc'
+        file_hash = FileHash(algorithm='md5', expected_hash_value='abc', file_path='/tmp/fakepath.dat')
+        self.assertEqual(file_hash.is_valid(), True)
+
+    @patch('ddsc.core.download.HashUtil')
+    def test_is_valid__hash_mismatch(self, mock_hash_util):
+        mock_hash_util.return_value.hash.hexdigest.return_value = 'abc'
+        file_hash = FileHash(algorithm='md5', expected_hash_value='def', file_path='/tmp/fakepath.dat')
+        self.assertEqual(file_hash.is_valid(), False)
+
+    def test_get_supported_file_hashes(self):
+        dds_hashes = [
             {"algorithm": "sha1", "value": "abc"},
             {"algorithm": "md5", "value": "def"},
-        ], file_path='/tmp/fakepath.dat')
-        self.assertEqual(file_hash.status, FileHash.STATUS_OK)
-        self.assertEqual(file_hash.get_status_line(), '/tmp/fakepath.dat def md5 OK')
-        self.assertEqual(file_hash.conflicted, False)
-        file_hash.raise_for_status()
-
-    @patch('ddsc.core.download.HashUtil')
-    def test_create_for_best_hash_md5_hash_failed(self, mock_hash_util):
-        mock_hash_util.return_value.hash.hexdigest.return_value = 'def'
-        file_hash = FileHash.create_for_best_hash(dds_hashes=[
-            {"algorithm": "sha1", "value": "abc"},
             {"algorithm": "md5", "value": "hij"},
-        ], file_path='/tmp/fakepath.dat')
-        self.assertEqual(file_hash.status, FileHash.STATUS_FAILED)
-        self.assertEqual(file_hash.get_status_line(), '/tmp/fakepath.dat hij md5 FAILED')
-        self.assertEqual(file_hash.conflicted, False)
-        with self.assertRaises(ValueError) as raised_exception:
-            file_hash.raise_for_status()
-        self.assertEqual(str(raised_exception.exception), 'Hash validation error: /tmp/fakepath.dat hij md5 FAILED')
-
-    @patch('ddsc.core.download.HashUtil')
-    def test_create_for_best_hash_with_conflicted_hashes(self, mock_hash_util):
-        mock_hash_util.return_value.hash.hexdigest.return_value = 'def'
-        file_hash = FileHash.create_for_best_hash(dds_hashes=[
-            {"algorithm": "md5", "value": "abc"},
-            {"algorithm": "md5", "value": "def"},
-        ], file_path='/tmp/fakepath.dat')
-        self.assertEqual(file_hash.status, FileHash.STATUS_OK)
-        self.assertEqual(file_hash.get_status_line(), '/tmp/fakepath.dat def md5 CONFLICTED')
-        self.assertEqual(file_hash.conflicted, True)
-        file_hash.raise_for_status()
-
-    @patch('ddsc.core.download.HashUtil')
-    def test_get_supported_file_hashes(self, mock_hash_util):
-        mock_hash_util.return_value.hash.hexdigest.return_value = 'def'
-        file_hashes = FileHash.get_supported_file_hashes([
-            {"algorithm": "md5", "value": "abc"},
-            {"algorithm": "md5", "value": "def"},
-            {"algorithm": "sha1", "value": "hij"},
-        ], file_path='/tmp/fakepath.dat')
+        ]
+        file_hashes = FileHash.get_supported_file_hashes(dds_hashes, '/tmp/data.txt')
         self.assertEqual(len(file_hashes), 2)
-        self.assertEqual(file_hashes[0].status, "FAILED")
-        self.assertEqual(file_hashes[0].expected_hash_value, "abc")
-        self.assertEqual(file_hashes[1].status, "OK")
-        self.assertEqual(file_hashes[1].expected_hash_value, "def")
+        self.assertEqual(file_hashes[0].expected_hash_value, 'def')
+        self.assertEqual(file_hashes[1].expected_hash_value, 'hij')
+
+    def test_separate_valid_and_failed_hashes(self):
+        valid_hash = Mock()
+        valid_hash.is_valid.return_value = True
+        failed_hash = Mock()
+        failed_hash.is_valid.return_value = False
+
+        valid_file_hashes, failed_file_hashes = FileHash.separate_valid_and_failed_hashes([failed_hash, valid_hash])
+
+        self.assertEqual(len(valid_file_hashes), 1)
+        self.assertEqual(valid_file_hashes[0], valid_hash)
+        self.assertEqual(len(failed_file_hashes), 1)
+        self.assertEqual(failed_file_hashes[0], failed_hash)
+
+
+class TestFileHashStatus(TestCase):
+    def setUp(self):
+        self.file_hash = FileHash(algorithm='md5', expected_hash_value='abc', file_path='/tmp/data.txt')
+        self.file_hash2 = FileHash(algorithm='md5', expected_hash_value='def', file_path='/tmp/data.txt')
+
+    def test_has_a_valid_hash(self):
+        file_hash_status = FileHashStatus(self.file_hash, status=FileHashStatus.STATUS_OK)
+        self.assertEqual(file_hash_status.has_a_valid_hash(), True)
+        file_hash_status.status = FileHashStatus.STATUS_CONFLICTED
+        self.assertEqual(file_hash_status.has_a_valid_hash(), True)
+        file_hash_status.status = FileHashStatus.STATUS_FAILED
+        self.assertEqual(file_hash_status.has_a_valid_hash(), False)
+
+    def test_get_status_line(self):
+        file_hash_status = FileHashStatus(self.file_hash, status=FileHashStatus.STATUS_OK)
+        self.assertEqual(file_hash_status.get_status_line(), '/tmp/data.txt abc md5 OK')
+        file_hash_status.status = FileHashStatus.STATUS_CONFLICTED
+        self.assertEqual(file_hash_status.get_status_line(), '/tmp/data.txt abc md5 CONFLICTED')
+        file_hash_status.status = FileHashStatus.STATUS_FAILED
+        self.assertEqual(file_hash_status.get_status_line(), '/tmp/data.txt abc md5 FAILED')
+
+    def test_raise_for_status(self):
+        file_hash_status = FileHashStatus(self.file_hash, status=FileHashStatus.STATUS_OK)
+        file_hash_status.raise_for_status()
+
+        file_hash_status.status = FileHashStatus.STATUS_CONFLICTED
+        file_hash_status.raise_for_status()
+
+        file_hash_status.status = FileHashStatus.STATUS_FAILED
+        with self.assertRaises(ValueError) as raised_exception:
+            file_hash_status.raise_for_status()
+        self.assertEqual(str(raised_exception.exception), 'Hash validation error: /tmp/data.txt abc md5 FAILED')
+
+    @patch('ddsc.core.download.FileHash')
+    def test_determine_for_hashes__no_hashes_found(self, mock_file_hash):
+        mock_file_hash.separate_valid_and_failed_hashes.return_value = [], []
+        dds_hashes = []
+        with self.assertRaises(ValueError) as raised_exception:
+            FileHashStatus.determine_for_hashes(dds_hashes, file_path='/tmp/fakepath.dat')
+        self.assertEqual(str(raised_exception.exception),
+                         'Unable to validate: No supported hashes found for file /tmp/fakepath.dat')
+        mock_file_hash.get_supported_file_hashes.assert_called_with(dds_hashes, '/tmp/fakepath.dat')
+        mock_file_hash.separate_valid_and_failed_hashes.assert_called_with(
+            mock_file_hash.get_supported_file_hashes.return_value
+        )
+
+    @patch('ddsc.core.download.FileHash')
+    def test_determine_for_hashes__only_valid_hashes(self, mock_file_hash):
+        mock_file_hash.separate_valid_and_failed_hashes.return_value = [self.file_hash, self.file_hash2], []
+        dds_hashes = [
+            {"algorithm": "md5", "value": "abc"},
+            {"algorithm": "md5", "value": "def"}
+        ]
+        file_hash_status = FileHashStatus.determine_for_hashes(dds_hashes, file_path='/tmp/fakepath.dat')
+        self.assertEqual(file_hash_status.status, FileHashStatus.STATUS_OK)
+        self.assertEqual(file_hash_status.file_hash, self.file_hash)
+
+    @patch('ddsc.core.download.FileHash')
+    def test_determine_for_hashes__only_failed_hashes(self, mock_file_hash):
+        mock_file_hash.separate_valid_and_failed_hashes.return_value = [], [self.file_hash, self.file_hash2]
+        dds_hashes = [
+            {"algorithm": "md5", "value": "abc"},
+            {"algorithm": "md5", "value": "def"}
+        ]
+        file_hash_status = FileHashStatus.determine_for_hashes(dds_hashes, file_path='/tmp/fakepath.dat')
+        self.assertEqual(file_hash_status.status, FileHashStatus.STATUS_FAILED)
+        self.assertEqual(file_hash_status.file_hash, self.file_hash)
+
+    @patch('ddsc.core.download.FileHash')
+    def test_determine_for_hashes__both_valid_and_failed_hashes(self, mock_file_hash):
+        mock_file_hash.separate_valid_and_failed_hashes.return_value = [self.file_hash], [self.file_hash2]
+        dds_hashes = [
+            {"algorithm": "md5", "value": "abc"},
+            {"algorithm": "md5", "value": "def"}
+        ]
+        file_hash_status = FileHashStatus.determine_for_hashes(dds_hashes, file_path='/tmp/fakepath.dat')
+        self.assertEqual(file_hash_status.status, FileHashStatus.STATUS_CONFLICTED)
+        self.assertEqual(file_hash_status.file_hash, self.file_hash)

--- a/ddsc/core/tests/test_download.py
+++ b/ddsc/core/tests/test_download.py
@@ -269,7 +269,21 @@ class TestProjectDownload(TestCase):
         downloader.check_downloaded_files([project_file])
         mock_print.assert_has_calls([
             call('All downloaded files have been verified successfully.'),
-            call(MISMATCHED_FILE_HASH_WARNING.format(1))
+            call(MISMATCHED_FILE_HASH_WARNING.format("1 file"))
+        ])
+
+    @patch('ddsc.core.download.HashUtil')
+    @patch('ddsc.core.download.print')
+    def test_check_downloaded_files_when_two_files_with_conflicted_hashes(self, mock_print, mock_hash_util):
+        project_file = ProjectFile(self.mock_file_json_data)
+        project_file.hashes = [{"algorithm": "md5", "value": "abc"}, {"algorithm": "md5", "value": "def"}]
+        mock_hash_util.return_value.hash.hexdigest.return_value = 'abc'
+
+        downloader = ProjectDownload(None, None, dest_directory='/tmp/data2/', path_filter=None)
+        downloader.check_downloaded_files([project_file, project_file])
+        mock_print.assert_has_calls([
+            call('All downloaded files have been verified successfully.'),
+            call(MISMATCHED_FILE_HASH_WARNING.format("2 files"))
         ])
 
 

--- a/ddsc/sdk/client.py
+++ b/ddsc/sdk/client.py
@@ -5,7 +5,7 @@ from ddsc.config import create_config
 from ddsc.core.remotestore import DOWNLOAD_FILE_CHUNK_SIZE, RemoteFile, ProjectFile, RemotePath
 from ddsc.core.fileuploader import FileUploadOperations, ParallelChunkProcessor, ParentData
 from ddsc.core.localstore import PathData
-from ddsc.core.download import FileHash, DownloadSettings, FileDownloader, FileToDownload
+from ddsc.core.download import FileHashStatus, DownloadSettings, FileDownloader, FileToDownload
 from ddsc.core.util import KindType, NoOpProgressPrinter, REMOTE_PATH_SEP
 from ddsc.core.moveutil import MoveUtil
 from future.utils import python_2_unicode_compatible
@@ -464,8 +464,8 @@ class File(BaseResponseItem):
         file_url_downloader = FileDownloader(settings, files_to_download)
         file_url_downloader.run()
 
-        file_hash = FileHash.create_for_best_hash(self.current_version['upload']['hashes'], path)
-        file_hash.raise_for_status()
+        file_hash_status = FileHashStatus.determine_for_hashes(self.current_version['upload']['hashes'], path)
+        file_hash_status.raise_for_status()
 
     def delete(self):
         """

--- a/ddsc/sdk/client.py
+++ b/ddsc/sdk/client.py
@@ -464,7 +464,7 @@ class File(BaseResponseItem):
         file_url_downloader = FileDownloader(settings, files_to_download)
         file_url_downloader.run()
 
-        file_hash = FileHash.create_for_first_supported_algorithm(self.current_version['upload']['hashes'], path)
+        file_hash = FileHash.create_for_best_hash(self.current_version['upload']['hashes'], path)
         file_hash.raise_for_status()
 
     def delete(self):

--- a/ddsc/sdk/tests/test_client.py
+++ b/ddsc/sdk/tests/test_client.py
@@ -595,9 +595,9 @@ class TestFile(TestCase):
     @patch('ddsc.sdk.client.FileToDownload')
     @patch('ddsc.sdk.client.DownloadSettings')
     @patch('ddsc.sdk.client.FileDownloader')
-    @patch('ddsc.sdk.client.FileHash')
-    def test_download_to_path(self, mock_file_hash, mock_file_downloader, mock_download_settings, mock_file_to_download,
-                              mock_project_file):
+    @patch('ddsc.sdk.client.FileHashStatus')
+    def test_download_to_path(self, mock_file_hash_status, mock_file_downloader, mock_download_settings,
+                              mock_file_to_download, mock_project_file):
         mock_dds_connection = Mock()
 
         file = File(mock_dds_connection, self.file_dict)
@@ -610,9 +610,9 @@ class TestFile(TestCase):
         mock_file_downloader.assert_called_with(mock_download_settings.return_value,
                                                 [mock_file_to_download.return_value])
         mock_file_downloader.return_value.run.assert_called_with()
-        mock_file_hash.create_for_best_hash.assert_called_with(
+        mock_file_hash_status.determine_for_hashes.assert_called_with(
             [{'algorithm': 'md5', 'value': 'abcd'}], "/tmp/data.dat")
-        mock_file_hash.create_for_best_hash.return_value.raise_for_status.assert_called_with()
+        mock_file_hash_status.determine_for_hashes.return_value.raise_for_status.assert_called_with()
 
     def test_delete(self):
         mock_dds_connection = Mock()

--- a/ddsc/sdk/tests/test_client.py
+++ b/ddsc/sdk/tests/test_client.py
@@ -610,9 +610,9 @@ class TestFile(TestCase):
         mock_file_downloader.assert_called_with(mock_download_settings.return_value,
                                                 [mock_file_to_download.return_value])
         mock_file_downloader.return_value.run.assert_called_with()
-        mock_file_hash.create_for_first_supported_algorithm.assert_called_with(
+        mock_file_hash.create_for_best_hash.assert_called_with(
             [{'algorithm': 'md5', 'value': 'abcd'}], "/tmp/data.dat")
-        mock_file_hash.create_for_first_supported_algorithm.return_value.raise_for_status.assert_called_with()
+        mock_file_hash.create_for_best_hash.return_value.raise_for_status.assert_called_with()
 
     def test_delete(self):
         mock_dds_connection = Mock()


### PR DESCRIPTION
Adds support to check all known hashes attached to a file when downloading. Before this change DukeDSClient only checked the first MD5 hashes found. DukeDSClient will now validate all MD5 hashes. Files that have both valid and invalid hashes will have status CONFLICTED. If there are CONFLICTED files a warning will be printed but no error raised. If there are any FAILED hashes an error will be raised.

Example terminal output after downloading a project with a conflicted file:
```
...
Verifying contents of 2 downloaded files using file hashes.
mh/me.jpeg 0106a7dcf3ab09bc47cab34a7ff1fbba md5 OK
mh/stuff.txt 7e11867261e621458a06f3e6bc301c8b md5 CONFLICTED
All downloaded files have at least one valid hash.

WARNING: Some downloaded files also have invalid hashes.

```

Example project in DukeDS dev that has multiple checksums: https://dev.dataservice.duke.edu/#/project/cfa04bfd-c025-4025-8153-b058d0893a12
The file in the above project has an additional wrong checksum added via the [PUT /api/v1/uploads/{id}/hashes](
https://apidev.dataservice.duke.edu/apiexplorer#!/uploads/putApiV1UploadsIdHashes) DukeDS API.


## Background
There was a bug in the DukeDS web portal where [large files uploaded had an incorrect hash]( https://github.com/Duke-Translational-Bioinformatics/duke-data-service-portal/issues/901).
A project was created to [add the correct hash to these files](https://github.com/Duke-Translational-Bioinformatics/md5_reporter). This leaves the incorrect hash in the database for these files.

Fixes #256
