### PR TITLE
Allow deleting files/folders with ddsclient

### DIFF
--- a/ddsc/cmdparser.py
+++ b/ddsc/cmdparser.py
@@ -459,12 +459,17 @@ class CommandParser(object):
 
     def register_delete_command(self, delete_func):
         """
-        Add 'delete' command delete a project from the remote store.
+        Add 'delete' command delete a project or a file/folder within a project from the remote store.
         :param delete_func: function: run when user choses this option.
         """
-        description = "Permanently delete a project."
+        description = "Permanently delete a project or file/folder."
         delete_parser = self.subparsers.add_parser('delete', description=description)
         add_project_name_or_id_arg(delete_parser, help_text_suffix="delete")
+        delete_parser.add_argument('--path',
+                                   metavar='RemotePath',
+                                   type=to_unicode,
+                                   dest='remote_path',
+                                   help="remote path specifying the file/folder to be deleted instead of the entire project")
         _add_force_arg(delete_parser, "Do not prompt before deleting.")
         delete_parser.set_defaults(func=delete_func)
 

--- a/ddsc/ddsclient.py
+++ b/ddsc/ddsclient.py
@@ -444,7 +444,7 @@ class ListCommand(BaseCommand):
         return project_name
 
 
-class DeleteCommand(BaseCommand):
+class DeleteCommand(ClientCommand):
     """
     Delete a single project from the duke-data-service.
     """
@@ -460,12 +460,17 @@ class DeleteCommand(BaseCommand):
         Deletes a single project specified by project_name in args.
         :param args Namespace arguments parsed from the command line
         """
-        project = self.fetch_project(args, must_exist=True, include_children=False)
+        project = self.get_project_by_name_or_id(args)
+        delete_target = project
+        delete_target_name = project.name
+        if args.remote_path:
+            delete_target = project.get_child_for_path(args.remote_path)
+            delete_target_name = "{} path {}".format(delete_target_name, args.remote_path)
         if not args.force:
-            delete_prompt = "Are you sure you wish to delete {} (y/n)?".format(project.name)
+            delete_prompt = "Are you sure you wish to delete {} (y/n)?".format(delete_target_name)
             if not boolean_input_prompt(delete_prompt):
                 return
-        self.remote_store.delete_project(self.create_project_name_or_id_from_args(args))
+        delete_target.delete()
 
 
 class ListAuthRolesCommand(BaseCommand):

--- a/ddsc/tests/test_cmdparser.py
+++ b/ddsc/tests/test_cmdparser.py
@@ -208,3 +208,14 @@ class TestCommandParser(TestCase):
         mock_os.path.exists.return_value = True
         mock_os.listdir.return_value = ['stuff']
         format_destination_path(path='/tmp/somepath')
+
+    def test_register_delete_command(self):
+        command_parser = CommandParser(version_str='1.0')
+        command_parser.register_delete_command(self.set_parsed_args)
+        self.assertEqual(['delete'], list(command_parser.subparsers.choices.keys()))
+        command_parser.run_command(['delete', '-p', 'mouse'])
+        self.assertEqual('mouse', self.parsed_args.project_name)
+        self.assertEqual(None, self.parsed_args.remote_path)
+        command_parser.run_command(['delete', '-p', 'mouse', '--path', '/data/file1.txt'])
+        self.assertEqual('mouse', self.parsed_args.project_name)
+        self.assertEqual('/data/file1.txt', self.parsed_args.remote_path)

--- a/ddsc/tests/test_ddsclient.py
+++ b/ddsc/tests/test_ddsclient.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 from unittest import TestCase
 from ddsc.ddsclient import BaseCommand, UploadCommand, ListCommand, DownloadCommand, ClientCommand, MoveCommand
 from ddsc.ddsclient import ShareCommand, DeliverCommand, InfoCommand, read_argument_file_contents, \
-    INVALID_DELIVERY_RECIPIENT_MSG, DDSClient
+    INVALID_DELIVERY_RECIPIENT_MSG, DDSClient, DeleteCommand
 from ddsc.exceptions import DDSUserException
 from mock import patch, MagicMock, Mock, call, ANY
 
@@ -517,3 +517,22 @@ class TestInfoCommand(TestCase):
             call("Size: 3 top level folders, 0 subfolders, 1 file (12 KiB)"),
             call(),
         ])
+
+
+class TestDeleteCommand(TestCase):
+    @patch('ddsc.ddsclient.Client')
+    def test_run_project_delete(self, mock_client):
+        move_command = DeleteCommand(config=Mock())
+        move_command.run(Mock(project_name='mouse', remote_path=None))
+        mock_project = mock_client.return_value.get_project_by_name.return_value
+        mock_client.return_value.get_project_by_name.assert_called_with("mouse")
+        mock_project.delete.assert_called_with()
+
+    @patch('ddsc.ddsclient.Client')
+    def test_run_project_delete_path(self, mock_client):
+        move_command = DeleteCommand(config=Mock())
+        move_command.run(Mock(project_name='mouse', remote_path='/data/file1.dat'))
+        mock_project = mock_client.return_value.get_project_by_name.return_value
+        mock_client.return_value.get_project_by_name.assert_called_with("mouse")
+        mock_project.get_child_for_path.assert_called_with('/data/file1.dat')
+        mock_project.get_child_for_path.return_value.delete.assert_called_with()


### PR DESCRIPTION
Adds --path option to delete command to delete a single file/folder instead of an entire project.