### PR TITLE
derive user email when null

### DIFF
--- a/ddsc/core/remotestore.py
+++ b/ddsc/core/remotestore.py
@@ -2,7 +2,7 @@ import os
 from ddsc.core.ddsapi import DataServiceApi, DataServiceError, DataServiceAuth
 from ddsc.core.util import KindType, REMOTE_PATH_SEP, RemotePath
 from ddsc.core.localstore import HashUtil
-from ddsc.core.userutil import UserUtil
+from ddsc.core.userutil import UserUtil, DUKE_EMAIL_SUFFIX
 
 FETCH_ALL_USERS_PAGE_SIZE = 25
 DOWNLOAD_FILE_CHUNK_SIZE = 20 * 1024 * 1024
@@ -472,6 +472,8 @@ class RemoteUser(object):
         self.username = json_data['username']
         self.full_name = json_data['full_name']
         self.email = json_data['email']
+        if not self.email and self.username:
+            self.email = '{}{}'.format(self.username, DUKE_EMAIL_SUFFIX)
         self.first_name = json_data['first_name']
         self.last_name = json_data['last_name']
 

--- a/ddsc/core/tests/test_remotestore.py
+++ b/ddsc/core/tests/test_remotestore.py
@@ -257,6 +257,26 @@ class TestRemoteUser(TestCase):
         self.assertEqual('John', user.first_name)
         self.assertEqual('Smith', user.last_name)
         self.assertEqual('id:12789123897123978 username:js123 full_name:John Smith', str(user))
+        self.assertEqual('john.smith@duke.edu', user.email)
+
+    def test_parse_user_derive_email(self):
+        users_json_str = """{
+            "results": [
+            {
+              "id": "12789123897123978",
+              "username": "js123",
+              "full_name": "John Smith",
+              "email": null,
+              "first_name" : "John",
+              "last_name" : "Smith"
+            }
+            ]
+        }
+        """
+        blob = json.loads(users_json_str)
+        project_json = blob['results'][0]
+        user = RemoteUser(project_json)
+        self.assertEqual('js123@duke.edu', user.email)
 
 
 class TestRemoteAuthRole(TestCase):


### PR DESCRIPTION
Fix patterned after https://github.com/Duke-GCB/D4S2/pull/233.
This is to work around a limitation of the DukeDS affiliate/user listing.

Fixes #290 