### PR TITLE
Drop python2 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,10 @@ Please see [the tutorial on installing packages](https://packaging.python.org/tu
 
 ### Config file setup.
 
-DukeDSClient requires a config file containing an __agent_key__ and a __user_key__.
-DukeDSClient supports a global configuration file at /etc/ddsclient.conf and a user configuration file at ~/.ddsclient.
-Settings in the user configuration file override those in the global configuration.
-Details of all configuration options: [Configuration options](https://github.com/Duke-GCB/DukeDSClient/wiki/Configuration).
+DukeDSClient requires a config file containing your credentials used to access the duke-data-service.
+Complete details are available in the [configuration documentation](https://github.com/Duke-GCB/DukeDSClient/wiki/Configuration).
 
-#####  Follow these instructions to setup your __user_key__ and  __agent_key__:
+#####  Create credentials and config file
 
 [Instructions for adding agent and user keys to the user config file.](https://github.com/Duke-GCB/DukeDSClient/wiki/Agent-User-Keys-(setup))
 

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ For help email <gcb-help@duke.edu>.
 
 # Installation:
 
-DukeDSClient is can be installed using the `pip3` command line program.
+DukeDSClient can be installed using the `pip3` command line program.
 
-To install or upgrade **DukeDSClient** from a Terminal/Command Prompt run the following:
+To install or upgrade **DukeDSClient** from a Terminal or Command Prompt run the following:
 ```
 pip3 install --upgrade DukeDSClient
 ```

--- a/README.md
+++ b/README.md
@@ -9,9 +9,6 @@ For help email <gcb-help@duke.edu>.
 # Requirements
 
 - [python](https://www.python.org/) - version 3.5+
-- [requests](http://docs.python-requests.org/en/master/) - python module
-- [PyYAML](http://pyyaml.org/wiki/PyYAML) - python module
-
 
 # Installation:
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ For help email <gcb-help@duke.edu>.
 
 - [python](https://www.python.org/) - version 3.5+
 
+__NOTE:__ When installing Python on Windows be sure to check the `Add Python to PATH` checkbox. This will avoid a problem where `pip3` and/or `ddsclient` cannot be found. 
+
 # Installation:
 
 DukeDSClient can be installed using the `pip3` command line program.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Command line tool to upload/manage project on the [duke-data-service](https://gi
 [![Coverage Status](https://coveralls.io/repos/github/Duke-GCB/DukeDSClient/badge.svg)](https://coveralls.io/github/Duke-GCB/DukeDSClient)
 
 
-To get help installing or using this tool send an email to <gcb-help@duke.edu>.
+For help email <gcb-help@duke.edu>.
 
 # Requirements
 
@@ -19,11 +19,11 @@ To get help installing or using this tool send an email to <gcb-help@duke.edu>.
 DukeDSClient is written in Python and packaged for easy installation from [PyPI](https://pypi.org/project/DukeDSClient/) using `pip3`.
 If you do not have superuser or administrative privileges on your machine, you will either have to run `pip3` with the [`--user` scheme](https://docs.python.org/3/install/index.html#alternate-installation-the-user-scheme) or create a [virtual environment](https://packaging.python.org/tutorials/installing-packages/#creating-virtual-environments).
 
-Please see [the tutorial on installing packages](https://packaging.python.org/tutorials/installing-packages/) for full details, but the below commands will install **DukeDSClient** using `pip3`:
-
+To simply install **DukeDSClient** run the following from a Terminal/Command Prompt:
 ```
 pip3 install DukeDSClient
 ```
+Please see [the tutorial on installing packages](https://packaging.python.org/tutorials/installing-packages/) for other options on installing python packages.
 
 ### Config file setup.
 
@@ -37,13 +37,6 @@ Details of all configuration options: [Configuration options](https://github.com
 [Instructions for adding agent and user keys to the user config file.](https://github.com/Duke-GCB/DukeDSClient/wiki/Agent-User-Keys-(setup))
 
 ### Usage:
-
-If DukeDSClient is installed in a [virtual environment](https://packaging.python.org/tutorials/installing-packages/#creating-virtual-environments), you must activate the virtual environment before running ddsclient:
-
-```
-source ddsclient-env/bin/activate
-```
-
 See general help screen:
 
 ```
@@ -59,6 +52,12 @@ ddsclient <command> -h
 All commands take the form:
 ```
 ddsclient <command> <arguments...>
+```
+
+If DukeDSClient has been installed in a [virtual environment](https://packaging.python.org/tutorials/installing-packages/#creating-virtual-environments), you must activate the virtual environment before running ddsclient:
+
+```
+source ddsclient-env/bin/activate
 ```
 
 ### Upload:

--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
-# DukeDSClient
-Command line tool to upload/manage project on the [duke-data-service](https://github.com/Duke-Translational-Bioinformatics/duke-data-service).
-
-[![CircleCI](https://circleci.com/gh/Duke-GCB/DukeDSClient.svg?style=svg)](https://circleci.com/gh/Duke-GCB/DukeDSClient)
-[![Coverage Status](https://coveralls.io/repos/github/Duke-GCB/DukeDSClient/badge.svg)](https://coveralls.io/github/Duke-GCB/DukeDSClient)
-
+# DukeDSClient [![CircleCI](https://circleci.com/gh/Duke-GCB/DukeDSClient.svg?style=svg)](https://circleci.com/gh/Duke-GCB/DukeDSClient)
+Command line tool to upload/manage projects on the [duke-data-service](https://github.com/Duke-Translational-Bioinformatics/duke-data-service).
 
 For help email <gcb-help@duke.edu>.
+
+[![Coverage Status](https://coveralls.io/repos/github/Duke-GCB/DukeDSClient/badge.svg)](https://coveralls.io/github/Duke-GCB/DukeDSClient)
+
 
 # Requirements
 
@@ -17,13 +16,12 @@ For help email <gcb-help@duke.edu>.
 # Installation:
 
 DukeDSClient is written in Python and packaged for easy installation from [PyPI](https://pypi.org/project/DukeDSClient/) using `pip3`.
-If you do not have superuser or administrative privileges on your machine, you will either have to run `pip3` with the [`--user` scheme](https://docs.python.org/3/install/index.html#alternate-installation-the-user-scheme) or create a [virtual environment](https://packaging.python.org/tutorials/installing-packages/#creating-virtual-environments).
-
 To simply install **DukeDSClient** run the following from a Terminal/Command Prompt:
 ```
 pip3 install DukeDSClient
 ```
-Please see [the tutorial on installing packages](https://packaging.python.org/tutorials/installing-packages/) for other options on installing python packages.
+If you do not have superuser or administrative privileges on your machine, you will either have to run `pip3` with the [`--user` scheme](https://docs.python.org/3/install/index.html#alternate-installation-the-user-scheme) or create a [virtual environment](https://packaging.python.org/tutorials/installing-packages/#creating-virtual-environments).
+Please see [the tutorial on installing packages](https://packaging.python.org/tutorials/installing-packages/) for more details.
 
 ### Config file setup.
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
-# DukeDSClient
-Command line tool to upload/manage projects on the [duke-data-service](https://github.com/Duke-Translational-Bioinformatics/duke-data-service).
+# DukeDSClient [![CircleCI](https://circleci.com/gh/Duke-GCB/DukeDSClient.svg?style=svg)](https://circleci.com/gh/Duke-GCB/DukeDSClient) [![Coverage Status](https://coveralls.io/repos/github/Duke-GCB/DukeDSClient/badge.svg)](https://coveralls.io/github/Duke-GCB/DukeDSClient)
+
+This command line program will allow you to upload, download, and manage projects in the [duke-data-service](https://github.com/Duke-Translational-Bioinformatics/duke-data-service).
 
 For help email <gcb-help@duke.edu>.
 
-[![CircleCI](https://circleci.com/gh/Duke-GCB/DukeDSClient.svg?style=svg)](https://circleci.com/gh/Duke-GCB/DukeDSClient)
-[![Coverage Status](https://coveralls.io/repos/github/Duke-GCB/DukeDSClient/badge.svg)](https://coveralls.io/github/Duke-GCB/DukeDSClient)
 
 # Requirements
 
@@ -12,12 +11,15 @@ For help email <gcb-help@duke.edu>.
 
 # Installation:
 
-DukeDSClient is written in Python and packaged for easy installation from [PyPI](https://pypi.org/project/DukeDSClient/) using `pip3`.
+DukeDSClient is can be installed using the `pip3` command line program.
 
-To install **DukeDSClient** from a Terminal/Command Prompt run the following:
+To install or upgrade **DukeDSClient** from a Terminal/Command Prompt run the following:
 ```
-pip3 install DukeDSClient
+pip3 install --upgrade DukeDSClient
 ```
+
+The above commmand will install the latest version of DukeDSClient from [PyPI](https://pypi.org/project/DukeDSClient/).
+
 If you do not have superuser or administrative privileges on your machine, you will either have to run `pip3` with the [`--user` scheme](https://docs.python.org/3/install/index.html#alternate-installation-the-user-scheme) or create a [virtual environment](https://packaging.python.org/tutorials/installing-packages/#creating-virtual-environments).
 Please see [the tutorial on installing packages](https://packaging.python.org/tutorials/installing-packages/) for more details.
 
@@ -48,12 +50,6 @@ ddsclient <command> -h
 All commands take the form:
 ```
 ddsclient <command> <arguments...>
-```
-
-If DukeDSClient has been installed in a [virtual environment](https://packaging.python.org/tutorials/installing-packages/#creating-virtual-environments), you must activate the virtual environment before running ddsclient:
-
-```
-source ddsclient-env/bin/activate
 ```
 
 ### Upload:

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# DukeDSClient [![CircleCI](https://circleci.com/gh/Duke-GCB/DukeDSClient.svg?style=svg)](https://circleci.com/gh/Duke-GCB/DukeDSClient)
+# DukeDSClient
 Command line tool to upload/manage projects on the [duke-data-service](https://github.com/Duke-Translational-Bioinformatics/duke-data-service).
 
 For help email <gcb-help@duke.edu>.
 
+[![CircleCI](https://circleci.com/gh/Duke-GCB/DukeDSClient.svg?style=svg)](https://circleci.com/gh/Duke-GCB/DukeDSClient)
 [![Coverage Status](https://coveralls.io/repos/github/Duke-GCB/DukeDSClient/badge.svg)](https://coveralls.io/github/Duke-GCB/DukeDSClient)
-
 
 # Requirements
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ pip3 install --upgrade DukeDSClient
 
 The above commmand will install the latest version of DukeDSClient from [PyPI](https://pypi.org/project/DukeDSClient/).
 
-If you do not have superuser or administrative privileges on your machine, you will either have to run `pip3` with the [`--user` scheme](https://docs.python.org/3/install/index.html#alternate-installation-the-user-scheme) or create a [virtual environment](https://packaging.python.org/tutorials/installing-packages/#creating-virtual-environments).
+If you receive a permission denied error it may be due to you not having superuser or administrative privileges on your machine. You can run `pip3` with the [`--user` scheme](https://docs.python.org/3/install/index.html#alternate-installation-the-user-scheme) or create a [virtual environment](https://packaging.python.org/tutorials/installing-packages/#creating-virtual-environments) to work around this limitation.
 Please see [the tutorial on installing packages](https://packaging.python.org/tutorials/installing-packages/) for more details.
 
 ### Config file setup.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ For help email <gcb-help@duke.edu>.
 # Installation:
 
 DukeDSClient is written in Python and packaged for easy installation from [PyPI](https://pypi.org/project/DukeDSClient/) using `pip3`.
-To simply install **DukeDSClient** run the following from a Terminal/Command Prompt:
+
+To install **DukeDSClient** from a Terminal/Command Prompt run the following:
 ```
 pip3 install DukeDSClient
 ```

--- a/README.md
+++ b/README.md
@@ -5,26 +5,24 @@ Command line tool to upload/manage project on the [duke-data-service](https://gi
 [![Coverage Status](https://coveralls.io/repos/github/Duke-GCB/DukeDSClient/badge.svg)](https://coveralls.io/github/Duke-GCB/DukeDSClient)
 
 
+To get help installing or using this tool send an email to <gcb-help@duke.edu>.
+
 # Requirements
 
-- [python](https://www.python.org/) - version 2.7+ with a functional ssl module.
+- [python](https://www.python.org/) - version 3.5+
 - [requests](http://docs.python-requests.org/en/master/) - python module
 - [PyYAML](http://pyyaml.org/wiki/PyYAML) - python module
 
-The preferred python versions are 2.7.9+ or 3.4.1+ as they have functional ssl modules by default.
-Older python 2.7 may work by following this guide: [Older-python-2.7-setup](https://github.com/Duke-GCB/DukeDSClient/wiki/Older-python-2.7-setup)
 
 # Installation:
 
-DukeDSClient is written in Python and packaged for easy installation from [PyPI](https://pypi.org/project/DukeDSClient/) using `pip`.
-If you do not have superuser or administrative privileges on your machine, you will either have to create a [virtual environment (recommended)](https://packaging.python.org/tutorials/installing-packages/#creating-virtual-environments) or run `pip` with the [`--user` scheme](https://docs.python.org/3/install/index.html#alternate-installation-the-user-scheme).
+DukeDSClient is written in Python and packaged for easy installation from [PyPI](https://pypi.org/project/DukeDSClient/) using `pip3`.
+If you do not have superuser or administrative privileges on your machine, you will either have to run `pip3` with the [`--user` scheme](https://docs.python.org/3/install/index.html#alternate-installation-the-user-scheme) or create a [virtual environment](https://packaging.python.org/tutorials/installing-packages/#creating-virtual-environments).
 
-Please see [the tutorial on installing packages](https://packaging.python.org/tutorials/installing-packages/) for full details, but the below commands will create a virtual environment named **ddsclient-env** and install **DukeDSClient**:
+Please see [the tutorial on installing packages](https://packaging.python.org/tutorials/installing-packages/) for full details, but the below commands will install **DukeDSClient** using `pip3`:
 
 ```
-python3 -m venv ddsclient-env       # Creates an environment called 'ddsclient-env'
-source ddsclient-env/bin/activate   # Activates the ddsclient-env environment
-pip3 install DukeDSClient           # Installs 'DukeDSClient' into 'ddsclient-env'
+pip3 install DukeDSClient
 ```
 
 ### Config file setup.

--- a/ddsc/tests/test_versioncheck.py
+++ b/ddsc/tests/test_versioncheck.py
@@ -5,12 +5,6 @@ import requests
 
 
 class TestVerifyEncoding(TestCase):
-    def test_check_version_works(self):
-        """
-        pypi shouldn't be a greater version than the development version
-        """
-        check_version()
-
     @patch("ddsc.versioncheck.get_internal_version")
     @patch("ddsc.versioncheck.get_pypi_version")
     def test_check_version_new_version_raises(self, mock_get_pypi_version, mock_get_internal_version):

--- a/integration_test.sh
+++ b/integration_test.sh
@@ -2,6 +2,8 @@ set -e
 
 USERNAME=$1
 USER_EMAIL=$2
+PROJECT_PREFIX="int_test"
+export PROJ="python$PROJECT_PREFIX"
 
 if [ "$USERNAME" == "" -o "$USER_EMAIL" == "" ]
 then
@@ -9,43 +11,16 @@ then
    exit 1
 fi
 
-USERNAME=$1
-USER_EMAIL=$2
-
-PROJECT_PREFIX="int_test"
-
-echo "python unit tests"
-python setup.py -q test
-
-echo "python3 unit tests"
-python3 setup.py -q test
-
-export PROJ="python$PROJECT_PREFIX"
 echo "test upload $PROJ"
-python -m ddsc upload -p $PROJ ddsc/
-python -m ddsc add-user -p $PROJ --email $USER_EMAIL
+python3 -m ddsc upload -p $PROJ ddsc/
+python3 -m ddsc add-user -p $PROJ --email $USER_EMAIL
 
 echo "Waiting for DukeDS background processing"
 sleep 30
+
 echo "test download $PROJ"
 # test filename conversion
-python -m ddsc download -p $PROJ
+python3 -m ddsc download -p $PROJ $PROJ
 echo "differences:"
 diff --brief -r ddsc/ $PROJ/ddsc/
 rm -rf $PROJ
-
-export PROJ2="python3$PROJECT_PREFIX"
-echo "test upload $PROJ2"
-python3 -m ddsc upload -p $PROJ2 ddsc/
-python3 -m ddsc add-user -p $PROJ2 --user $USERNAME
-python3 -m ddsc remove-user -p $PROJ2 --user $USERNAME
-
-echo "Waiting for DukeDS background processing"
-sleep 30
-echo "test download $PROJ2"
-rm -rf /tmp/$PROJ2
-python3 -m ddsc download -p $PROJ /tmp/$PROJ2
-echo "differences:"
-diff --brief -r ddsc/ /tmp/$PROJ2/ddsc/
-
-echo "Success check data on portal"

--- a/setup.py
+++ b/setup.py
@@ -25,14 +25,11 @@ setup(name='DukeDSClient',
             ]
         },
         classifiers=[
-            'Development Status :: 3 - Alpha',
+            'Development Status :: 5 - Production/Stable',
             'Intended Audience :: Developers',
             'Topic :: Utilities',
-            'License :: OSI Approved :: MIT License',
-            'Programming Language :: Python :: 2.7',
-            'Programming Language :: Python :: 3.3',
-            'Programming Language :: Python :: 3.4',
-            'Programming Language :: Python :: 3.5',
+            'License :: OSI Approved :: MIT License'
         ],
+        python_requires='>=3.5',
     )
 


### PR DESCRIPTION
Update config and docs to require python 3.5+
python 3.4 went end of life March 18th, 2019
python 2.7 went end of life Jan 1st, 2020
