### PR TITLE
Faster upload resume

### DIFF
--- a/ddsc/core/d4s2.py
+++ b/ddsc/core/d4s2.py
@@ -372,10 +372,12 @@ class D4S2Project(object):
         :param temp_directory: str path to directory who's files we will upload
         """
         self.print_func("Uploading to '{}'.".format(project_name))
-        items_to_send = [os.path.join(temp_directory, item) for item in os.listdir(os.path.abspath(temp_directory))]
+        paths_to_send = [os.path.join(temp_directory, item) for item in os.listdir(os.path.abspath(temp_directory))]
         project_name_or_id = ProjectNameOrId.create_from_name(project_name)
-        project_upload = ProjectUpload(self.config, project_name_or_id, items_to_send,
-                                       file_upload_post_processor=UploadedFileRelations(activity))
+
+        project_upload = ProjectUpload.create_for_paths(self.config, self.remote_store, project_name_or_id,
+                                                        paths_to_send,
+                                                        file_upload_post_processor=UploadedFileRelations(activity))
         project_upload.run()
 
     def _is_current_user(self, some_user):

--- a/ddsc/core/localstore.py
+++ b/ddsc/core/localstore.py
@@ -202,6 +202,8 @@ class LocalFile(object):
         self.size = self.path_data.size()
         self.mimetype = self.path_data.mime_type()
         self.remote_id = ''
+        self.remote_file_hash_alg = None
+        self.remote_file_hash = None
         self.is_file = True
         self.kind = KindType.file_str
         self.sent_to_remote = False
@@ -225,6 +227,16 @@ class LocalFile(object):
         :param remote_file: RemoteFile remote data pull remote_id from
         """
         self.remote_id = remote_file.id
+        self.remote_file_hash_alg = remote_file.hash_alg
+        self.remote_file_hash = remote_file.file_hash
+
+    def calculate_local_hash(self):
+        return self.path_data.get_hash()
+
+    def hash_matches_remote(self, hash_data):
+        if self.remote_file_hash and self.remote_file_hash_alg:
+            return hash_data.matches(self.remote_file_hash_alg, self.remote_file_hash)
+        return False
 
     def set_remote_id_after_send(self, remote_id):
         """

--- a/ddsc/core/localstore.py
+++ b/ddsc/core/localstore.py
@@ -201,7 +201,6 @@ class LocalFile(object):
         self.name = self.path_data.name()
         self.size = self.path_data.size()
         self.mimetype = self.path_data.mime_type()
-        self.need_to_send = True
         self.remote_id = ''
         self.is_file = True
         self.kind = KindType.file_str
@@ -222,13 +221,10 @@ class LocalFile(object):
 
     def update_remote_ids(self, remote_file):
         """
-        Based on a remote file try to assign a remote_id and compare hash info.
+        Based on a remote file try to assign a remote_id
         :param remote_file: RemoteFile remote data pull remote_id from
         """
         self.remote_id = remote_file.id
-        hash_data = self.path_data.get_hash()
-        if hash_data.matches(remote_file.hash_alg, remote_file.file_hash):
-            self.need_to_send = False
 
     def set_remote_id_after_send(self, remote_id):
         """

--- a/ddsc/core/localstore.py
+++ b/ddsc/core/localstore.py
@@ -347,13 +347,15 @@ class LocalFile(object):
             return hash_data.matches(self.remote_file_hash_alg, self.remote_file_hash)
         return False
 
-    def set_remote_id_after_send(self, remote_id):
+    def set_remote_values_after_send(self, remote_id, remote_hash_alg, remote_file_hash):
         """
         Set remote_id to specific value after this file has been sent to remote store.
         :param remote_id: str uuid of the file in the remote store
         """
         self.sent_to_remote = True
         self.remote_id = remote_id
+        self.remote_file_hash_alg = remote_hash_alg
+        self.remote_file_hash = remote_file_hash
 
     def count_chunks(self, bytes_per_chunk):
         """

--- a/ddsc/core/projectuploader.py
+++ b/ddsc/core/projectuploader.py
@@ -194,7 +194,7 @@ class ProjectUploader(object):
         """
         num_chunks = ParallelChunkProcessor.determine_num_chunks(self.settings.config.upload_bytes_per_chunk,
                                                                  local_file.size)
-        self.settings.watcher.transferring_item(local_file, increment_amt=num_chunks)
+        self.settings.watcher.increment_progress(num_chunks)
 
 
 class SmallItemUploadTaskBuilder(object):

--- a/ddsc/core/projectuploader.py
+++ b/ddsc/core/projectuploader.py
@@ -435,7 +435,9 @@ class ProjectUploadDryRun(object):
         :param item: object: project, folder or file we will add to upload_items if necessary.
         """
         if item.kind == KindType.file_str:
-            self.add_upload_item(item.path)
+            hash_data = item.calculate_local_hash()
+            if not item.hash_matches_remote(hash_data):
+                self.add_upload_item(item.path)
         else:
             if item.kind == KindType.project_str:
                 pass

--- a/ddsc/core/projectuploader.py
+++ b/ddsc/core/projectuploader.py
@@ -375,7 +375,7 @@ class CreateSmallFileCommand(object):
         parent_data = ParentData(self.parent.kind, self.parent.remote_id)
         path_data = self.local_file.get_path_data()
         params = parent_data, path_data, self.local_file.remote_id, self.local_file.remote_file_hash_alg, \
-                 self.local_file.remote_file_hash
+            self.local_file.remote_file_hash
 
         return UploadContext(self.settings, params, message_queue, task_id)
 

--- a/ddsc/core/projectuploader.py
+++ b/ddsc/core/projectuploader.py
@@ -1,6 +1,6 @@
 from ddsc.core.util import ProjectWalker, KindType
 from ddsc.core.ddsapi import DataServiceAuth, DataServiceApi
-from ddsc.core.fileuploader import FileUploader, FileUploadOperations, ParentData
+from ddsc.core.fileuploader import FileUploader, FileUploadOperations, ParentData, ParallelChunkProcessor
 from ddsc.core.parallel import TaskExecutor, TaskRunner
 
 
@@ -172,7 +172,9 @@ class ProjectUploader(object):
         Updates progress bar for a file that was already uploaded
         :param local_file: LocalFile
         """
-        self.settings.watcher.transferring_item(local_file, increment_amt=local_file.size)
+        num_chunks = ParallelChunkProcessor.determine_num_chunks(self.settings.config.upload_bytes_per_chunk,
+                                                                 local_file.size)
+        self.settings.watcher.transferring_item(local_file, increment_amt=num_chunks)
 
 
 class SmallItemUploadTaskBuilder(object):

--- a/ddsc/core/projectuploader.py
+++ b/ddsc/core/projectuploader.py
@@ -167,11 +167,12 @@ class ProjectUploader(object):
         Upload files that were too large.
         """
         for local_file, parent in self.large_files:
-
+            self.settings.watcher.transferring_item(local_file, increment_amt=0, override_msg_verb='checking')
             hash_data = local_file.calculate_local_hash()
             if local_file.hash_matches_remote(hash_data):
                 self.file_already_uploaded(local_file)
             else:
+                self.settings.watcher.transferring_item(local_file, increment_amt=0)
                 self.process_large_file(local_file, parent, hash_data)
 
     def process_large_file(self, local_file, parent, hash_data):
@@ -385,7 +386,8 @@ class CreateSmallFileCommand(object):
         self.file_upload_post_processor = file_upload_post_processor
 
     def before_run(self, parent_task_result):
-        pass
+        # Update progress bar so this filename will be shown
+        self.settings.watcher.transferring_item(self.local_file, increment_amt=0)
 
     def create_context(self, message_queue, task_id):
         """

