### PR TITLE
Cleanup multiprocessing pool

### DIFF
--- a/ddsc/core/download.py
+++ b/ddsc/core/download.py
@@ -5,7 +5,7 @@ import math
 import requests
 from ddsc.core.localstore import HashUtil
 from ddsc.core.util import ProgressPrinter
-from ddsc.core.parallel import TaskExecutor, TaskRunner
+from ddsc.core.parallel import TaskRunner
 from ddsc.core.ddsapi import DataServiceAuth, DataServiceApi
 from ddsc.core.remotestore import RemoteStore, ProjectFile, RemoteFileUrl
 from ddsc.core.retry import RetrySettings
@@ -279,7 +279,7 @@ class FileDownloader(object):
         task_runner.run()
 
     def _create_task_runner(self):
-        return TaskRunner(TaskExecutor(self.settings.config.download_workers))
+        return TaskRunner(self.settings.config.download_workers)
 
     def make_ranges(self, file_to_download):
         """

--- a/ddsc/core/projectuploader.py
+++ b/ddsc/core/projectuploader.py
@@ -1,7 +1,7 @@
 from ddsc.core.util import ProjectWalker, KindType
 from ddsc.core.ddsapi import DataServiceAuth, DataServiceApi
 from ddsc.core.fileuploader import FileUploader, FileUploadOperations, ParentData, ParallelChunkProcessor
-from ddsc.core.parallel import TaskExecutor, TaskRunner
+from ddsc.core.parallel import TaskRunner
 
 
 class UploadSettings(object):
@@ -100,7 +100,7 @@ class ProjectUploader(object):
         Setup to talk to the data service based on settings.
         :param settings: UploadSettings: settings to use for uploading.
         """
-        self.runner = TaskRunner(TaskExecutor(settings.config.upload_workers))
+        self.runner = TaskRunner(settings.config.upload_workers)
         self.settings = settings
         self.small_item_task_builder = SmallItemUploadTaskBuilder(self.settings, self.runner)
         self.small_files = []

--- a/ddsc/core/tests/test_download.py
+++ b/ddsc/core/tests/test_download.py
@@ -355,7 +355,8 @@ class TestFileToDownload(TestCase):
 
 class TestFileDownloader(TestCase):
     def setUp(self):
-        self.mock_config = Mock(download_bytes_per_chunk=1000)
+        self.num_download_workers = 5
+        self.mock_config = Mock(download_bytes_per_chunk=1000, download_workers=self.num_download_workers)
         self.mock_settings = Mock(dest_directory='/tmp/data2', config=self.mock_config)
         self.mock_file1 = Mock(path="data/file1.txt", size=200, local_path='/tmp/data2/data/file1.txt')
         self.mock_file1.get_remote_parent_path.return_value = 'data'
@@ -417,6 +418,7 @@ class TestFileDownloader(TestCase):
         downloader.download_files()
 
         # Download small file in one command, large file in two commands).
+        mock_task_runner.assert_called_with(self.num_download_workers)
         add_calls = mock_task_runner.return_value.add.call_args_list
         self.assertEqual(5, len(add_calls))
         command = add_calls[0][1]['command']

--- a/ddsc/core/tests/test_download.py
+++ b/ddsc/core/tests/test_download.py
@@ -378,9 +378,8 @@ class TestFileDownloader(TestCase):
         downloader.download_files.assert_called_with()
 
     @patch('ddsc.core.download.TaskRunner')
-    @patch('ddsc.core.download.TaskExecutor')
     @patch('ddsc.core.download.os')
-    def test_make_local_directories(self, mock_os, mock_task_executor, mock_task_runner):
+    def test_make_local_directories(self, mock_os, mock_task_runner):
         mock_os.path.exists.return_value = True
         mock_os.path = os.path
         downloader = FileDownloader(self.mock_settings, self.mock_files_to_download)
@@ -388,9 +387,8 @@ class TestFileDownloader(TestCase):
         mock_os.makedirs.assert_called_with('/tmp/data2/data')
 
     @patch('ddsc.core.download.TaskRunner')
-    @patch('ddsc.core.download.TaskExecutor')
     @patch('ddsc.core.download.os')
-    def test_make_big_empty_files(self, mock_os, mock_task_executor, mock_task_runner):
+    def test_make_big_empty_files(self, mock_os, mock_task_runner):
         mock_os.path.exists.return_value = True
         mock_os.path = os.path
         downloader = FileDownloader(self.mock_settings, self.mock_files_to_download)
@@ -402,8 +400,7 @@ class TestFileDownloader(TestCase):
         fake_open.return_value.write.assert_called_with(b'\0')
 
     @patch('ddsc.core.download.TaskRunner')
-    @patch('ddsc.core.download.TaskExecutor')
-    def test_download_files(self, mock_task_executor, mock_task_runner):
+    def test_download_files(self, mock_task_runner):
         downloader = FileDownloader(self.mock_settings, self.mock_files_to_download)
         downloader.group_files_by_size = Mock()
         mock_small_file = Mock(size=100)

