### PR TITLE
Allow checking and waiting for project consistency

### DIFF
--- a/DukeDS/__init__.py
+++ b/DukeDS/__init__.py
@@ -10,9 +10,12 @@ delete_file = DukeDS.delete_file
 move_file_or_folder = DukeDS.move_file_or_folder
 can_deliver_to_user_with_email = DukeDS.can_deliver_to_user_with_email
 can_deliver_to_user_with_username = DukeDS.can_deliver_to_user_with_username
+is_project_consistent = DukeDS.is_project_consistent
+wait_for_project_consistency = DukeDS.wait_for_project_consistency
 
 __all__ = ['list_projects', 'create_project', 'delete_project',
            'create_folder',
            'list_files', 'download_file', 'upload_file', 'delete_file',
            'move_file_or_folder',
-           'can_deliver_to_user_with_email', 'can_deliver_to_user_with_username']
+           'can_deliver_to_user_with_email', 'can_deliver_to_user_with_username',
+           'is_project_consistent', 'wait_for_project_consistency']

--- a/ddsc/cmdparser.py
+++ b/ddsc/cmdparser.py
@@ -513,6 +513,19 @@ class CommandParser(object):
         add_project_name_or_id_arg(parser, help_text_suffix="to show the information about")
         parser.set_defaults(func=info_func)
 
+    def register_check_command(self, check_func):
+        """
+        Add 'check' command to verify a project is consistent.
+        :param check_func: function: run when user choses this option.
+        """
+        description = "Check that a project is in a consistent state."
+        check_parser = self.subparsers.add_parser('check', description=description)
+        add_project_name_or_id_arg(check_parser, help_text_suffix="check")
+        check_parser.add_argument('--wait',
+                                  help="Wait for project to become consistent.",
+                                  action='store_true')
+        check_parser.set_defaults(func=check_func)
+
     def run_command(self, args):
         """
         Parse command line arguments and run function registered for the appropriate command.

--- a/ddsc/core/consistency.py
+++ b/ddsc/core/consistency.py
@@ -1,0 +1,107 @@
+import time
+from ddsc.core.ddsapi import DSResourceNotConsistentError, DSHashMismatchError
+from tabulate import tabulate
+
+
+class UploadDetails(object):
+    def __init__(self, dds_file, remote_path):
+        self.dds_file = dds_file
+        self.remote_path = remote_path
+        self.dds_upload = dds_file.get_upload()
+        self.status = self.dds_upload.status
+
+    def inconsistent(self):
+        return not self.status.is_consistent
+
+    def had_error(self):
+        return self.status.error_on is not None
+
+    def is_bad(self):
+        return self.inconsistent() or self.had_error()
+
+    def name(self):
+        return self.dds_file.name
+
+    def status_str(self):
+        if self.inconsistent():
+            return 'Inconsistent'
+        elif self.had_error():
+            return 'Error'
+        return 'Ok'
+
+    def file_id(self):
+        return self.dds_file.id
+
+    def message(self):
+        if self.inconsistent():
+            return 'started upload at {}'.format(self.status.initiated_on)
+        elif self.had_error():
+            return self.status.error_message
+        return ''
+
+
+class ProjectChecker(object):
+
+    def __init__(self, config, project):
+        self.config = config
+        self.project = project
+
+    def files_are_ok(self):
+        try:
+            self._try_fetch_project_files()
+            return True
+        except (DSResourceNotConsistentError, DSHashMismatchError):
+            return False
+
+    def _try_fetch_project_files(self):
+        # exhaust the project files generator to fetch urls for all files
+        for _, _ in self.project.get_project_files_generator(self.config.page_size):
+            pass
+
+    def get_bad_uploads(self):
+        results = []
+        for remote_path, dds_file in self.project.get_path_to_files().items():
+            upload_details = UploadDetails(dds_file, remote_path)
+            if upload_details.is_bad():
+                results.append(upload_details)
+        return results
+
+    def get_bad_uploads_table_data(self):
+        headers = ["File", "Status", "Message", "FileID", "RemotePath"]
+        data = []
+        for upload_details in self.get_bad_uploads():
+            data.append([
+                upload_details.name(),
+                upload_details.status_str(),
+                upload_details.message(),
+                upload_details.file_id(),
+                upload_details.remote_path
+            ])
+        return headers, data
+
+    def delete_bad_uploads(self):
+        for bad_upload in self.get_bad_uploads():
+            bad_upload.dds_file.delete()
+
+    def print_bad_uploads_table(self):
+        print("ERROR: Project {} is not in a consistent state.\n".format(self.project.name))
+        print("Please wait while file uploads are checked.\nThis process can take quite a while.")
+        headers, data = self.get_bad_uploads_table_data()
+        print(tabulate(data, headers=headers))
+        print("\nNOTE: Inconsistent files should resolve in a few minutes after starting.")
+        print("\nAn inconsistent file can be deleted by running:\n ddsclient delete -p <ProjectName> --path <RemotePath>")
+        print()
+
+    def wait_for_consistency(self, wait_sec=5):
+        while True:
+            try:
+                print("Checking files for project {}".format(self.project.name))
+                self._try_fetch_project_files()
+                # if we are able to fetch all files project is in a consistent state
+                print("Project {} is consistent.".format(self.project.name))
+                return True
+            except DSResourceNotConsistentError:
+                print("Project not consistent yet. Waiting.")
+                time.sleep(wait_sec)
+            except DSHashMismatchError:
+                raise

--- a/ddsc/core/ddsapi.py
+++ b/ddsc/core/ddsapi.py
@@ -294,6 +294,13 @@ class DSResourceNotConsistentError(DataServiceError):
         super(self.__class__, self).__init__(response, url_suffix, request_data)
 
 
+class DSHashMismatchError(DataServiceError):
+    """
+    Exception thrown when a DukeDS resource has an incorrect hash.
+    """
+    pass
+
+
 class DataServiceApi(object):
     """
     Sends json messages and receives responses back from Duke Data Service api.