--- a/ddsc/core/projectuploader.py
+++ b/ddsc/core/projectuploader.py
@@ -434,13 +434,14 @@ class ProjectUploadDryRun(object):
     Recursively visits children of the project passed to run.
     Builds a list of the names of folders/files that need to be uploaded.
     """
-    def __init__(self):
+    def __init__(self, local_project):
         self.upload_items = []
+        self._run(local_project)
 
     def add_upload_item(self, name):
         self.upload_items.append(name)
 
-    def run(self, local_project):
+    def _run(self, local_project):
         """
         Appends file/folder paths to upload_items based on the contents of this project that need to be uploaded.
         :param local_project: LocalProject: project we will build the list for
@@ -464,3 +465,18 @@ class ProjectUploadDryRun(object):
                     self.add_upload_item(item.path)
             for child in item.children:
                 self._visit_recur(child)
+
+    def get_report(self):
+        """
+        Returns text displaying the items that need to be uploaded or a message saying there are no files/folders
+        to upload.
+        :return: str: report text
+        """
+        if not self.upload_items:
+            return "\n\nNo changes found. Nothing needs to be uploaded.\n\n"
+        else:
+            result = "\n\nFiles/Folders that need to be uploaded:\n"
+            for item in self.upload_items:
+                result += "{}\n".format(item)
+            result += "\n"
+            return result

--- a/ddsc/core/projectuploader.py
+++ b/ddsc/core/projectuploader.py
@@ -149,8 +149,7 @@ class ProjectUploader(object):
         Upload files that were too large.
         """
         for local_file, parent in self.large_items:
-            if local_file.need_to_send:
-                self.process_large_file(local_file, parent)
+            self.process_large_file(local_file, parent)
 
     def process_large_file(self, local_file, parent):
         """
@@ -206,14 +205,13 @@ class SmallItemUploadTaskBuilder(object):
         If file is small add create small file command otherwise raise error.
         Large files shouldn't be passed to SmallItemUploadTaskBuilder.
         """
-        if item.need_to_send:
-            if item.size > self.settings.config.upload_bytes_per_chunk:
-                msg = "Programmer Error: Trying to upload large file as small item size:{} name:{}"
-                raise ValueError(msg.format(item.size, item.name))
-            else:
-                command = CreateSmallFileCommand(self.settings, item, parent,
-                                                 self.settings.file_upload_post_processor)
-                self.task_runner_add(parent, item, command)
+        if item.size > self.settings.config.upload_bytes_per_chunk:
+            msg = "Programmer Error: Trying to upload large file as small item size:{} name:{}"
+            raise ValueError(msg.format(item.size, item.name))
+        else:
+            command = CreateSmallFileCommand(self.settings, item, parent,
+                                             self.settings.file_upload_post_processor)
+            self.task_runner_add(parent, item, command)
 
     def task_runner_add(self, parent, item, command):
         """

