### PR TITLE
add command to show project info/size

### DIFF
--- a/ddsc/cmdparser.py
+++ b/ddsc/cmdparser.py
@@ -497,6 +497,16 @@ class CommandParser(object):
                             help='remote path specifying where to move the file/folder to')
         parser.set_defaults(func=move_func)
 
+    def register_size_command(self, size_func):
+        """
+        Add 'size' command to get the size of a remote project.
+        :param size_func: function: run when user choses this option.
+        """
+        description = "Print the size of a project."
+        parser = self.subparsers.add_parser('size', description=description)
+        add_project_name_or_id_arg(parser, help_text_suffix="to show the size of")
+        parser.set_defaults(func=size_func)
+
     def run_command(self, args):
         """
         Parse command line arguments and run function registered for the appropriate command.

--- a/ddsc/cmdparser.py
+++ b/ddsc/cmdparser.py
@@ -497,15 +497,15 @@ class CommandParser(object):
                             help='remote path specifying where to move the file/folder to')
         parser.set_defaults(func=move_func)
 
-    def register_size_command(self, size_func):
+    def register_info_command(self, info_func):
         """
-        Add 'size' command to get the size of a remote project.
-        :param size_func: function: run when user choses this option.
+        Add 'info' command to get details of a remote project.
+        :param info_func: function: run when user choses this option.
         """
-        description = "Print the size of a project."
-        parser = self.subparsers.add_parser('size', description=description)
-        add_project_name_or_id_arg(parser, help_text_suffix="to show the size of")
-        parser.set_defaults(func=size_func)
+        description = "Print information about a project."
+        parser = self.subparsers.add_parser('info', description=description)
+        add_project_name_or_id_arg(parser, help_text_suffix="to show the information about")
+        parser.set_defaults(func=info_func)
 
     def run_command(self, args):
         """

--- a/ddsc/core/ddsapi.py
+++ b/ddsc/core/ddsapi.py
@@ -1109,6 +1109,7 @@ class DataServiceApi(object):
     def portal_url(self, project_id):
         return 'https://{}/#/project/{}'.format(self.auth.config.get_portal_url_base(), project_id)
 
+
 class MultiJSONResponse(object):
     """
     Wraps up multiple requests.Response objects into an object that will return composite dictionary for json() method.

--- a/ddsc/core/ddsapi.py
+++ b/ddsc/core/ddsapi.py
@@ -1107,6 +1107,11 @@ class DataServiceApi(object):
         print(msg)
 
     def portal_url(self, project_id):
+        """
+        Return a url to the DukeDS web portal for the specified project id.
+        :param project_id: str: uuid of the project to create a url for
+        :return: str: url to web portal
+        """
         return 'https://{}/#/project/{}'.format(self.auth.config.get_portal_url_base(), project_id)
 
 

--- a/ddsc/core/ddsapi.py
+++ b/ddsc/core/ddsapi.py
@@ -1106,6 +1106,8 @@ class DataServiceApi(object):
     def set_status_message(self, msg):
         print(msg)
 
+    def portal_url(self, project_id):
+        return 'https://{}/#/project/{}'.format(self.auth.config.get_portal_url_base(), project_id)
 
 class MultiJSONResponse(object):
     """

--- a/ddsc/core/tests/test_ddsapi.py
+++ b/ddsc/core/tests/test_ddsapi.py
@@ -830,6 +830,16 @@ class TestDataServiceApi(TestCase):
         api.set_status_message('Connection error')
         mock_print.assert_called_with('Connection error')
 
+    def test_portal_url(self):
+        mock_requests = MagicMock()
+        mock_auth = self.create_mock_auth(config_page_size=100)
+        mock_auth.config.get_portal_url_base.return_value = 'dataservice.duke.edu'
+        api = DataServiceApi(auth=mock_auth,
+                             url="something.com/v1",
+                             http=mock_requests)
+        url = api.portal_url('abc123')
+        self.assertEqual(url, 'https://dataservice.duke.edu/#/project/abc123')
+
 
 class TestDataServiceAuth(TestCase):
     @patch('ddsc.core.ddsapi.get_user_agent_str')

--- a/ddsc/core/tests/test_upload.py
+++ b/ddsc/core/tests/test_upload.py
@@ -52,6 +52,5 @@ class TestProjectUpload(TestCase):
     def test_get_url_msg(self, mock_local_project, mock_remote_store):
         project_upload = ProjectUpload(config=Mock(), project_name_or_id=Mock(), folders=Mock(),
                                        follow_symlinks=False, file_upload_post_processor=None)