@@ -459,6 +466,9 @@ class DataServiceApi(object):
         if resp.status_code == 404:
             if resp.json().get("code") == "resource_not_consistent":
                 raise DSResourceNotConsistentError(resp, url_suffix, data)
+        if resp.status_code == 400:
+            if resp.json().get("reason") == "reported hash value does not match size computed by StorageProvider":
+                raise DSHashMismatchError(resp, url_suffix, data)
         raise DataServiceError(resp, url_suffix, data)
 
     def create_project(self, project_name, desc):

--- a/ddsc/core/tests/test_consistency.py
+++ b/ddsc/core/tests/test_consistency.py
@@ -1,0 +1,121 @@
+from unittest import TestCase
+from ddsc.core.consistency import UploadDetails, ProjectChecker, DSResourceNotConsistentError
+from mock import Mock, patch, call
+
+
+class TestUploadDetails(TestCase):
+    def test_inconsistent_status(self):
+        mock_dds_file = Mock()
+        mock_dds_file.name = 'file1.dat'
+        mock_dds_file.id = '123'
+        mock_status = Mock(is_consistent=False, initiated_on='2021-01-01', error_on=None)
+        mock_dds_file.get_upload.return_value.status = mock_status
+        upload_details = UploadDetails(mock_dds_file, '/data/file1.dat')
+        self.assertEqual(upload_details.inconsistent(), True)
+        self.assertEqual(upload_details.had_error(), False)
+        self.assertEqual(upload_details.is_bad(), True)
+        self.assertEqual(upload_details.name(), 'file1.dat')
+        self.assertEqual(upload_details.status_str(), 'Inconsistent')
+        self.assertEqual(upload_details.file_id(), '123')
+        self.assertEqual(upload_details.message(), 'started upload at 2021-01-01')
+
+    def test_error_status(self):
+        mock_dds_file = Mock()
+        mock_dds_file.name = 'file1.dat'
+        mock_dds_file.id = '123'
+        mock_status = Mock(is_consistent=True, initiated_on='2021-01-01', error_on='2021-01-02', error_message='bad data')
+        mock_dds_file.get_upload.return_value.status = mock_status
+        upload_details = UploadDetails(mock_dds_file, '/data/file1.dat')
+        self.assertEqual(upload_details.inconsistent(), False)
+        self.assertEqual(upload_details.had_error(), True)
+        self.assertEqual(upload_details.is_bad(), True)
+        self.assertEqual(upload_details.name(), 'file1.dat')
+        self.assertEqual(upload_details.status_str(), 'Error')
+        self.assertEqual(upload_details.file_id(), '123')
+        self.assertEqual(upload_details.message(), 'bad data')
+
+    def test_error_ok(self):
+        mock_dds_file = Mock()
+        mock_dds_file.name = 'file1.dat'
+        mock_dds_file.id = '123'
+        mock_status = Mock(is_consistent=True, initiated_on='2021-01-01', error_on=None, error_message=None)
+        mock_dds_file.get_upload.return_value.status = mock_status
+        upload_details = UploadDetails(mock_dds_file, '/data/file1.dat')
+        self.assertEqual(upload_details.inconsistent(), False)
+        self.assertEqual(upload_details.had_error(), False)
+        self.assertEqual(upload_details.is_bad(), False)
+        self.assertEqual(upload_details.name(), 'file1.dat')
+        self.assertEqual(upload_details.status_str(), 'Ok')
+        self.assertEqual(upload_details.file_id(), '123')
+        self.assertEqual(upload_details.message(), '')
+        self.assertEqual(upload_details.remote_path, '/data/file1.dat')
+
+
+class TestProjectChecker(TestCase):
+    def setUp(self):
+        self.config = Mock()
+        self.project = Mock()
+        self.project.name = "Mouse"
+        self.checker = ProjectChecker(self.config, self.project)
+
+    def test_files_are_ok__good(self):
+        self.project.get_project_files_generator.return_value = []
+        self.assertEqual(self.checker.files_are_ok(), True)
+
+    def test_files_are_ok__error(self):
+        self.project.get_project_files_generator.side_effect = DSResourceNotConsistentError(Mock(), Mock(), Mock())
+        dds_file = Mock()
+        dds_file.name = "file1.txt"
+        dds_file.id = "123"
+        dds_file.get_upload.return_value.status.is_consistent = False
+        dds_file.get_upload.return_value.status.error_on = None
+        dds_file.get_upload.return_value.status.initiated_on = '2021-01-01'
+        self.project.get_path_to_files.return_value.items.return_value = [
+            ("/data/bad/file1.txt", dds_file)
+        ]
+        self.assertEqual(self.checker.files_are_ok(), False)
+        headers, data = self.checker.get_bad_uploads_table_data()
+        self.assertEqual(headers, ['File', 'Status', 'Message', 'FileID', 'RemotePath'])
+        self.assertEqual(data, [['file1.txt', 'Inconsistent', 'started upload at 2021-01-01', '123',
+                                 '/data/bad/file1.txt']])
+
+    @patch('ddsc.core.consistency.print')
+    @patch('ddsc.core.consistency.UploadDetails')
+    def test_print_bad_uploads_table(self, mock_upload_details, mock_print):
+        mock_upload_details.return_value.is_bad.return_value = True
+        mock_upload_details.return_value.name.return_value = 'file1.txt'
+        mock_upload_details.return_value.status_str.return_value = 'BAD'
+        mock_upload_details.return_value.message.return_value = ' file is bad'
+        mock_upload_details.return_value.file_id.return_value = '123'
+        mock_upload_details.return_value.remote_path = '/data/file1.txt'
+        self.project.get_path_to_files.return_value.items.return_value = [
+            ('/data/file1.txt', Mock())
+        ]
+        self.checker.print_bad_uploads_table()
+        mock_print.assert_has_calls([
+            call("ERROR: Project Mouse is not in a consistent state.\n"),
+            call("Please wait while file uploads are checked.\nThis process can take quite a while."),
+            call('File       Status    Message        FileID  RemotePath\n'
+                 '---------  --------  -----------  --------  ---------------\n'
+                 'file1.txt  BAD       file is bad       123  /data/file1.txt'),
+            call('\nNOTE: Inconsistent files should resolve in a few minutes after starting.'),
+            call('\nAn inconsistent file can be deleted by running:\n ddsclient delete -p <ProjectName> '
+                 '--path <RemotePath>'),
+            call()
+        ])
+
+    @patch('ddsc.core.consistency.print')
+    @patch('ddsc.core.consistency.time')
+    def test_wait_for_consistency(self, mock_time, mock_print):
+        self.project.get_project_files_generator.side_effect = [
+            DSResourceNotConsistentError(Mock(), Mock(), Mock()),
+            []
+        ]
+        self.checker.wait_for_consistency(wait_sec=10)
+        mock_print.assert_has_calls([
+            call('Checking files for project Mouse'),
+            call('Project not consistent yet. Waiting.'),
+            call('Checking files for project Mouse'),
+            call('Project Mouse is consistent.')
+        ])
+        mock_time.sleep.assert_called_with(10)