--- a/ddsc/core/projectuploader.py
+++ b/ddsc/core/projectuploader.py
@@ -435,8 +435,7 @@ class ProjectUploadDryRun(object):
         :param item: object: project, folder or file we will add to upload_items if necessary.
         """
         if item.kind == KindType.file_str:
-            if item.need_to_send:
-                self.add_upload_item(item.path)
+            self.add_upload_item(item.path)
         else:
             if item.kind == KindType.project_str:
                 pass

--- a/ddsc/core/tests/test_d4s2.py
+++ b/ddsc/core/tests/test_d4s2.py
@@ -131,8 +131,8 @@ class TestD4S2Project(TestCase):
         download_pre_processor = kwargs['file_download_pre_processor']
         self.assertEqual(DownloadedFileRelations, download_pre_processor.__class__)
 
-        mock_project_upload.assert_called()
-        args, kwargs = mock_project_upload.call_args
+        mock_project_upload.create_for_paths.assert_called()
+        args, kwargs = mock_project_upload.create_for_paths.call_args
         file_upload_post_processor = kwargs['file_upload_post_processor']
         self.assertEqual(UploadedFileRelations, file_upload_post_processor.__class__)
 

--- a/ddsc/core/tests/test_fileuploader.py
+++ b/ddsc/core/tests/test_fileuploader.py
@@ -3,7 +3,7 @@ from ddsc.core.fileuploader import ParallelChunkProcessor, upload_async, FileUpl
     RetrySettings, ForbiddenSendExternalException, ChunkSender, FileUploader
 from ddsc.core.ddsapi import DSResourceNotConsistentError, DataServiceError
 import requests
-from mock import MagicMock, Mock, patch, call
+from mock import MagicMock, Mock, patch, call, ANY
 
 
 class FakeConfig(object):
@@ -366,3 +366,5 @@ class TestFileUploader(TestCase):
                                               storage_provider_id=config.storage_provider_id)
         mock_parallel_chunkprocessor.assert_called_with(uploader)
         mock_parallel_chunkprocessor.return_value.run.assert_called_with()
+        mock_finish_upload = mock_file_upload_operations.return_value.finish_upload
+        mock_finish_upload.assert_called_with(mock_create_upload.return_value, hash_data, ANY, local_file.remote_id)

--- a/ddsc/core/tests/test_fileuploader.py
+++ b/ddsc/core/tests/test_fileuploader.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 from ddsc.core.fileuploader import ParallelChunkProcessor, upload_async, FileUploadOperations, \
-    RetrySettings, ForbiddenSendExternalException, ChunkSender
+    RetrySettings, ForbiddenSendExternalException, ChunkSender, FileUploader
 from ddsc.core.ddsapi import DSResourceNotConsistentError, DataServiceError
 import requests
 from mock import MagicMock, Mock, patch, call
@@ -351,3 +351,18 @@ class TestChunkSender(TestCase):
             chunk_sender._send_chunk(chunk='abc', chunk_num=1)
 
         self.assertEqual(str(raised_exception.exception), 'Forbidden')
+
+
+class TestFileUploader(TestCase):
+    @patch('ddsc.core.fileuploader.FileUploadOperations')
+    @patch('ddsc.core.fileuploader.ParallelChunkProcessor')
+    def test_upload(self, mock_parallel_chunkprocessor, mock_file_upload_operations):
+        config, data_service, local_file, hash_data, watcher = Mock(), Mock(), Mock(), Mock(), Mock()
+        uploader = FileUploader(config, data_service, local_file, hash_data, watcher)
+        uploader.upload(project_id='mouse', parent_kind='dds-project', parent_id='abc123')
+
+        mock_create_upload = mock_file_upload_operations.return_value.create_upload
+        mock_create_upload.assert_called_with('mouse', local_file.get_path_data.return_value, hash_data,
+                                              storage_provider_id=config.storage_provider_id)
+        mock_parallel_chunkprocessor.assert_called_with(uploader)
+        mock_parallel_chunkprocessor.return_value.run.assert_called_with()

--- a/ddsc/core/tests/test_localstore.py
+++ b/ddsc/core/tests/test_localstore.py
@@ -203,6 +203,24 @@ class TestLocalFile(TestCase):
             f.size = file_size
             self.assertEqual(expected, f.count_chunks(bytes_per_chunk))
 
+    @patch('ddsc.core.localstore.os')
+    @patch('ddsc.core.localstore.PathData')
+    def test_set_remote_values_after_send(self, mock_path_data, mock_os):
+        f = LocalFile('fakefile.txt')
+        self.assertEqual(f.remote_id, '')
+        self.assertEqual(f.remote_file_hash_alg, None)
+        self.assertEqual(f.remote_file_hash, None)
+        self.assertEqual(f.sent_to_remote, False)
+        f.set_remote_values_after_send(
+            remote_id='abc123',
+            remote_hash_alg='md5',
+            remote_file_hash='defjkl'
+        )
+        self.assertEqual(f.remote_id, 'abc123')
+        self.assertEqual(f.remote_file_hash_alg, 'md5')
+        self.assertEqual(f.remote_file_hash, 'defjkl')
+        self.assertEqual(f.sent_to_remote, True)
+
 
 class TestLocalItemsCounter(TestCase):
     def test_to_str(self):

--- a/ddsc/core/tests/test_localstore.py
+++ b/ddsc/core/tests/test_localstore.py
@@ -1,8 +1,8 @@
 import shutil
 import tarfile
 from unittest import TestCase
-from ddsc.core.localstore import LocalFile, LocalFolder, LocalProject, KindType
-from mock import patch
+from ddsc.core.localstore import LocalFile, LocalFolder, LocalProject, KindType, LocalItemsCounter, ItemsToSendCounter
+from mock import patch, Mock
 
 
 INCLUDE_ALL = ''
@@ -202,3 +202,35 @@ class TestLocalFile(TestCase):
         for file_size, bytes_per_chunk, expected in values:
             f.size = file_size
             self.assertEqual(expected, f.count_chunks(bytes_per_chunk))
+
+
+class TestLocalItemsCounter(TestCase):
+    def test_to_str(self):
+        local_project = Mock()
+        local_project.children = [
+            Mock(kind='dds-file'),
+            Mock(kind='dds-folder', children=[
+                Mock(kind='dds-file'),
+            ]),
+        ]
+        counter = LocalItemsCounter(local_project)
+        self.assertEqual(counter.to_str(prefix="Checking"), 'Checking 2 files and 1 folder.')
+
+
+class TestItemsToSendCounter(TestCase):
+    def test_to_str(self):
+        local_project = Mock(kind='dds-project')
+        mock_file1 = Mock(kind='dds-file')
+        mock_file1.count_chunks.return_value = 10
+        mock_file2 = Mock(kind='dds-file')
+        mock_file2.count_chunks.return_value = 10
+        local_project.children = [
+            mock_file1,
+            Mock(kind='dds-folder', children=[
+                mock_file2,
+            ]),
+        ]
+        counter = ItemsToSendCounter(local_project, bytes_per_chunk=100)
+        counter_str = counter.to_str(prefix="Synchronizing", local_items_count=Mock(files=3, folders=3))
+        self.assertEqual(counter_str,
+                         'Synchronizing 1 new file, 2 existing files, 2 new folders and 1 existing folder.')

--- a/ddsc/core/tests/test_projectuploader.py
+++ b/ddsc/core/tests/test_projectuploader.py
@@ -49,15 +49,13 @@ class TestProjectUploadDryRun(TestCase):
     def test_single_empty_non_existant_directory(self):
         local_file = MagicMock(kind=KindType.folder_str, children=[], path='joe', remote_id=None)
         local_project = MagicMock(kind=KindType.project_str, children=[local_file])
-        upload_dry_run = ProjectUploadDryRun()
-        upload_dry_run.run(local_project)
+        upload_dry_run = ProjectUploadDryRun(local_project)
         self.assertEqual(['joe'], upload_dry_run.upload_items)
 
     def test_single_empty_existing_directory(self):
         local_file = MagicMock(kind=KindType.folder_str, children=[], path='joe', remote_id='abc')
         local_project = MagicMock(kind=KindType.project_str, children=[local_file])
-        upload_dry_run = ProjectUploadDryRun()
-        upload_dry_run.run(local_project)
+        upload_dry_run = ProjectUploadDryRun(local_project)
         self.assertEqual([], upload_dry_run.upload_items)
 
     def test_some_files(self):
@@ -68,8 +66,7 @@ class TestProjectUploadDryRun(TestCase):
         local_file3 = MagicMock(kind=KindType.file_str, path='results.txt')
         local_file3.hash_matches_remote.return_value = False
         local_project = MagicMock(kind=KindType.project_str, children=[local_file1, local_file2, local_file3])
-        upload_dry_run = ProjectUploadDryRun()
-        upload_dry_run.run(local_project)
+        upload_dry_run = ProjectUploadDryRun(local_project)
         self.assertEqual(['joe.txt', 'results.txt'], upload_dry_run.upload_items)
         local_file1.hash_matches_remote.assert_called_with(
             local_file1.calculate_local_hash.return_value
@@ -101,8 +98,7 @@ class TestProjectUploadDryRun(TestCase):
                                   children=[child_folder],
                                   remote_id=None)
         local_project = MagicMock(kind=KindType.project_str, children=[parent_folder])
-        upload_dry_run = ProjectUploadDryRun()
-        upload_dry_run.run(local_project)
+        upload_dry_run = ProjectUploadDryRun(local_project)
         expected_results = [
             '/data/2017',
             '/data/2017/08',
@@ -132,8 +128,7 @@ class TestProjectUploadDryRun(TestCase):
                                   children=[child_folder],
                                   remote_id='123')
         local_project = MagicMock(kind=KindType.project_str, children=[parent_folder])
-        upload_dry_run = ProjectUploadDryRun()
-        upload_dry_run.run(local_project)
+        upload_dry_run = ProjectUploadDryRun(local_project)
         expected_results = [
             '/data/2017/08/flyresults',
             '/data/2017/08/flyresults/joe.txt',

--- a/ddsc/core/tests/test_projectuploader.py
+++ b/ddsc/core/tests/test_projectuploader.py
@@ -136,6 +136,18 @@ class TestProjectUploadDryRun(TestCase):
         ]
         self.assertEqual(expected_results, upload_dry_run.upload_items)
 
+    def test_get_report_no_changes(self):
+        local_project = MagicMock(kind=KindType.project_str, children=[])
+        upload_dry_run = ProjectUploadDryRun(local_project)
+        upload_dry_run.upload_items = []
+        self.assertEqual(upload_dry_run.get_report().strip(), 'No changes found. Nothing needs to be uploaded.')
+
+    def test_get_report_changes_exist(self):
+        local_project = MagicMock(kind=KindType.project_str, children=[])
+        upload_dry_run = ProjectUploadDryRun(local_project)
+        upload_dry_run.upload_items = ['somefile']
+        self.assertEqual(upload_dry_run.get_report().strip(), 'Files/Folders that need to be uploaded:\nsomefile')
+
 
 class TestCreateProjectCommand(TestCase):
     def test_constructor_fails_for_id(self):

--- a/ddsc/core/tests/test_projectuploader.py
+++ b/ddsc/core/tests/test_projectuploader.py
@@ -168,12 +168,13 @@ class TestCreateSmallFile(TestCase):
     @patch('ddsc.core.projectuploader.FileUploadOperations', autospec=True)
     def test_create_small_file_passes_zero_index(self, mock_file_operations):
         mock_path_data = Mock()
+        mock_path_data.get_hash.return_value.matches.return_value = False
         mock_path_data.read_whole_file.return_value = 'data'
         mock_file_operations.return_value.create_upload_and_chunk_url.return_value = (
             'someId', {'host': 'somehost', 'url': 'someurl'}
         )
 
-        upload_context = Mock(params=(Mock(), mock_path_data, Mock()))
+        upload_context = Mock(params=(Mock(), mock_path_data, Mock(), 'md5', 'abc'))
         resp = create_small_file(upload_context)
 
         self.assertEqual(resp, mock_file_operations.return_value.finish_upload.return_value)

--- a/ddsc/core/tests/test_projectuploader.py
+++ b/ddsc/core/tests/test_projectuploader.py
@@ -62,18 +62,32 @@ class TestProjectUploadDryRun(TestCase):
 
     def test_some_files(self):
         local_file1 = MagicMock(kind=KindType.file_str, path='joe.txt')
+        local_file1.hash_matches_remote.return_value = False
         local_file2 = MagicMock(kind=KindType.file_str, path='data.txt')
+        local_file2.hash_matches_remote.return_value = True
         local_file3 = MagicMock(kind=KindType.file_str, path='results.txt')
+        local_file3.hash_matches_remote.return_value = False
         local_project = MagicMock(kind=KindType.project_str, children=[local_file1, local_file2, local_file3])
         upload_dry_run = ProjectUploadDryRun()
         upload_dry_run.run(local_project)
-        self.assertEqual(['joe.txt', 'data.txt', 'results.txt'], upload_dry_run.upload_items)
-        # TODO check hashing difference of files (data.txt previously)
+        self.assertEqual(['joe.txt', 'results.txt'], upload_dry_run.upload_items)
+        local_file1.hash_matches_remote.assert_called_with(
+            local_file1.calculate_local_hash.return_value
+        )
+        local_file2.hash_matches_remote.assert_called_with(
+            local_file2.calculate_local_hash.return_value
+        )
+        local_file3.hash_matches_remote.assert_called_with(
+            local_file3.calculate_local_hash.return_value
+        )
 
     def test_nested_directories(self):
         local_file1 = MagicMock(kind=KindType.file_str, path='/data/2017/08/flyresults/joe.txt')
+        local_file1.hash_matches_remote.return_value = False
         local_file2 = MagicMock(kind=KindType.file_str, path='/data/2017/08/flyresults/data.txt')
+        local_file2.hash_matches_remote.return_value = True
         local_file3 = MagicMock(kind=KindType.file_str, path='/data/2017/08/flyresults/results.txt')
+        local_file3.hash_matches_remote.return_value = False
         grandchild_folder = MagicMock(kind=KindType.folder_str,
                                       path="/data/2017/08/flyresults",
                                       children=[local_file1, local_file2, local_file3],
@@ -94,16 +108,17 @@ class TestProjectUploadDryRun(TestCase):
             '/data/2017/08',
             '/data/2017/08/flyresults',
             '/data/2017/08/flyresults/joe.txt',
-            '/data/2017/08/flyresults/data.txt',
             '/data/2017/08/flyresults/results.txt',
         ]
         self.assertEqual(expected_results, upload_dry_run.upload_items)
-        # TODO check hashing difference of files (data.txt previously)
 
     def test_nested_directories_skip_parents(self):
         local_file1 = MagicMock(kind=KindType.file_str, path='/data/2017/08/flyresults/joe.txt')
+        local_file1.hash_matches_remote.return_value = False
         local_file2 = MagicMock(kind=KindType.file_str, path='/data/2017/08/flyresults/data.txt')
+        local_file2.hash_matches_remote.return_value = True
         local_file3 = MagicMock(kind=KindType.file_str, path='/data/2017/08/flyresults/results.txt')
+        local_file3.hash_matches_remote.return_value = False
         grandchild_folder = MagicMock(kind=KindType.folder_str,
                                       path="/data/2017/08/flyresults",
                                       children=[local_file1, local_file2, local_file3],
@@ -122,11 +137,9 @@ class TestProjectUploadDryRun(TestCase):
         expected_results = [
             '/data/2017/08/flyresults',
             '/data/2017/08/flyresults/joe.txt',
-            '/data/2017/08/flyresults/data.txt',
             '/data/2017/08/flyresults/results.txt',
         ]
         self.assertEqual(expected_results, upload_dry_run.upload_items)
-        # TODO check hashing difference of files (data.txt previously)
 
 
 class TestCreateProjectCommand(TestCase):

--- a/ddsc/core/tests/test_projectuploader.py
+++ b/ddsc/core/tests/test_projectuploader.py
@@ -233,7 +233,7 @@ class TestProjectUploader(TestCase):
     @patch('ddsc.core.projectuploader.TaskExecutor')
     @patch('ddsc.core.projectuploader.SmallItemUploadTaskBuilder')
     def test_run_with_large_files_hash_matching(self, mock_small_task_builder, mock_task_executor, mock_task_runner,
-                                       mock_project_walker):
+                                                mock_project_walker):
         settings = Mock()
         settings.config.upload_bytes_per_chunk = 100
         uploader = ProjectUploader(settings)

--- a/ddsc/core/tests/test_projectuploader.py
+++ b/ddsc/core/tests/test_projectuploader.py
@@ -61,18 +61,19 @@ class TestProjectUploadDryRun(TestCase):
         self.assertEqual([], upload_dry_run.upload_items)
 
     def test_some_files(self):
-        local_file1 = MagicMock(kind=KindType.file_str, path='joe.txt', need_to_send=True)
-        local_file2 = MagicMock(kind=KindType.file_str, path='data.txt', need_to_send=False)
-        local_file3 = MagicMock(kind=KindType.file_str, path='results.txt', need_to_send=True)
+        local_file1 = MagicMock(kind=KindType.file_str, path='joe.txt')
+        local_file2 = MagicMock(kind=KindType.file_str, path='data.txt')
+        local_file3 = MagicMock(kind=KindType.file_str, path='results.txt')
         local_project = MagicMock(kind=KindType.project_str, children=[local_file1, local_file2, local_file3])
         upload_dry_run = ProjectUploadDryRun()
         upload_dry_run.run(local_project)
-        self.assertEqual(['joe.txt', 'results.txt'], upload_dry_run.upload_items)
+        self.assertEqual(['joe.txt', 'data.txt', 'results.txt'], upload_dry_run.upload_items)
+        # TODO check hashing difference of files (data.txt previously)
 
     def test_nested_directories(self):
-        local_file1 = MagicMock(kind=KindType.file_str, path='/data/2017/08/flyresults/joe.txt', need_to_send=True)
-        local_file2 = MagicMock(kind=KindType.file_str, path='/data/2017/08/flyresults/data.txt', need_to_send=False)
-        local_file3 = MagicMock(kind=KindType.file_str, path='/data/2017/08/flyresults/results.txt', need_to_send=True)
+        local_file1 = MagicMock(kind=KindType.file_str, path='/data/2017/08/flyresults/joe.txt')
+        local_file2 = MagicMock(kind=KindType.file_str, path='/data/2017/08/flyresults/data.txt')
+        local_file3 = MagicMock(kind=KindType.file_str, path='/data/2017/08/flyresults/results.txt')
         grandchild_folder = MagicMock(kind=KindType.folder_str,
                                       path="/data/2017/08/flyresults",
                                       children=[local_file1, local_file2, local_file3],
@@ -93,14 +94,16 @@ class TestProjectUploadDryRun(TestCase):
             '/data/2017/08',
             '/data/2017/08/flyresults',
             '/data/2017/08/flyresults/joe.txt',
+            '/data/2017/08/flyresults/data.txt',
             '/data/2017/08/flyresults/results.txt',
         ]
         self.assertEqual(expected_results, upload_dry_run.upload_items)
+        # TODO check hashing difference of files (data.txt previously)
 
     def test_nested_directories_skip_parents(self):
-        local_file1 = MagicMock(kind=KindType.file_str, path='/data/2017/08/flyresults/joe.txt', need_to_send=True)
-        local_file2 = MagicMock(kind=KindType.file_str, path='/data/2017/08/flyresults/data.txt', need_to_send=False)
-        local_file3 = MagicMock(kind=KindType.file_str, path='/data/2017/08/flyresults/results.txt', need_to_send=True)
+        local_file1 = MagicMock(kind=KindType.file_str, path='/data/2017/08/flyresults/joe.txt')
+        local_file2 = MagicMock(kind=KindType.file_str, path='/data/2017/08/flyresults/data.txt')
+        local_file3 = MagicMock(kind=KindType.file_str, path='/data/2017/08/flyresults/results.txt')
         grandchild_folder = MagicMock(kind=KindType.folder_str,
                                       path="/data/2017/08/flyresults",
                                       children=[local_file1, local_file2, local_file3],
@@ -119,9 +122,11 @@ class TestProjectUploadDryRun(TestCase):
         expected_results = [
             '/data/2017/08/flyresults',
             '/data/2017/08/flyresults/joe.txt',
+            '/data/2017/08/flyresults/data.txt',
             '/data/2017/08/flyresults/results.txt',
         ]
         self.assertEqual(expected_results, upload_dry_run.upload_items)
+        # TODO check hashing difference of files (data.txt previously)
 
 
 class TestCreateProjectCommand(TestCase):

--- a/ddsc/core/tests/test_projectuploader.py
+++ b/ddsc/core/tests/test_projectuploader.py
@@ -251,9 +251,11 @@ class TestProjectUploader(TestCase):
         uploader.process_large_file.assert_not_called()
         settings.watcher.transferring_item.assert_has_calls([
             call(large_file_new, increment_amt=0, override_msg_verb='checking'),  # show checking
-            call(large_file_new, increment_amt=20),   # update progress as sending (file already at remote)
             call(large_file_existing, increment_amt=0, override_msg_verb='checking'),   # show checking
-            call(large_file_existing, increment_amt=10),   # update progress as sending (file already at remote)
+        ])
+        # The progress bar should be incremented for both files that are already at the remote store
+        settings.watcher.increment_progress.assert_has_calls([
+            call(20), call(10)
         ])
 
     @patch('ddsc.core.projectuploader.TaskRunner')
@@ -302,8 +304,10 @@ class TestProjectUploader(TestCase):
             call(local_file1, increment_amt=0),
             # Show checking for file2
             call(local_file2, increment_amt=0, override_msg_verb='checking'),
-            # Already remote so increment progress for entire file
-            call(local_file2, increment_amt=2),
+        ])
+        # The progress bar should be incremented for local_file2 since local matches remote
+        settings.watcher.increment_progress.assert_has_calls([
+            call(2)
         ])
 
 

--- a/ddsc/core/tests/test_upload.py
+++ b/ddsc/core/tests/test_upload.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 from unittest import TestCase
-from ddsc.core.upload import ProjectUpload
+from ddsc.core.upload import ProjectUpload, UploadReport
 from mock import patch, Mock
 
 
@@ -12,3 +12,37 @@ class TestProjectUpload(TestCase):
                                        items_to_send_count=None, file_upload_post_processor=None)
         mock_remote_store.return_value.data_service.portal_url.return_value = 'https://127.0.0.1/#/project/123'
         self.assertEqual(project_upload.get_url_msg(), 'URL to view project: https://127.0.0.1/#/project/123')
+
+    @patch("ddsc.core.upload.RemoteStore")
+    @patch("ddsc.core.upload.LocalProject")
+    def test_create_for_paths(self, mock_local_project, mock_remote_store):
+        config, remote_store, project_name_or_id, file_upload_post_processor = Mock(), Mock(), Mock(), Mock()
+        paths = ['/tmp/data']
+        project_upload = ProjectUpload.create_for_paths(config, remote_store, project_name_or_id, paths,
+                                                        follow_symlinks=False,
+                                                        file_upload_post_processor=file_upload_post_processor)
+        self.assertEqual(project_upload.config, config)
+        self.assertEqual(project_upload.local_project, mock_local_project.return_value)
+        self.assertEqual(project_upload.items_to_send_count,
+                         mock_local_project.return_value.count_items_to_send.return_value)
+
+        remote_store.fetch_remote_project.assert_called_with(project_name_or_id)
+        project_upload.local_project.update_remote_ids.assert_called_with(
+            remote_store.fetch_remote_project.return_value
+        )
+        mock_local_project.return_value.add_paths.assert_called_with(['/tmp/data'])
+
+
+class TestUploadReport(TestCase):
+    def test_summary(self):
+        upload_report = UploadReport('mouse')
+        upload_report.visit_project(Mock(remote_id='project1'))
+        upload_report.visit_folder(Mock(path='data', remote_id='folder1', sent_to_remote=True), None)
+        upload_report.visit_folder(Mock(path='code', remote_id='folder2', sent_to_remote=False), None)
+        upload_report.visit_folder(Mock(path='results', remote_id='folder3', sent_to_remote=False), None)
+        upload_report.visit_file(Mock(path='data/file1.txt', remote_id='file1', sent_to_remote=True), None)
+        upload_report.visit_file(Mock(path='code/run.sh', remote_id='file2', sent_to_remote=False), None)
+        upload_report.visit_file(Mock(path='code/clean.sh', remote_id='file3', sent_to_remote=False), None)
+
+        self.assertEqual(upload_report.summary(),
+                         'Uploaded 1 file and 1 folder. 2 files and 2 folders are already up to date.')

--- a/ddsc/core/tests/test_upload.py
+++ b/ddsc/core/tests/test_upload.py
@@ -9,6 +9,6 @@ class TestProjectUpload(TestCase):
     @patch("ddsc.core.upload.LocalProject")
     def test_get_url_msg(self, mock_local_project, mock_remote_store):
         project_upload = ProjectUpload(config=Mock(), project_name_or_id=Mock(), local_project=Mock(),
-                                       file_upload_post_processor=None)
+                                       items_to_send_count=None, file_upload_post_processor=None)
         mock_remote_store.return_value.data_service.portal_url.return_value = 'https://127.0.0.1/#/project/123'
         self.assertEqual(project_upload.get_url_msg(), 'URL to view project: https://127.0.0.1/#/project/123')

--- a/ddsc/core/tests/test_upload.py
+++ b/ddsc/core/tests/test_upload.py
@@ -1,56 +1,14 @@
 from __future__ import absolute_import
 from unittest import TestCase
-from ddsc.core.upload import ProjectUpload, LocalOnlyCounter
-from ddsc.core.localstore import LocalFile
-from ddsc.core.remotestore import ProjectNameOrId
-from mock import MagicMock, patch, Mock
-
-
-class TestUploadCommand(TestCase):
-    @patch("ddsc.core.upload.RemoteStore")
-    @patch("ddsc.core.upload.ProjectUpload")
-    @patch("ddsc.core.upload.ProjectUploadDryRun")
-    def test_nothing_to_do(self, MockProjectUploadDryRun, MockProjectUpload, MockRemoteStore):
-        MockProjectUploadDryRun().upload_items = []
-        name_or_id = ProjectNameOrId.create_from_name("someProject")
-        project_upload = ProjectUpload(MagicMock(), name_or_id, ["data"])
-        dry_run_report = project_upload.dry_run_report()
-        self.assertIn("No changes found. Nothing needs to be uploaded.", dry_run_report)
-
-    @patch("ddsc.core.upload.RemoteStore")
-    @patch("ddsc.core.upload.ProjectUpload")
-    @patch("ddsc.core.upload.ProjectUploadDryRun")
-    def test_two_files_to_upload(self, MockProjectUploadDryRun, MockProjectUpload, MockRemoteStore):
-        MockProjectUploadDryRun().upload_items = ['data.txt', 'data2.txt']
-        name_or_id = ProjectNameOrId.create_from_name("someProject")
-        project_upload = ProjectUpload(MagicMock(), name_or_id, ["data"])
-        dry_run_report = project_upload.dry_run_report()
-        self.assertIn("Files/Folders that need to be uploaded:", dry_run_report)
-        self.assertIn("data.txt", dry_run_report)
-        self.assertIn("data2.txt", dry_run_report)
-
-
-class TestLocalOnlyCounter(TestCase):
-    @patch('ddsc.core.localstore.os')
-    @patch('ddsc.core.localstore.PathData')
-    def test_total_items(self, mock_path_data, mock_os):
-        counter = LocalOnlyCounter(bytes_per_chunk=100)
-        self.assertEqual(0, counter.total_items())
-        f = LocalFile('fakefile.txt')
-        f.size = 0
-        counter.visit_file(f, None)
-        self.assertEqual(1, counter.total_items())
-        f = LocalFile('fakefile2.txt')
-        f.size = 200
-        counter.visit_file(f, None)
-        self.assertEqual(3, counter.total_items())
+from ddsc.core.upload import ProjectUpload
+from mock import patch, Mock
 
 
 class TestProjectUpload(TestCase):
     @patch("ddsc.core.upload.RemoteStore")
     @patch("ddsc.core.upload.LocalProject")
     def test_get_url_msg(self, mock_local_project, mock_remote_store):
-        project_upload = ProjectUpload(config=Mock(), project_name_or_id=Mock(), folders=Mock(),
-                                       follow_symlinks=False, file_upload_post_processor=None)
+        project_upload = ProjectUpload(config=Mock(), project_name_or_id=Mock(), local_project=Mock(),
+                                       file_upload_post_processor=None)
         mock_remote_store.return_value.data_service.portal_url.return_value = 'https://127.0.0.1/#/project/123'
         self.assertEqual(project_upload.get_url_msg(), 'URL to view project: https://127.0.0.1/#/project/123')

--- a/ddsc/core/tests/test_util.py
+++ b/ddsc/core/tests/test_util.py
@@ -174,6 +174,18 @@ class TestProgressPrinter(TestCase):
         self.assertEqual(False, progress_printer.waiting)
         self.assertEqual(1, progress_printer.progress_bar.show_running.call_count)
 
+    @patch('ddsc.core.util.ProgressBar')
+    @patch('ddsc.core.util.os')
+    def test_transferring_item_override_msg_verb(self, mock_os, mock_progress_bar):
+        progress_bar = mock_progress_bar.return_value
+        mock_os.path.basename.return_value = 'somefile.txt'
+        progress_printer = ProgressPrinter(total=10, msg_verb='sending')
+        progress_printer.transferring_item(Mock(), increment_amt=0)
+        progress_bar.update.assert_called_with(0, "sending somefile.txt")
+        progress_bar.reset_mock()
+        progress_printer.transferring_item(Mock(), increment_amt=0, override_msg_verb='checking')
+        progress_bar.update.assert_called_with(0, "checking somefile.txt")
+
 
 class TestRemotePath(TestCase):
     def test_add_leading_slash(self):

--- a/ddsc/core/tests/test_util.py
+++ b/ddsc/core/tests/test_util.py
@@ -191,7 +191,9 @@ class TestProgressPrinter(TestCase):
         self.assertEqual(progress_printer.cnt, 0)
         progress_printer.increment_progress(5)
         self.assertEqual(progress_printer.cnt, 5)
-        progress_printer.increment_progress(5)
+        progress_printer.increment_progress(4)
+        self.assertEqual(progress_printer.cnt, 9)
+        progress_printer.increment_progress()
         self.assertEqual(progress_printer.cnt, 10)
 
 

--- a/ddsc/core/tests/test_util.py
+++ b/ddsc/core/tests/test_util.py
@@ -186,6 +186,14 @@ class TestProgressPrinter(TestCase):
         progress_printer.transferring_item(Mock(), increment_amt=0, override_msg_verb='checking')
         progress_bar.update.assert_called_with(0, "checking somefile.txt")
 
+    def test_increment_progress(self):
+        progress_printer = ProgressPrinter(total=10, msg_verb='sending')
+        self.assertEqual(progress_printer.cnt, 0)
+        progress_printer.increment_progress(5)
+        self.assertEqual(progress_printer.cnt, 5)
+        progress_printer.increment_progress(5)
+        self.assertEqual(progress_printer.cnt, 10)
+
 
 class TestRemotePath(TestCase):
     def test_add_leading_slash(self):

--- a/ddsc/core/tests/test_util.py
+++ b/ddsc/core/tests/test_util.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
 
 from ddsc.core.util import verify_terminal_encoding, ProgressBar, ProgressPrinter, KindType, RemotePath, humanize_bytes,\
-    plural_fmt
+    plural_fmt, join_with_commas_and_and
 from mock import patch, Mock
 
 
@@ -212,3 +212,17 @@ class TestPluralFmt(TestCase):
         self.assertEqual(plural_fmt("folder", 1), "1 folder")
         self.assertEqual(plural_fmt("folder", 2), "2 folders")
         self.assertEqual(plural_fmt("folder", 3), "3 folders")
+
+
+class TestJoinWithCommasAndAnd(TestCase):
+    def test_join_with_commas_and_and(self):
+        items = []
+        self.assertEqual(join_with_commas_and_and(items), '')
+        items = ['abc']
+        self.assertEqual(join_with_commas_and_and(items), 'abc')
+        items = ['abc', 'def']
+        self.assertEqual(join_with_commas_and_and(items), 'abc and def')
+        items = ['abc', 'def', 'hij']
+        self.assertEqual(join_with_commas_and_and(items), 'abc, def and hij')
+        items = ['abc', 'def', 'hij', 'klm']
+        self.assertEqual(join_with_commas_and_and(items), 'abc, def, hij and klm')

--- a/ddsc/core/upload.py
+++ b/ddsc/core/upload.py
@@ -1,90 +1,48 @@
 import datetime
-from ddsc.core.localstore import LocalProject
 from ddsc.core.remotestore import RemoteStore
 from ddsc.core.util import ProgressPrinter, ProjectWalker, plural_fmt
-from ddsc.core.projectuploader import UploadSettings, ProjectUploader, ProjectUploadDryRun
+from ddsc.core.projectuploader import UploadSettings, ProjectUploader
+from ddsc.core.localstore import LocalProject
 
 
 class ProjectUpload(object):
     """
     Allows uploading a local project to a remote duke-data-service.
     """
-    def __init__(self, config, project_name_or_id, folders, follow_symlinks=False, file_upload_post_processor=None):
+    def __init__(self, config, project_name_or_id, local_project, file_upload_post_processor=None):
         """
         Setup for uploading folders dictionary of paths to project_name using config.
         :param config: Config configuration for performing the upload(url, keys, etc)
         :param project_name_or_id: ProjectNameOrId: name or id of the project we will upload files to
