### PR TITLE
raise better exception for an empty config file

### DIFF
--- a/ddsc/config.py
+++ b/ddsc/config.py
@@ -88,7 +88,11 @@ class Config(object):
         filename = os.path.expanduser(filename)
         if os.path.exists(filename):
             with open(filename, 'r') as yaml_file:
-                self.update_properties(yaml.safe_load(yaml_file))
+                config_data = yaml.safe_load(yaml_file)
+                if config_data:
+                    self.update_properties(config_data)
+                else:
+                    raise ValueError("Error: Empty config file {}".format(filename))
 
     def update_properties(self, new_values):
         """

--- a/ddsc/tests/test_config.py
+++ b/ddsc/tests/test_config.py
@@ -2,7 +2,7 @@ from unittest import TestCase
 import math
 import ddsc.config
 import multiprocessing
-from mock.mock import patch
+from mock.mock import patch, mock_open
 
 
 class TestConfig(TestCase):
@@ -159,3 +159,13 @@ class TestConfig(TestCase):
         }
         config.update_properties(some_config)
         self.assertEqual(config.storage_provider_id, '123456')
+
+    @patch('ddsc.config.os')
+    def test_add_properties_empty_file(self, mock_os):
+        mock_os.path.expanduser.return_value = '/home/user/.ddsclient'
+        mock_os.path.exists.return_value = True
+        config = ddsc.config.Config()
+        with self.assertRaises(ValueError) as raised_exception:
+            with patch('builtins.open', mock_open(read_data='')):
+                config.add_properties('~/.ddsclient')
+        self.assertEqual(str(raised_exception.exception), 'Error: Empty config file /home/user/.ddsclient')


### PR DESCRIPTION
The `yaml.safe_load` method returns None for an empty YAML file(which makes sense). 
This caused problems loading config. Changes here check for None and show a better error message.

Fixes #316