-        project_upload.local_project = Mock(remote_id='123')
-        project_upload.config.get_portal_url_base.return_value = '127.0.0.1'
+        mock_remote_store.return_value.data_service.portal_url.return_value = 'https://127.0.0.1/#/project/123'
         self.assertEqual(project_upload.get_url_msg(), 'URL to view project: https://127.0.0.1/#/project/123')

--- a/ddsc/core/tests/test_util.py
+++ b/ddsc/core/tests/test_util.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 
-from ddsc.core.util import verify_terminal_encoding, ProgressBar, ProgressPrinter, KindType, RemotePath
+from ddsc.core.util import verify_terminal_encoding, ProgressBar, ProgressPrinter, KindType, RemotePath, humanize_bytes
 from mock import patch, Mock
 
 
@@ -186,3 +186,18 @@ class TestRemotePath(TestCase):
         self.assertEqual(RemotePath.split('/data'), ['data'])
         self.assertEqual(RemotePath.split('/data/file1.txt'), ['data', 'file1.txt'])
         self.assertEqual(RemotePath.split('/data/other/file1.txt'), ['data', 'other', 'file1.txt'])
+
+
+class TestHumanizeBytes(TestCase):
+    def test_humanize_bytes(self):
+        vals = [
+            (1, "1 B"),
+            (1023, "1023 B"),
+            (1024, "1 KiB"),
+            (1536, "1.5 KiB"),
+            (1024 ** 2, "1 MiB"),
+            (1024 ** 3, "1 GiB"),
+            (1024 ** 4, "1024 GiB"),
+        ]
+        for input_val, expected_result in vals:
+            self.assertEqual(humanize_bytes(input_val), expected_result)

--- a/ddsc/core/tests/test_util.py
+++ b/ddsc/core/tests/test_util.py
@@ -1,6 +1,7 @@
 from unittest import TestCase
 
-from ddsc.core.util import verify_terminal_encoding, ProgressBar, ProgressPrinter, KindType, RemotePath, humanize_bytes
+from ddsc.core.util import verify_terminal_encoding, ProgressBar, ProgressPrinter, KindType, RemotePath, humanize_bytes,\
+    plural_fmt
 from mock import patch, Mock
 
 
@@ -201,3 +202,13 @@ class TestHumanizeBytes(TestCase):
         ]
         for input_val, expected_result in vals:
             self.assertEqual(humanize_bytes(input_val), expected_result)
+
+
+class TestPluralFmt(TestCase):
+    def test_plural_fmt(self):
+        self.assertEqual(plural_fmt("taco", 1), "1 taco")
+        self.assertEqual(plural_fmt("taco", 2), "2 tacos")
+        self.assertEqual(plural_fmt("folder", 0), "0 folders")
+        self.assertEqual(plural_fmt("folder", 1), "1 folder")
+        self.assertEqual(plural_fmt("folder", 2), "2 folders")
+        self.assertEqual(plural_fmt("folder", 3), "3 folders")

--- a/ddsc/core/upload.py
+++ b/ddsc/core/upload.py
@@ -1,7 +1,7 @@
 import datetime
 from ddsc.core.localstore import LocalProject
 from ddsc.core.remotestore import RemoteStore
-from ddsc.core.util import ProgressPrinter, ProjectWalker
+from ddsc.core.util import ProgressPrinter, ProjectWalker, plural_fmt
 from ddsc.core.projectuploader import UploadSettings, ProjectUploader, ProjectUploadDryRun
 
 
@@ -165,22 +165,11 @@ class LocalOnlyCounter(object):
         Return a string representing the totals contained herein.
         :return: str counts/types string
         """
-        return '{}, {}, {}'.format(LocalOnlyCounter.plural_fmt('project', self.projects),
-                                   LocalOnlyCounter.plural_fmt('folder', self.folders),
-                                   LocalOnlyCounter.plural_fmt('file', self.files))
+        return '{}, {}, {}'.format(plural_fmt('project', self.projects),
+                                   plural_fmt('folder', self.folders),
+                                   plural_fmt('file', self.files))
 
-    @staticmethod
-    def plural_fmt(name, cnt):
-        """
-        pluralize name if necessary and combine with cnt
-        :param name: str name of the item type
-        :param cnt: int number items of this type
-        :return: str name and cnt joined
-        """
-        if cnt == 1:
-            return '{} {}'.format(cnt, name)
-        else:
-            return '{} {}s'.format(cnt, name)
+
 
 
 class UploadReport(object):

--- a/ddsc/core/upload.py
+++ b/ddsc/core/upload.py
@@ -103,7 +103,7 @@ class ProjectUpload(object):
         """
         msg = 'URL to view project'
         project_id = self.local_project.remote_id