-        :param folders: [str] list of paths of files/folders to upload to the project
-        :param follow_symlinks: bool if true we will traverse symbolic linked directories
+        :param local_project: LocalProject: contains files and folders to upload
         :param file_upload_post_processor: object: has run(data_service, file_response) method to run after uploading
         """
         self.config = config
         self.remote_store = RemoteStore(config)
         self.project_name_or_id = project_name_or_id
-        self.remote_project = self.remote_store.fetch_remote_project(project_name_or_id)
-        self.local_project = ProjectUpload._load_local_project(folders, follow_symlinks, config.file_exclude_regex)
-        self.local_project.update_remote_ids(self.remote_project)
-        self.different_items = self._count_differences()
+        self.local_project = local_project
         self.file_upload_post_processor = file_upload_post_processor
 
     @staticmethod
-    def _load_local_project(folders, follow_symlinks, file_exclude_regex):
-        local_project = LocalProject(followsymlinks=follow_symlinks, file_exclude_regex=file_exclude_regex)
-        local_project.add_paths(folders)
-        return local_project
+    def create_for_paths(config, remote_store, project_name_or_id, paths, follow_symlinks=False,
+                         file_upload_post_processor=None):
+        local_project = LocalProject(followsymlinks=follow_symlinks, file_exclude_regex=config.file_exclude_regex)
+        local_project.add_paths(paths)
+        remote_project = remote_store.fetch_remote_project(project_name_or_id)
+        local_project.update_remote_ids(remote_project)
+        return ProjectUpload(config, project_name_or_id, local_project,
+                             file_upload_post_processor=file_upload_post_processor)
 
-    def _count_differences(self):
-        """
-        Count how many things we will be sending.
-        :param local_project: LocalProject project we will send data from
-        :return: LocalOnlyCounter contains counts for various items
-        """
-        different_items = LocalOnlyCounter(self.config.upload_bytes_per_chunk)
-        different_items.walk_project(self.local_project)
-        return different_items
-
-    def needs_to_upload(self):
-        """
-        Is there anything in the local project different from the remote project.
-        :return: bool is there any point in calling upload()
-        """
-        return self.different_items.total_items() != 0
-
-    def run(self):
+    def run(self, items_to_send_count):
         """
         Upload different items within local_project to remote store showing a progress bar.
         """
-        progress_printer = ProgressPrinter(self.different_items.total_items(), msg_verb='sending')
+        progress_printer = ProgressPrinter(items_to_send_count.total_items(), msg_verb='sending')
         upload_settings = UploadSettings(self.config, self.remote_store.data_service, progress_printer,
                                          self.project_name_or_id, self.file_upload_post_processor)
         project_uploader = ProjectUploader(upload_settings)
         project_uploader.run(self.local_project)
         progress_printer.finished()
-
-    def dry_run_report(self):
-        """
-        Returns text displaying the items that need to be uploaded or a message saying there are no files/folders
-        to upload.
-        :return: str: report text
-        """
-        project_uploader = ProjectUploadDryRun()
-        project_uploader.run(self.local_project)
-        items = project_uploader.upload_items
-        if not items:
-            return "\n\nNo changes found. Nothing needs to be uploaded.\n\n"
-        else:
-            result = "\n\nFiles/Folders that need to be uploaded:\n"
-            for item in items:
-                result += "{}\n".format(item)
-            result += "\n"
-            return result
-
-    def get_differences_summary(self):
-        """
-        Print a summary of what is to be done.
-        :param different_items: LocalOnlyCounter item that contains the summary
-        """
-        return 'Uploading {}.'.format(self.different_items.result_str())
 
     def get_upload_report(self):
         """