--- a/ddsc/core/tests/test_ddsapi.py
+++ b/ddsc/core/tests/test_ddsapi.py
@@ -6,7 +6,7 @@ from ddsc.core.ddsapi import MultiJSONResponse, DataServiceApi, DataServiceAuth,
 from ddsc.core.ddsapi import MissingInitialSetupError, SoftwareAgentNotFoundError, AuthTokenCreationError, \
     UnexpectedPagingReceivedError, DataServiceError, DSResourceNotConsistentError, \
     retry_until_resource_is_consistent, retry_connection_exceptions, CONNECTION_RETRY_MESSAGE, \
-    RetrySettings, OAuthDataServiceAuth
+    RetrySettings, OAuthDataServiceAuth, DSHashMismatchError
 from mock import MagicMock, Mock, patch, ANY, call
 
 
@@ -514,6 +514,14 @@ class TestDataServiceApi(TestCase):
         url_suffix = ""
         data = None
         with self.assertRaises(DataServiceError):
+            DataServiceApi._check_err(resp, url_suffix, data, allow_pagination=False)
+
+    def test_check_err_with_400_hash_wrong(self):
+        resp = Mock(headers={}, status_code=400)
+        resp.json.return_value = {"reason": "reported hash value does not match size computed by StorageProvider"}
+        url_suffix = ""
+        data = None
+        with self.assertRaises(DSHashMismatchError):
             DataServiceApi._check_err(resp, url_suffix, data, allow_pagination=False)
 
     def test_check_err_with_404(self):

