### PR TITLE
Skip non-regular files when uploading

### DIFF
--- a/ddsc/core/localstore.py
+++ b/ddsc/core/localstore.py
@@ -31,7 +31,9 @@ class LocalProject(object):
         :param path: str path to add
         """
         abspath = os.path.abspath(path)
-        self.children.append(_build_project_tree(abspath, self.followsymlinks, self.file_filter))
+        child = _build_project_tree(abspath, self.followsymlinks, self.file_filter)
+        if child:
+            self.children.append(child)
 
     def add_paths(self, path_list):
         """
@@ -216,7 +218,7 @@ def _build_project_tree(path, followsymlinks, file_filter):
 
 
 def _on_non_regular_file(path):
-    raise ValueError("Unsupported type of file {}".format(path))
+    print("Warning: Skipping {}. This is an unsupported type of file.".format(path))
 
 
 def _build_folder_tree(top_abspath, followsymlinks, file_filter):

--- a/ddsc/core/tests/test_localstore.py
+++ b/ddsc/core/tests/test_localstore.py
@@ -2,7 +2,7 @@ import shutil
 import tarfile
 from unittest import TestCase
 from ddsc.core.localstore import LocalFile, LocalFolder, LocalProject, KindType, LocalItemsCounter, ItemsToSendCounter
-from mock import patch, Mock, call
+from mock import patch, Mock
 
 
 INCLUDE_ALL = ''

--- a/ddsc/core/tests/test_localstore.py
+++ b/ddsc/core/tests/test_localstore.py
@@ -106,6 +106,15 @@ class TestProjectContent(TestCase):
             '/note.txt'
         ])
 
+    @patch('ddsc.core.localstore.isfile')
+    def test_top_level_non_regular_file(self, mock_isfile):
+        mock_isfile.return_value = False
+        content = LocalProject(False, file_exclude_regex=INCLUDE_ALL)
+        with self.assertRaises(ValueError) as raised_exception:
+            content.add_path('/tmp/DukeDsClientTestFolder/note.txt')
+        self.assertEqual(str(raised_exception.exception),
+                         'Unsupported type of file /tmp/DukeDsClientTestFolder/note.txt')
+
     def test_empty_folder_str(self):
         content = LocalProject(False, file_exclude_regex=INCLUDE_ALL)
         content.add_path('/tmp/DukeDsClientTestFolder/emptyfolder')
@@ -129,6 +138,15 @@ class TestProjectContent(TestCase):
             '/scripts',
             '/scripts/makemoney.sh',
         ])
+
+    @patch('ddsc.core.localstore.isfile')
+    def test_one_folder_containing_non_regular_file(self, mock_isfile):
+        mock_isfile.return_value = False
+        content = LocalProject(False, file_exclude_regex=INCLUDE_ALL)
+        with self.assertRaises(ValueError) as raised_exception:
+            content.add_path('/tmp/DukeDsClientTestFolder/scripts')
+        self.assertEqual(str(raised_exception.exception),
+                         'Unsupported type of file /tmp/DukeDsClientTestFolder/scripts/makemoney.sh')
 
     def test_nested_folder_str(self):
         content = LocalProject(False, file_exclude_regex=INCLUDE_ALL)


### PR DESCRIPTION
When uploading skip non-regular files (such as pipe files, sockets, etc) and warn the user.

Fixes #288 