@@ -95,7 +53,7 @@ class ProjectUpload(object):
                                                          include_children=False)
         report = UploadReport(project.name)
         report.walk_project(self.local_project)
-        return report.get_content()
+        return report
 
     def get_url_msg(self):
         """
@@ -107,83 +65,26 @@ class ProjectUpload(object):
         return url
 
 
-class LocalOnlyCounter(object):
-    """
-    Visitor that counts items that need to be sent in LocalContent.
-    """
-    def __init__(self, bytes_per_chunk):
-        self.projects = 0
-        self.folders = 0
-        self.files = 0
-        self.chunks = 0
-        self.bytes_per_chunk = bytes_per_chunk
-
-    def walk_project(self, project):
-        """
-        Increment counters for each project, folder, and files calling visit methods below.
-        :param project: LocalProject project we will count items of.
-        """
-        # This method will call visit_project, visit_folder, and visit_file below as it walks the project tree.
-        ProjectWalker.walk_project(project, self)
-
-    def visit_project(self, item):
-        """
-        Increments counter if the project is not already remote.
-        :param item: LocalProject
-        """
-        if not item.remote_id:
-            self.projects += 1
-
-    def visit_folder(self, item, parent):
-        """
-        Increments counter if item is not already remote
-        :param item: LocalFolder
-        :param parent: LocalFolder/LocalProject
-        """
-        if not item.remote_id:
-            self.folders += 1
-
-    def visit_file(self, item, parent):
-        """
-        Increments counter if item needs to be sent.
-        :param item: LocalFile
-        :param parent: LocalFolder/LocalProject
-        """
-        self.files += 1
-        self.chunks += item.count_chunks(self.bytes_per_chunk)
-
-    def total_items(self):
-        """
-        Total number of files/folders/chunks that need to be sent.
-        :return: int number of items to be sent.
-        """
-        return self.projects + self.folders + self.chunks
-
-    def result_str(self):
-        """
-        Return a string representing the totals contained herein.
-        :return: str counts/types string
-        """
-        return '{}, {}, {}'.format(plural_fmt('project', self.projects),
-                                   plural_fmt('folder', self.folders),
-                                   plural_fmt('file', self.files))
-
-
 class UploadReport(object):
     """
     Creates a text report of items that were sent to the remote store.
     """
     def __init__(self, project_name):
         """