-        url = '{}: https://{}/#/project/{}'.format(msg, self.config.get_portal_url_base(), project_id)
+        url = '{}: {}'.format(msg, self.remote_store.data_service.portal_url(project_id))
         return url
 
 

--- a/ddsc/core/upload.py
+++ b/ddsc/core/upload.py
@@ -170,8 +170,6 @@ class LocalOnlyCounter(object):
                                    plural_fmt('file', self.files))
 
 
-
-
 class UploadReport(object):
     """
     Creates a text report of items that were sent to the remote store.

--- a/ddsc/core/util.py
+++ b/ddsc/core/util.py
@@ -397,6 +397,11 @@ class RemotePath(object):
 
 
 def humanize_bytes(num_bytes):
+    """
+    Convert a number of bytes to human version
+    :param num_bytes: int: bytes to be converted to
+    :return: str
+    """
     val = num_bytes
     suffix = "B"
     if val >= 1024:

--- a/ddsc/core/util.py
+++ b/ddsc/core/util.py
@@ -410,3 +410,16 @@ def humanize_bytes(num_bytes):
         suffix = "GiB"
     val = "{:0.1f} {}".format(val, suffix)
     return val.replace(".0", "")
+
+
+def plural_fmt(name, cnt):
+    """
+    pluralize name if necessary and combine with cnt
+    :param name: str name of the item type
+    :param cnt: int number items of this type
+    :return: str name and cnt joined
+    """
+    if cnt == 1:
+        return '{} {}'.format(cnt, name)
+    else:
+        return '{} {}s'.format(cnt, name)

--- a/ddsc/core/util.py
+++ b/ddsc/core/util.py
@@ -394,3 +394,19 @@ class RemotePath(object):
     def split(remote_path):
         remote_path_no_leading_slash = RemotePath.strip_leading_slash(remote_path)
         return remote_path_no_leading_slash.split(REMOTE_PATH_SEP)
+
+
+def humanize_bytes(num_bytes):
+    val = num_bytes
+    suffix = "B"
+    if val >= 1024:
+        val = val / 1024
+        suffix = "KiB"
+    if val >= 1024:
+        val = val / 1024
+        suffix = "MiB"
+    if val >= 1024:
+        val = val / 1024
+        suffix = "GiB"
+    val = "{:0.1f} {}".format(val, suffix)
+    return val.replace(".0", "")

--- a/ddsc/ddsclient.py
+++ b/ddsc/ddsclient.py
@@ -9,7 +9,7 @@ from ddsc.core.remotestore import RemoteStore, RemoteAuthRole, ProjectNameOrId
 from ddsc.core.upload import ProjectUpload
 from ddsc.cmdparser import CommandParser, format_destination_path, replace_invalid_path_chars
 from ddsc.core.download import ProjectDownload
-from ddsc.core.util import ProjectDetailsList, verify_terminal_encoding
+from ddsc.core.util import ProjectDetailsList, verify_terminal_encoding, humanize_bytes
 from ddsc.core.pathfilter import PathFilter
 from ddsc.versioncheck import check_version, VersionException, get_internal_version_str
 from ddsc.config import create_config
@@ -50,6 +50,7 @@ class DDSClient(object):
         parser.register_delete_command(self._setup_run_command(DeleteCommand))
         parser.register_list_auth_roles_command(self._setup_run_command(ListAuthRolesCommand))
         parser.register_move_command(self._setup_run_command(MoveCommand))
+        parser.register_size_command(self._setup_run_command(SizeCommand))
         return parser
 
     def _setup_run_command(self, command_constructor):
@@ -480,6 +481,16 @@ class MoveCommand(ClientCommand):
         """
         project = self.get_project_by_name_or_id(args)
         project.move_file_or_folder(args.source_remote_path, args.target_remote_path)
+
+
+class SizeCommand(ClientCommand):
+    """
+    Prints size of a project in a human readable format.
+    """
+    def run(self, args):
+        project = self.get_project_by_name_or_id(args)
+        total_bytes = sum([f.current_version['upload']['size'] for f in project.get_all_files()])
+        print(humanize_bytes(total_bytes))
 
 
 def boolean_input_prompt(message):

--- a/ddsc/ddsclient.py
+++ b/ddsc/ddsclient.py
@@ -9,7 +9,7 @@ from ddsc.core.remotestore import RemoteStore, RemoteAuthRole, ProjectNameOrId
 from ddsc.core.upload import ProjectUpload
 from ddsc.cmdparser import CommandParser, format_destination_path, replace_invalid_path_chars
 from ddsc.core.download import ProjectDownload
