### PR TITLE
Fix KeyError due to upload payload differences

### DIFF
--- a/ddsc/core/fileuploader.py
+++ b/ddsc/core/fileuploader.py
@@ -255,10 +255,13 @@ class FileUploadOperations(object):
         upload_data = upload_response.json()
         file_name = upload_data['name']
         file_size = upload_data['size']
-        total_chunk_size = sum([chunk['size'] for chunk in upload_data['chunks']])
-        if file_size != total_chunk_size:
-            raise ValueError("Failure uploading {}. Size mismatch file: {} vs chunks:{}."
-                             "\nPlease retry uploading.".format(file_name, file_size, total_chunk_size))
+        file_chunks = upload_data.get('chunks')
+        # Only multi-chunk file uploads have 'chunks' payload (even though single chunk files have 1 chunk uploaded)
+        if file_chunks:
+            total_chunk_size = sum([chunk['size'] for chunk in file_chunks])
+            if file_size != total_chunk_size:
+                raise ValueError("Failure uploading {}. Size mismatch file: {} vs chunks:{}."
+                                 "\nPlease retry uploading.".format(file_name, file_size, total_chunk_size))
 
 
 class ParallelChunkProcessor(object):

--- a/ddsc/core/tests/test_fileuploader.py
+++ b/ddsc/core/tests/test_fileuploader.py
@@ -195,6 +195,19 @@ class TestFileUploadOperations(TestCase):
                          'Failure uploading somefile.txt. Size mismatch file: 150 vs chunks:100.\n'
                          'Please retry uploading.')
 
+    def test_finish_upload_with_no_chunks(self):
+        data_service = MagicMock()
+        data_service.get_upload.return_value.json.return_value = {
+            'name': 'somefile.txt',
+            'size': 150
+        }
+        fop = FileUploadOperations(data_service, MagicMock())
+        fop.finish_upload(upload_id="123",
+                          hash_data=MagicMock(),
+                          parent_data=MagicMock(),
+                          remote_file_id="456")
+        data_service.complete_upload.assert_called()
+
     @patch('ddsc.core.ddsapi.time.sleep')
     def test_create_upload_with_one_pause(self, mock_sleep):
         data_service = MagicMock()


### PR DESCRIPTION
Only checking size for multi-chunk uploads.
Fixes bug introduced in #293