### PR TITLE
use Anaconda3/2019.10-gcb01 for environment module

### DIFF
--- a/deploy/ddsclient-generic-gcb01.spec
+++ b/deploy/ddsclient-generic-gcb01.spec
@@ -62,7 +62,7 @@ Prefix: %{_prefix}
 %define buildhostversion 1
 %define compiler %( if [[ %{getenv:TYPE} == "Comp" || %{getenv:TYPE} == "MPI" ]]; then if [[ -n "%{getenv:FASRCSW_COMPS}" ]]; then echo "%{getenv:FASRCSW_COMPS}"; fi; else echo "system"; fi)
 %define mpi %(if [[ %{getenv:TYPE} == "MPI" ]]; then if [[ -n "%{getenv:FASRCSW_MPIS}" ]]; then echo "%{getenv:FASRCSW_MPIS}"; fi; else echo ""; fi)
-%define builddependencies Anaconda3/5.0.1-gcb01
+%define builddependencies Anaconda3/2019.10-gcb01
 %define rundependencies %{builddependencies}
 %define buildcomments %{nil}
 %define requestor %{nil}
@@ -132,8 +132,8 @@ umask 022
 cd "$FASRCSW_DEV"/rpmbuild/BUILD/%{name}-%{version}
 echo %{buildroot} | grep -q %{name}-%{version} && rm -rf %{buildroot}
 mkdir -p %{buildroot}/%{_prefix}
-mkdir -p %{buildroot}/%{_prefix}/lib/python3.6/site-packages
-export PYTHONPATH=%{buildroot}/%{_prefix}/lib/python3.6/site-packages
+mkdir -p %{buildroot}/%{_prefix}/lib/python3.7/site-packages
+export PYTHONPATH=%{buildroot}/%{_prefix}/lib/python3.7/site-packages
 PYTHONUSERBASE=%{buildroot}/%{_prefix} pip install --user --upgrade PyYAML requests DukeDSClient==%{version}
 #(this should not need to be changed)
 #these files are nice to have; %%doc is not as prefix-friendly as I would like
@@ -237,7 +237,7 @@ prepend_path("LIBRARY_PATH",        "%{_prefix}/lib")
 --prepend_path("PATH",                "%{_prefix}/sbin")
 --prepend_path("INFOPATH",            "%{_prefix}/share/info")
 --prepend_path("MANPATH",             "%{_prefix}/share/man")
-prepend_path("PYTHONPATH",          "%{_prefix}/lib/python3.6/site-packages")
+prepend_path("PYTHONPATH",          "%{_prefix}/lib/python3.7/site-packages")
 EOF
 
 #------------------- App data file


### PR DESCRIPTION
Updates to the latest python environment module for the template used when releasing new versions.