--- a/ddsc/sdk/dukeds.py
+++ b/ddsc/sdk/dukeds.py
@@ -31,9 +31,30 @@ class DukeDS(object):
         """
         Delete a project with the specified name. Raises ItemNotFound if no such project exists
         :param project_name: str: name of the project to delete
-        :return:
         """
         Session().delete_project(project_name)
+
+    @staticmethod
+    def is_project_consistent(project_name):
+        """
+        Check that a project is in a consistent state. When large projects are uploaded the DukeDS service can take
+        a while finish background processing. Before deleting uploaded files you should check that the project is in
+        a consistent state. If there is a problem with the project a message will be printed.
+        :param project_name: str: name of the project to check
+        :return: bool: True if the project is consistent.
+        """
+        return Session().is_project_consistent(project_name)
+
+    @staticmethod
+    def wait_for_project_consistency(project_name, wait_sec=5):
+        """
+        Wait for the project to be in a consistent state. When large projects are uploaded the DukeDS service can take
+        a while finish background processing. Before deleting uploaded files you should check that the project is in
+        a consistent state. If there is a problem with the project a message will be printed.
+        :param project_name: str: name of the project to check
+        :param wait_sec: Seconds to wait before giving up.
+        """
+        return Session().wait_for_project_consistency(project_name, wait_sec=wait_sec)
 
     @staticmethod
     def create_folder(project_name, remote_path):
@@ -266,3 +287,23 @@ class Session(object):
     def move_file_or_folder(self, project_name, source_remote_path, target_remote_path):
         project = self._get_or_create_project(project_name)
         project.move_file_or_folder(source_remote_path, target_remote_path)
+
+    def is_project_consistent(self, project_name):
+        """
+        Check that a project is in a consistent state. When large projects are uploaded the DukeDS service can take
+        a while finish background processing. Before deleting uploaded files you should check that the project is in
+        a consistent state. If there is a problem with the project a message will be printed.
+        :param project_name: str: name of the project to check
+        :return: bool: True if the project is consistent.
+        """
+        project = self._get_project_for_name(project_name)
+        return project.is_consistent()
+
+    def wait_for_project_consistency(self, project_name, wait_sec=5):
+        """
+        Wait for the project to become consistent.
+        :param project_name: name of the project to wait for
+        :param wait_sec: Seconds to wait before giving up.
+        """
+        project = self._get_project_for_name(project_name)
+        project.wait_for_consistency(wait_sec=wait_sec)

