### PR TITLE
Fixes KeyError when adding user by email under python2

### DIFF
--- a/ddsc/cmdparser.py
+++ b/ddsc/cmdparser.py
@@ -26,7 +26,9 @@ def to_unicode(s):
     :param s: string to convert to unicode
     :return: unicode string for argument
     """
-    return s if six.PY3 else unicode(s, 'utf-8')
+    # Disabling flake8 undefined name unicode check below.
+    # flake8 is unaware of the python version check which makes this safe to do.
+    return s if six.PY3 else unicode(s, 'utf-8')  # noqa: F821
 
 
 def add_project_name_arg(arg_parser, required, help_text):

--- a/ddsc/cmdparser.py
+++ b/ddsc/cmdparser.py
@@ -4,7 +4,6 @@ Command line parser for the application.
 import os
 import argparse
 import six
-from builtins import str
 
 DESCRIPTION_STR = "DukeDSClient ({}) Manage projects/folders/files in the duke-data-service"
 INVALID_PATH_CHARS = (':', '/', '\\')
@@ -27,7 +26,7 @@ def to_unicode(s):
     :param s: string to convert to unicode
     :return: unicode string for argument
     """
-    return s if six.PY3 else str(s, 'utf-8')
+    return s if six.PY3 else unicode(s, 'utf-8')
 
 
 def add_project_name_arg(arg_parser, required, help_text):


### PR DESCRIPTION
The `str` implementation that is part of python-future is [incompatible with urlencode](https://github.com/PythonCharmers/python-future/issues/219). This caused the KeyError when attempting to pass an email address to requests. The python-future `str` implementation is meant to be a backport of the python3 `str`.
In this PR we go back to using `unicode` and silence the bogus flake8 error `unicode` raises

Fixes #275 