-        Create report witht the specified project name since the local store doesn't contain that info.
+        Create report with the specified project name since the local store doesn't contain that info.
         :param project_name: str project name for the report
         """
-        self.report_items = []
+        self.report_items = [ReportItem('SENT FILENAME', 'ID', 'SIZE', 'HASH')]
         self.project_name = project_name
-        self._add_report_item('SENT FILENAME', 'ID', 'SIZE', 'HASH')
+        self.sent_data = False
+        self.sent_files = 0
+        self.up_to_date_files = 0
+        self.sent_folders = 0
+        self.up_to_date_folders = 0
 
-    def _add_report_item(self, name, remote_id, size='', file_hash=''):
+    def _add_sent_item(self, name, remote_id, size='', file_hash=''):
         self.report_items.append(ReportItem(name, remote_id, size, file_hash))
+        self.sent_data = True
 
     def walk_project(self, project):
         """
@@ -199,7 +100,7 @@ class UploadReport(object):
         :param item: LocalContent project level item
         """
         if item.sent_to_remote:
-            self._add_report_item('Project', item.remote_id)
+            self._add_sent_item('Project', item.remote_id)
 
     def visit_folder(self, item, parent):
         """
@@ -208,7 +109,10 @@ class UploadReport(object):
         :param parent: LocalFolder/LocalContent not used here
         """
         if item.sent_to_remote:
-            self._add_report_item(item.path, item.remote_id)
+            self._add_sent_item(item.path, item.remote_id)
+            self.sent_folders += 1
+        else:
+            self.up_to_date_folders += 1
 
     def visit_file(self, item, parent):
         """