-from ddsc.core.util import ProjectDetailsList, verify_terminal_encoding, humanize_bytes
+from ddsc.core.util import ProjectDetailsList, verify_terminal_encoding
 from ddsc.core.pathfilter import PathFilter
 from ddsc.versioncheck import check_version, VersionException, get_internal_version_str
 from ddsc.config import create_config

--- a/ddsc/ddsclient.py
+++ b/ddsc/ddsclient.py
@@ -50,7 +50,7 @@ class DDSClient(object):
         parser.register_delete_command(self._setup_run_command(DeleteCommand))
         parser.register_list_auth_roles_command(self._setup_run_command(ListAuthRolesCommand))
         parser.register_move_command(self._setup_run_command(MoveCommand))
-        parser.register_size_command(self._setup_run_command(SizeCommand))
+        parser.register_info_command(self._setup_run_command(InfoCommand))
         return parser
 
     def _setup_run_command(self, command_constructor):
@@ -483,14 +483,19 @@ class MoveCommand(ClientCommand):
         project.move_file_or_folder(args.source_remote_path, args.target_remote_path)
 
 
-class SizeCommand(ClientCommand):
+class InfoCommand(ClientCommand):
     """
-    Prints size of a project in a human readable format.
+    Prints information about a project.
     """
     def run(self, args):
         project = self.get_project_by_name_or_id(args)
-        total_bytes = sum([f.current_version['upload']['size'] for f in project.get_all_files()])
-        print(humanize_bytes(total_bytes))
+        summary = project.get_summary()
+        print()
+        print("Name: {}".format(project.name))
+        print("ID: {}".format(project.id))
+        print("URL: {}".format(project.portal_url()))
+        print("Size: {}".format(summary))
+        print()
 
 
 def boolean_input_prompt(message):

--- a/ddsc/sdk/client.py
+++ b/ddsc/sdk/client.py
@@ -372,14 +372,6 @@ class Project(BaseResponseItem):
         move_util = MoveUtil(self, source_remote_path, target_remote_path)
         return move_util.run()
 
-    def get_paths_to_files(self):
-        path_to_nodes = PathToFiles()
-        path_to_nodes.add_paths_for_children_of_node(self)
-        return path_to_nodes.paths
-
-    def get_all_files(self):
-        return self.get_paths_to_files().values()
-
     def delete(self):
         """
         Delete this project and it's children.

--- a/ddsc/sdk/client.py
+++ b/ddsc/sdk/client.py
@@ -372,6 +372,14 @@ class Project(BaseResponseItem):
         move_util = MoveUtil(self, source_remote_path, target_remote_path)
         return move_util.run()
 
+    def get_paths_to_files(self):
+        path_to_nodes = PathToFiles()
+        path_to_nodes.add_paths_for_children_of_node(self)
+        return path_to_nodes.paths
+
+    def get_all_files(self):
+        return self.get_paths_to_files().values()
+
     def delete(self):
         """
         Delete this project and it's children.

--- a/ddsc/tests/test_cmdparser.py
+++ b/ddsc/tests/test_cmdparser.py
@@ -196,6 +196,13 @@ class TestCommandParser(TestCase):
         self.assertEqual('/data/file1.txt', self.parsed_args.source_remote_path)
         self.assertEqual('/data/file1_bak.txt', self.parsed_args.target_remote_path)
 
+    def test_register_size_command(self):
+        command_parser = CommandParser(version_str='1.0')
+        command_parser.register_size_command(self.set_parsed_args)
+        self.assertEqual(['size'], list(command_parser.subparsers.choices.keys()))
+        command_parser.run_command(['size', '-p', 'mouse'])
+        self.assertEqual('mouse', self.parsed_args.project_name)
+
     @patch("ddsc.cmdparser.os")
     def test_format_destination_path_ok_when_dir_empty(self, mock_os):
         mock_os.path.exists.return_value = True

--- a/ddsc/tests/test_cmdparser.py
+++ b/ddsc/tests/test_cmdparser.py
@@ -196,11 +196,11 @@ class TestCommandParser(TestCase):
         self.assertEqual('/data/file1.txt', self.parsed_args.source_remote_path)
         self.assertEqual('/data/file1_bak.txt', self.parsed_args.target_remote_path)
 
-    def test_register_size_command(self):
+    def test_register_info_command(self):
         command_parser = CommandParser(version_str='1.0')
-        command_parser.register_size_command(self.set_parsed_args)
-        self.assertEqual(['size'], list(command_parser.subparsers.choices.keys()))
-        command_parser.run_command(['size', '-p', 'mouse'])
+        command_parser.register_info_command(self.set_parsed_args)
+        self.assertEqual(['info'], list(command_parser.subparsers.choices.keys()))
+        command_parser.run_command(['info', '-p', 'mouse'])
         self.assertEqual('mouse', self.parsed_args.project_name)
 
     @patch("ddsc.cmdparser.os")

