### PR TITLE
Fix DukeDS.upload_file sdk method

### DIFF
--- a/ddsc/sdk/client.py
+++ b/ddsc/sdk/client.py
@@ -729,7 +729,7 @@ class UploadContext(object):
         self.watcher = self
         self.local_file = UploadFileInfo(path_data)
 
-    def transferring_item(self, item, increment_amt):
+    def transferring_item(self, item, increment_amt, transferred_bytes=0):
         pass
 
     def start_waiting(self):

--- a/ddsc/sdk/tests/test_client.py
+++ b/ddsc/sdk/tests/test_client.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
 from ddsc.sdk.client import Client, DDSConnection, BaseResponseItem, Project, Folder, File, FileDownload, FileUpload, \
-    ChildFinder, PathToFiles, ItemNotFound, ProjectSummary, REMOTE_PATH_SEP
-from ddsc.core.util import KindType
+    ChildFinder, PathToFiles, ItemNotFound, ProjectSummary, REMOTE_PATH_SEP, UploadContext
+from ddsc.core.util import KindType, wait_for_processes, ProgressQueue
 from ddsc.exceptions import DDSUserException
 from mock import patch, Mock, call
 
@@ -843,3 +843,15 @@ class TestProjectSummary(TestCase):
         summary = ProjectSummary(mock_project)
         expected = "1 top level folder, 1 subfolder, 2 files (3 KB)"
         self.assertEqual(str(summary), expected)
+
+
+class TestUploadContext(TestCase):
+    def test_wait_for_process(self):
+        upload_context = UploadContext(Mock(), Mock(), '', Mock())
+        item_size = 1
+        progress_queue = Mock()
+        progress_queue.get.side_effect = [
+            (ProgressQueue.PROCESSED, (10, 1))
+        ]
+        processes = []
+        wait_for_processes(processes, item_size, progress_queue, upload_context, Mock())

--- a/integration_test.sh
+++ b/integration_test.sh
@@ -24,3 +24,11 @@ python3 -m ddsc download -p $PROJ $PROJ
 echo "differences:"
 diff --brief -r ddsc/ $PROJ/ddsc/
 rm -rf $PROJ
+
+echo "SDK testing"
+python3 -c 'import DukeDS; DukeDS.upload_file("pythonint_test", "README.md")'
+python3 -c 'import DukeDS; DukeDS.download_file("pythonint_test", "README.md", "/tmp/README.md")'
+echo "differences:"
+diff README.md /tmp/README.md
+
+ddsclient delete -p pythonint_test --force


### PR DESCRIPTION
Adds missing `transferred_bytes` argument to `UploadContext.upload_file`.

Fixes #321