### PR TITLE
fix delivery copy error

### DIFF
--- a/ddsc/core/d4s2.py
+++ b/ddsc/core/d4s2.py
@@ -12,7 +12,7 @@ from ddsc.core.download import ProjectDownload
 from ddsc.core.ddsapi import DataServiceAuth
 from ddsc.core.util import KindType
 from ddsc.versioncheck import get_internal_version_str
-from ddsc.core.remotestore import ProjectNameOrId
+from ddsc.core.remotestore import ProjectNameOrId, RemotePath
 
 UNAUTHORIZED_MESSAGE = """
 ERROR: Your account does not have authorization for D4S2 (the deliver/share service).
@@ -480,5 +480,5 @@ class UploadedFileRelations(object):
         name_parts = [ancestor['name'] for ancestor in file_details['ancestors']
                       if ancestor['kind'] == KindType.folder_str]
         name_parts.append(file_details['name'])
-        remote_path = os.sep.join(name_parts)
+        remote_path = RemotePath.add_leading_slash(os.sep.join(name_parts))
         return self.activity.remote_path_to_file_version_id[remote_path]

--- a/ddsc/core/tests/test_d4s2.py
+++ b/ddsc/core/tests/test_d4s2.py
@@ -196,7 +196,7 @@ class TestUploadedFileRelations(TestCase):
         new_activity_id = '2'
         download_file_version_id = '32'
         upload_file_version_id = '33'
-        file_remote_path = 'data/results/seq1.fasta'
+        file_remote_path = '/data/results/seq1.fasta'
         file_details = {
             'name': 'seq1.fasta',
             'current_version': {


### PR DESCRIPTION
Changes made previously require a leading slash for all DDS remote paths.
The logic that creates a file relation between copied files did not include a leading slash.
Changes here add the leading slash so the file ID can be looked up.

Fixes #269