--- a/ddsc/tests/test_ddsclient.py
+++ b/ddsc/tests/test_ddsclient.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 from unittest import TestCase
 from ddsc.ddsclient import BaseCommand, UploadCommand, ListCommand, DownloadCommand, ClientCommand, MoveCommand
-from ddsc.ddsclient import ShareCommand, DeliverCommand, SizeCommand, read_argument_file_contents
+from ddsc.ddsclient import ShareCommand, DeliverCommand, InfoCommand, read_argument_file_contents
 from mock import patch, MagicMock, Mock, call
 
 
@@ -349,14 +349,22 @@ class TestMoveCommand(TestCase):
         mock_project.move_file_or_folder.assert_called_with('/data/file1.txt', '/data/file1.sv.txt')
 
 
-class TestSizeCommand(TestCase):
+class TestInfoCommand(TestCase):
     @patch('ddsc.ddsclient.Client')
     @patch('ddsc.ddsclient.print')
     def test_run(self, mock_print, mock_client):
         mock_project = mock_client.return_value.get_project_by_name.return_value
-        mock_file = Mock()
-        mock_file.current_version = {'upload': {'size': 3 * 1024}}
-        mock_project.get_all_files.return_value = [mock_file]
-        size_command = SizeCommand(config=Mock())
+        mock_project.name = "Mouse"
+        mock_project.id = "1234"
+        mock_project.portal_url.return_value = "someurl"
+        mock_project.get_summary.return_value = '3 top level folders, 0 subfolders, 1 file (12 KiB)'
+        size_command = InfoCommand(config=Mock())
         size_command.run(Mock(project_name='mouse'))
-        mock_print.assert_called_with("3 KiB")
+        mock_print.assert_has_calls([
+            call(),
+            call("Name: Mouse"),
+            call("ID: 1234"),
+            call("URL: someurl"),
+            call("Size: 3 top level folders, 0 subfolders, 1 file (12 KiB)"),
+            call(),
+        ])

--- a/ddsc/tests/test_ddsclient.py
+++ b/ddsc/tests/test_ddsclient.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 from unittest import TestCase
 from ddsc.ddsclient import BaseCommand, UploadCommand, ListCommand, DownloadCommand, ClientCommand, MoveCommand
-from ddsc.ddsclient import ShareCommand, DeliverCommand, read_argument_file_contents
+from ddsc.ddsclient import ShareCommand, DeliverCommand, SizeCommand, read_argument_file_contents
 from mock import patch, MagicMock, Mock, call
 
 
@@ -347,3 +347,16 @@ class TestMoveCommand(TestCase):
                               target_remote_path='/data/file1.sv.txt'))
         mock_project = mock_client.return_value.get_project_by_name.return_value
         mock_project.move_file_or_folder.assert_called_with('/data/file1.txt', '/data/file1.sv.txt')
+
+
+class TestSizeCommand(TestCase):
+    @patch('ddsc.ddsclient.Client')
+    @patch('ddsc.ddsclient.print')
+    def test_run(self, mock_print, mock_client):
+        mock_project = mock_client.return_value.get_project_by_name.return_value
+        mock_file = Mock()
+        mock_file.current_version = {'upload': {'size': 3 * 1024}}
+        mock_project.get_all_files.return_value = [mock_file]
+        size_command = SizeCommand(config=Mock())
+        size_command.run(Mock(project_name='mouse'))
+        mock_print.assert_called_with("3 KiB")


### PR DESCRIPTION
Adds `info` command to the cli.
This command can be run like so: `ddsclient info -p <ProjectName>`.
This command prints out project Name, ID, Web Portal URL, and Size information.
Size information includes folder/file counts and total file size.
This is patterned after [project data displayed within datadelivery](https://github.com/Duke-GCB/datadelivery-ui/blob/master/app/templates/components/project-detail.hbs).

These changes may be able to simplify the [D4S2 DDSProjectSummary class](https://github.com/Duke-GCB/D4S2/blob/c8b06dfa72f0225a943f2e2c7a6e64bbc50f81a3/switchboard/dds_util.py#L206)

Supporting changes
- Moves `portal_url` method from `ddsc/core/upload.py` to `ddsc/core/ddsapi.py`.
- Moves `plural_fmt` method from `ddsc/core/upload.py` to `ddsc/core/util.py`.
- Adds `humanize_bytes` to `ddsc/core/util.py`.