--- a/ddsc/core/tests/test_parallel.py
+++ b/ddsc/core/tests/test_parallel.py
@@ -98,8 +98,7 @@ class TestTaskRunner(TestCase):
     """
     def test_single_add(self):
         add_command = AddCommand(10, 30)
-        executor = TaskExecutor(10)
-        runner = TaskRunner(executor)
+        runner = TaskRunner(num_workers=10)
         runner.add(None, add_command)
         runner.run()
         self.assertEqual(add_command.parent_task_result, None)
@@ -109,8 +108,7 @@ class TestTaskRunner(TestCase):
     def test_two_adds_in_order(self):
         add_command = AddCommand(10, 30)
         add_command2 = AddCommand(4, 1)
-        executor = TaskExecutor(10)
-        runner = TaskRunner(executor)
+        runner = TaskRunner(num_workers=10)
         runner.add(None, add_command)
         runner.add(1, add_command2)
         runner.run()
@@ -122,8 +120,7 @@ class TestTaskRunner(TestCase):
     def test_two_adds_in_parallel(self):
         add_command = AddCommand(10, 30)
         add_command2 = AddCommand(4, 1)
-        executor = TaskExecutor(10)
-        runner = TaskRunner(executor)
+        runner = TaskRunner(num_workers=10)
         runner.add(None, add_command,)
         runner.add(None, add_command2)
         runner.run()
@@ -137,8 +134,7 @@ class TestTaskRunner(TestCase):
         add_command.send_message = 'ok'
         add_command2 = AddCommand(4, 1)
         add_command2.send_message = 'waiting'
-        executor = TaskExecutor(10)
-        runner = TaskRunner(executor)
+        runner = TaskRunner(num_workers=10)
         runner.add(None, add_command,)
         runner.add(None, add_command2)
         runner.run()

--- a/ddsc/core/tests/test_projectuploader.py
+++ b/ddsc/core/tests/test_projectuploader.py
@@ -208,10 +208,8 @@ class TestCreateSmallFile(TestCase):
 class TestProjectUploader(TestCase):
     @patch('ddsc.core.projectuploader.ProjectWalker')
     @patch('ddsc.core.projectuploader.TaskRunner')
-    @patch('ddsc.core.projectuploader.TaskExecutor')
     @patch('ddsc.core.projectuploader.SmallItemUploadTaskBuilder')
-    def test_run_sorts_new_files_first(self, mock_small_task_builder, mock_task_executor, mock_task_runner,
-                                       mock_project_walker):
+    def test_run_sorts_new_files_first(self, mock_small_task_builder, mock_task_runner, mock_project_walker):
         settings = Mock()
         settings.config.upload_bytes_per_chunk = 100
         uploader = ProjectUploader(settings)
@@ -247,10 +245,8 @@ class TestProjectUploader(TestCase):
 
     @patch('ddsc.core.projectuploader.ProjectWalker')
     @patch('ddsc.core.projectuploader.TaskRunner')
-    @patch('ddsc.core.projectuploader.TaskExecutor')
     @patch('ddsc.core.projectuploader.SmallItemUploadTaskBuilder')
-    def test_run_with_large_files_hash_matching(self, mock_small_task_builder, mock_task_executor, mock_task_runner,
-                                                mock_project_walker):
+    def test_run_with_large_files_hash_matching(self, mock_small_task_builder, mock_task_runner, mock_project_walker):
         settings = Mock()
         settings.config.upload_bytes_per_chunk = 100
         uploader = ProjectUploader(settings)
@@ -276,11 +272,10 @@ class TestProjectUploader(TestCase):
         ])
 
     @patch('ddsc.core.projectuploader.TaskRunner')
-    @patch('ddsc.core.projectuploader.TaskExecutor')
     @patch('ddsc.core.projectuploader.SmallItemUploadTaskBuilder')
     @patch('ddsc.core.projectuploader.FileUploader')
     def test_process_large_file_sets_file_hash_and_alg(self, mock_file_uploader, mock_small_task_builder,
-                                                       mock_task_executor, mock_task_runner):
+                                                       mock_task_runner):
         uploader = ProjectUploader(Mock())
         local_file = Mock()
         parent = Mock()
@@ -295,11 +290,9 @@ class TestProjectUploader(TestCase):
         )
 
     @patch('ddsc.core.projectuploader.TaskRunner')
-    @patch('ddsc.core.projectuploader.TaskExecutor')
     @patch('ddsc.core.projectuploader.SmallItemUploadTaskBuilder')
     @patch('ddsc.core.projectuploader.FileUploader')
-    def test_upload_large_files__updates_watcher(self, mock_file_uploader, mock_small_task_builder,
-                                                 mock_task_executor, mock_task_runner):
+    def test_upload_large_files__updates_watcher(self, mock_file_uploader, mock_small_task_builder, mock_task_runner):
         local_file1 = Mock(size=1000)
         local_file1.hash_matches_remote.return_value = False
         local_file2 = Mock(size=2000)

--- a/ddsc/core/tests/test_projectuploader.py
+++ b/ddsc/core/tests/test_projectuploader.py
@@ -212,6 +212,8 @@ class TestProjectUploader(TestCase):
     def test_run_sorts_new_files_first(self, mock_small_task_builder, mock_task_runner, mock_project_walker):
         settings = Mock()
         settings.config.upload_bytes_per_chunk = 100
+        num_upload_workers = 6
+        settings.config.upload_workers = num_upload_workers
         uploader = ProjectUploader(settings)
         uploader.process_large_file = Mock()
         small_file_existing = Mock(remote_id='abc123', size=1000)
@@ -232,6 +234,7 @@ class TestProjectUploader(TestCase):
 
         uploader.run(local_project)
 
+        mock_task_runner.assert_called_with(num_upload_workers)
         # small files should be sorted with new first
         uploader.small_item_task_builder.visit_file.assert_has_calls([
             call(small_file_new, None),


### PR DESCRIPTION
Closes multiprocessing pool to prevent ddsclient from hanging once the download completes on Windows. This problem was not observed on Linux or Mac. This is done by simplifying the TaskRunner class to manage the executor and cleanup at the end of the run method. 

Fixes #285 