### PR TITLE
Handle 400 errors in check command

### DIFF
--- a/ddsc/core/consistency.py
+++ b/ddsc/core/consistency.py
@@ -1,5 +1,5 @@
 import time
-from ddsc.core.ddsapi import DSResourceNotConsistentError, DSHashMismatchError
+from ddsc.core.ddsapi import DSResourceNotConsistentError, DSHashMismatchError, DataServiceError
 from tabulate import tabulate
 
 
@@ -52,6 +52,10 @@ class ProjectChecker(object):
             return True
         except (DSResourceNotConsistentError, DSHashMismatchError):
             return False
+        except DataServiceError as e:
+            if e.status_code == 400:
+                return False
+            raise
 
     def _try_fetch_project_files(self):
         # exhaust the project files generator to fetch urls for all files


### PR DESCRIPTION
Updates check command to handle 400 errors when checking files.
Previously we were looking for specific errors. 
Now we will also assume that the project is inconsistent if we receive any 400 errors during this process.