@@ -217,7 +121,10 @@ class UploadReport(object):
         :param parent: LocalFolder/LocalContent not used here
         """
         if item.sent_to_remote:
-            self._add_report_item(item.path, item.remote_id, item.size, item.get_hash_value())
+            self._add_sent_item(item.path, item.remote_id, item.size, item.get_hash_value())
+            self.sent_files += 1
+        else:
+            self.up_to_date_files += 1
 
     def _report_header(self):
         return u"Upload Report for Project: '{}' {}\n".format(self.project_name, datetime.datetime.utcnow())
@@ -236,6 +143,38 @@ class UploadReport(object):
         lines = [self._report_header()]
         lines.extend(self._report_body())
         return '\n'.join(lines)
+
+    def summary(self):
+        parts = []
+        uploaded_str = self.uploaded_items_str()
+        if uploaded_str:
+            parts.append(uploaded_str)
+        up_to_date_str = self.up_to_date_items_str()
+        if up_to_date_str:
+            parts.append(up_to_date_str)
+        return ' '.join(parts)
+
+    def uploaded_items_str(self):
+        parts = []
+        if self.sent_files:
+            parts.append(plural_fmt('file', self.sent_files))
+        if self.sent_folders:
+            parts.append(plural_fmt('folder', self.sent_folders))
+        if parts:
+            return "Uploaded {}.".format(" and ".join(parts))
+        else:
+            return ""
+
+    def up_to_date_items_str(self):
+        parts = []
+        if self.up_to_date_files:
+            parts.append(plural_fmt('file', self.up_to_date_files))
+        if self.up_to_date_folders:
+            parts.append(plural_fmt('folder', self.up_to_date_folders))
+        if parts:
+            return "{} are already up to date.".format(" and ".join(parts))
+        else:
+            return ""
 
 
 class ReportItem(object):

--- a/ddsc/core/upload.py
+++ b/ddsc/core/upload.py
@@ -15,6 +15,7 @@ class ProjectUpload(object):
         :param config: Config configuration for performing the upload(url, keys, etc)
         :param project_name_or_id: ProjectNameOrId: name or id of the project we will upload files to
         :param local_project: LocalProject: contains files and folders to upload
+        :param items_to_send_count: ItemsToSendCounter
         :param file_upload_post_processor: object: has run(data_service, file_response) method to run after uploading
         """
         self.config = config

--- a/ddsc/core/upload.py
+++ b/ddsc/core/upload.py
@@ -149,9 +149,8 @@ class LocalOnlyCounter(object):
         :param item: LocalFile
         :param parent: LocalFolder/LocalProject
         """
-        if item.need_to_send:
-            self.files += 1
-            self.chunks += item.count_chunks(self.bytes_per_chunk)
+        self.files += 1
+        self.chunks += item.count_chunks(self.bytes_per_chunk)
 
     def total_items(self):
         """