--- a/ddsc/sdk/tests/test_client.py
+++ b/ddsc/sdk/tests/test_client.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 from ddsc.sdk.client import Client, DDSConnection, BaseResponseItem, Project, Folder, File, FileDownload, FileUpload, \
-    ChildFinder, PathToFiles, ItemNotFound, ProjectSummary, REMOTE_PATH_SEP, UploadContext
+    ChildFinder, PathToFiles, ItemNotFound, ProjectSummary, REMOTE_PATH_SEP, UploadContext, UploadStatus, Upload
 from ddsc.core.util import KindType, wait_for_processes, ProgressQueue
 from ddsc.exceptions import DDSUserException
 from mock import patch, Mock, call
@@ -855,3 +855,41 @@ class TestUploadContext(TestCase):
         ]
         processes = []
         wait_for_processes(processes, item_size, progress_queue, upload_context, Mock())
+
+
+class TestUploadStatus(TestCase):
+    def test_constructor(self):
+        upload_status = UploadStatus({
+            'initiated_on': '2021-01-01',
+            'completed_on': '2021-01-02',
+            'is_consistent': True,
+            'purged_on': '2021-01-03',
+            'error_on': '2021-01-04',
+            'error_message': 'oops'
+        })
+        self.assertEqual(upload_status.initiated_on, '2021-01-01')
+        self.assertEqual(upload_status.completed_on, '2021-01-02')
+        self.assertEqual(upload_status.is_consistent, True)
+        self.assertEqual(upload_status.purged_on, '2021-01-03')
+        self.assertEqual(upload_status.error_on, '2021-01-04')
+        self.assertEqual(upload_status.error_message, 'oops')
+
+
+class TestUpload(TestCase):
+    def test_constructor(self):
+        data = {
+            'id': '123',
+            'name': 'file1.txt',
+            'status': {
+                'initiated_on': '2021-01-01',
+                'completed_on': '2021-01-02',
+                'is_consistent': True,
+                'purged_on': '2021-01-03',
+                'error_on': '2021-01-04',
+                'error_message': 'oops'
+            }
+        }
+        dds_connection = Mock()
+        upload = Upload(dds_connection, data)
+        self.assertEqual(str(upload), 'Upload id:123 name:file1.txt')
+        self.assertEqual(upload.status.initiated_on, '2021-01-01')

--- a/ddsc/tests/test_cmdparser.py
+++ b/ddsc/tests/test_cmdparser.py
@@ -219,3 +219,11 @@ class TestCommandParser(TestCase):
         command_parser.run_command(['delete', '-p', 'mouse', '--path', '/data/file1.txt'])
         self.assertEqual('mouse', self.parsed_args.project_name)
         self.assertEqual('/data/file1.txt', self.parsed_args.remote_path)
+
+    def test_register_check_command(self):
+        command_parser = CommandParser(version_str='1.0')
+        command_parser.register_check_command(self.set_parsed_args)
+        self.assertEqual(['check'], list(command_parser.subparsers.choices.keys()))
+        command_parser.run_command(['check', '-p', 'mouse'])
+        self.assertEqual(self.parsed_args.project_name, 'mouse')
+        self.assertEqual(self.parsed_args.project_id, None)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ PyYAML==5.1
 future==0.16.0
 six==1.10.0
 tenacity==5.0.4
+tabulate==0.8.9

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(name='DukeDSClient',
           'future',
           'six',
           'tenacity==6.2.0',
+          'tabulate'
         ],
         test_suite='nose.collector',
         tests_require=['nose', 'mock'],


### PR DESCRIPTION
Adds `ddsclient check -p <projectName>` command that checks that a project is in a consistent state.
There is an optional `--wait` flag for a the check command to wait until the project is consistent.
There are also sdk methods `DukeDS.is_project_consistent(projectName)` and `DukeDS.wait_for_project_consistency(projectName)`.

Fixes #324 