--- a/ddsc/core/upload.py
+++ b/ddsc/core/upload.py
@@ -123,7 +123,7 @@ class UploadReport(object):
         :param parent: LocalFolder/LocalContent not used here
         """
         if item.sent_to_remote:
-            self._add_sent_item(item.path, item.remote_id, item.size, item.get_hash_value())
+            self._add_sent_item(item.path, item.remote_id, item.size, item.remote_file_hash)
             self.sent_files += 1
         else:
             self.up_to_date_files += 1
@@ -206,4 +206,4 @@ class ReportItem(object):
         name_str = self.name.ljust(max_name)
         remote_id_str = self.remote_id.ljust(max_remote_id)
         size_str = self.size.ljust(max_size)
-        return u'{}    {}    {}    {}'.format(name_str, remote_id_str, size_str, self.file_hash)
+        return u'{}    {}    {}    {}'.format(name_str, remote_id_str, size_str, self.file_hash).rstrip()

--- a/ddsc/core/util.py
+++ b/ddsc/core/util.py
@@ -47,7 +47,7 @@ class NoOpProgressPrinter(object):
     def transferring_item(self, item, increment_amt=1, override_msg_verb=None):
         pass
 
-    def increment_progress(self, increment_amt):
+    def increment_progress(self, increment_amt=1):
         pass
 
     def finished(self):
@@ -90,7 +90,7 @@ class ProgressPrinter(object):
         self.progress_bar.update(percent_done, '{} {}'.format(msg_verb, details))
         self.progress_bar.show()
 
-    def increment_progress(self, amt):
+    def increment_progress(self, amt=1):
         self.cnt += amt
 
     def finished(self):

--- a/ddsc/core/util.py
+++ b/ddsc/core/util.py
@@ -428,3 +428,15 @@ def plural_fmt(name, cnt):
         return '{} {}'.format(cnt, name)
     else:
         return '{} {}s'.format(cnt, name)
+
+
+def join_with_commas_and_and(items):
+    if not items:
+        return ""
+    head_items = items[:-1]
+    last_item = items[-1]
+    head_items_str = ', '.join(head_items)
+    if head_items_str:
+        return ' and '.join([head_items_str, last_item])
+    else:
+        return last_item

--- a/ddsc/core/util.py
+++ b/ddsc/core/util.py
@@ -47,6 +47,9 @@ class NoOpProgressPrinter(object):
     def transferring_item(self, item, increment_amt=1, override_msg_verb=None):
         pass
 
+    def increment_progress(self, increment_amt):
+        pass
+
     def finished(self):
         pass
 
@@ -75,7 +78,7 @@ class ProgressPrinter(object):
         :param increment_amt: int amount to increase our count(how much progress have we made)
         :param override_msg_verb: str: overrides msg_verb specified in constructor
         """
-        self.cnt += increment_amt
+        self.increment_progress(increment_amt)
         percent_done = int(float(self.cnt) / float(self.total) * 100.0)
         if KindType.is_project(item):
             details = 'project'
@@ -86,6 +89,9 @@ class ProgressPrinter(object):
             msg_verb = override_msg_verb
         self.progress_bar.update(percent_done, '{} {}'.format(msg_verb, details))
         self.progress_bar.show()
+
+    def increment_progress(self, amt):
+        self.cnt += amt
 
     def finished(self):
         """

--- a/ddsc/core/util.py
+++ b/ddsc/core/util.py
@@ -44,7 +44,7 @@ class KindType(object):
 
 
 class NoOpProgressPrinter(object):
-    def transferring_item(self, item, increment_amt=1):
+    def transferring_item(self, item, increment_amt=1, override_msg_verb=None):
         pass
 
     def finished(self):
@@ -68,11 +68,12 @@ class ProgressPrinter(object):
         self.msg_verb = msg_verb
         self.progress_bar = ProgressBar()
 
-    def transferring_item(self, item, increment_amt=1):
+    def transferring_item(self, item, increment_amt=1, override_msg_verb=None):
         """
         Update progress that item is about to be transferred.
         :param item: LocalFile, LocalFolder, or LocalContent(project) that is about to be sent.
         :param increment_amt: int amount to increase our count(how much progress have we made)
+        :param override_msg_verb: str: overrides msg_verb specified in constructor
         """
         self.cnt += increment_amt
         percent_done = int(float(self.cnt) / float(self.total) * 100.0)
@@ -80,7 +81,10 @@ class ProgressPrinter(object):
             details = 'project'
         else:
             details = os.path.basename(item.path)
-        self.progress_bar.update(percent_done, '{} {}'.format(self.msg_verb, details))
+        msg_verb = self.msg_verb
+        if override_msg_verb:
+            msg_verb = override_msg_verb
+        self.progress_bar.update(percent_done, '{} {}'.format(msg_verb, details))
         self.progress_bar.show()
 
     def finished(self):

--- a/ddsc/ddsclient.py
+++ b/ddsc/ddsclient.py
@@ -185,8 +185,8 @@ class UploadCommand(BaseCommand):
             print(dry_run.get_report())
         else:
             # Upload files and folders
-            project_upload = ProjectUpload(self.config, project_name_or_id, local_project)
-            project_upload.run(items_to_send_count)
+            project_upload = ProjectUpload(self.config, project_name_or_id, local_project, items_to_send_count)
+            project_upload.run()
 
             # Show user results of upload
             upload_report = project_upload.get_upload_report()

--- a/ddsc/tests/test_ddsclient.py
+++ b/ddsc/tests/test_ddsclient.py
@@ -92,6 +92,16 @@ class TestUploadCommand(TestCase):
         mock_project_upload.assert_called_with(mock_config, ANY, mock_local_project.return_value)
         items_to_send = mock_local_project.return_value.count_items_to_send.return_value
         mock_project_upload.return_value.run.assert_called_with(items_to_send)
+        mock_print.assert_has_calls([
+            call(mock_local_project.return_value.count_local_items.return_value.to_str.return_value),
+            call(mock_local_project.return_value.count_items_to_send.return_value.to_str.return_value),
+            call(mock_project_upload.return_value.get_upload_report.return_value.summary.return_value),
+            call(),
+            call('\n'),
+            call(mock_project_upload.return_value.get_upload_report.return_value.get_content.return_value),
+            call('\n'),
+            call(mock_project_upload.return_value.get_url_msg.return_value),
+        ])
 
     @patch("ddsc.ddsclient.ProjectUpload")
     @patch("ddsc.ddsclient.ProjectNameOrId")

--- a/ddsc/tests/test_ddsclient.py
+++ b/ddsc/tests/test_ddsclient.py
@@ -89,9 +89,9 @@ class TestUploadCommand(TestCase):
         mock_local_project.return_value.update_remote_ids(remote_project)
 
         # uploads with local project
-        mock_project_upload.assert_called_with(mock_config, ANY, mock_local_project.return_value)
         items_to_send = mock_local_project.return_value.count_items_to_send.return_value
-        mock_project_upload.return_value.run.assert_called_with(items_to_send)
+        mock_project_upload.assert_called_with(mock_config, ANY, mock_local_project.return_value, items_to_send)
+        mock_project_upload.return_value.run.assert_called_with()
         mock_print.assert_has_calls([
             call(mock_local_project.return_value.count_local_items.return_value.to_str.return_value),
             call(mock_local_project.return_value.count_items_to_send.return_value.to_str.return_value),
@@ -131,9 +131,9 @@ class TestUploadCommand(TestCase):
         mock_local_project.return_value.update_remote_ids(remote_project)
 
         # uploads with local project
-        mock_project_upload.assert_called_with(mock_config, ANY, mock_local_project.return_value)
         items_to_send = mock_local_project.return_value.count_items_to_send.return_value
-        mock_project_upload.return_value.run.assert_called_with(items_to_send)
+        mock_project_upload.assert_called_with(mock_config, ANY, mock_local_project.return_value, items_to_send)
+        mock_project_upload.return_value.run.assert_called_with()
 
     @patch("ddsc.ddsclient.LocalProject")
     @patch("ddsc.ddsclient.ProjectUploadDryRun")


### PR DESCRIPTION
Speeds up resuming uploads. Removes [logic that checks all hashes for existing files](https://github.com/Duke-GCB/DukeDSClient/blob/16d75079cbc28b048fdc547e928e8778190d8e9c/ddsc/core/localstore.py#L223-L231) before beginning an upload. Instead when a file is encountered that is already uploaded(hash matches) we just skip uploading it. We also sort files that are new(not present in DukeDS) so they will be processed first. This change updates the command line messaging displayed by the `upload` command to reflect these changes.

Fixes #268