### PR TITLE
Check for valid download URLs after uploading

### DIFF
--- a/ddsc/cmdparser.py
+++ b/ddsc/cmdparser.py
@@ -367,7 +367,6 @@ class CommandParser(object):
         add_project_name_or_id_arg(upload_parser, help_text_suffix="upload files/folders to.")
         _add_folders_positional_arg(upload_parser)
         _add_follow_symlinks_arg(upload_parser)
-        _add_azure_arg(upload_parser)
         upload_parser.set_defaults(func=upload_func)
 
     def register_add_user_command(self, add_user_func):
@@ -383,7 +382,6 @@ class CommandParser(object):
         add_user_arg(user_or_email)
         add_email_arg(user_or_email)
         _add_auth_role_arg(add_user_parser, default_permissions='project_admin')
-        _add_azure_arg(add_user_parser)
         add_user_parser.set_defaults(func=add_user_func)
 
     def register_remove_user_command(self, remove_user_func):
@@ -397,7 +395,6 @@ class CommandParser(object):
         user_or_email = remove_user_parser.add_mutually_exclusive_group(required=True)
         add_user_arg(user_or_email)
         add_email_arg(user_or_email)
-        _add_azure_arg(remove_user_parser)
         remove_user_parser.set_defaults(func=remove_user_func)
 
     def register_download_command(self, download_func):
@@ -413,7 +410,6 @@ class CommandParser(object):
         include_or_exclude = download_parser.add_mutually_exclusive_group(required=False)
         _add_include_arg(include_or_exclude)
         _add_exclude_arg(include_or_exclude)
-        _add_azure_arg(download_parser)
         download_parser.set_defaults(func=download_func)
 
     def register_share_command(self, share_func):
@@ -433,7 +429,6 @@ class CommandParser(object):
         _add_resend_arg(share_parser, "Resend share")
         _add_message_file(share_parser, "Filename containing a message to be sent with the share. "
                                         "Pass - to read from stdin.")
-        _add_azure_arg(share_parser)
         share_parser.set_defaults(func=share_func)
 
     def register_deliver_command(self, deliver_func):
@@ -458,7 +453,6 @@ class CommandParser(object):
         _add_exclude_arg(include_or_exclude)
         _add_message_file(deliver_parser, "Filename containing a message to be sent with the delivery. "
                                           "Pass - to read from stdin.")
-        _add_azure_arg(deliver_parser)
         deliver_parser.set_defaults(func=deliver_func)
 
     def register_list_command(self, list_func):
@@ -473,7 +467,6 @@ class CommandParser(object):
         add_project_name_or_id_arg(project_name_or_auth_role, required=False,
                                    help_text_suffix="show details for")
         _add_long_format_option(list_parser, 'Display long format.')
-        _add_azure_arg(list_parser)
         list_parser.set_defaults(func=list_func)
 
     def register_delete_command(self, delete_func):
@@ -490,7 +483,6 @@ class CommandParser(object):
                                    dest='remote_path',
                                    help="remote path specifying the file/folder to be deleted instead of the entire project")
         _add_force_arg(delete_parser, "Do not prompt before deleting.")
-        _add_azure_arg(delete_parser)
         delete_parser.set_defaults(func=delete_func)
 
     def register_list_auth_roles_command(self, list_auth_roles_func):
@@ -501,7 +493,6 @@ class CommandParser(object):
         description = "List authorization roles for use with add_user command."
         list_auth_roles_parser = self.subparsers.add_parser('list-auth-roles', description=description)
         list_auth_roles_parser.set_defaults(func=list_auth_roles_func)
-        _add_azure_arg(list_auth_roles_parser)
 
     def register_move_command(self, move_func):
         """
@@ -522,7 +513,6 @@ class CommandParser(object):
                             metavar='Target',
                             type=to_unicode,
                             help='remote path specifying where to move the file/folder to')
-        _add_azure_arg(parser)
         parser.set_defaults(func=move_func)
 
     def register_info_command(self, info_func):
@@ -533,7 +523,6 @@ class CommandParser(object):
         description = "Print information about a project."
         parser = self.subparsers.add_parser('info', description=description)
         add_project_name_or_id_arg(parser, help_text_suffix="to show the information about")
-        _add_azure_arg(parser)
         parser.set_defaults(func=info_func)
 
     def register_check_command(self, check_func):
@@ -547,7 +536,6 @@ class CommandParser(object):
         check_parser.add_argument('--wait',
                                   help="Wait for project to become consistent.",
                                   action='store_true')
-        _add_azure_arg(check_parser)
         check_parser.set_defaults(func=check_func)
 
     def run_command(self, args):

--- a/ddsc/cmdparser.py
+++ b/ddsc/cmdparser.py
@@ -360,13 +360,19 @@ class CommandParser(object):
         Add the upload command to the parser and call upload_func(project_name, folders, follow_symlinks) when chosen.
         :param upload_func: func Called when this option is chosen: upload_func(project_name, folders, follow_symlinks).
         """
-        description = "Uploads local files and folders to a remote host."
+        description = "Uploads local files and folders to a remote store. After files are uploaded this command waits for all files to be valid/downloadable."
         upload_parser = self.subparsers.add_parser('upload', description=description)
         _add_dry_run(upload_parser, help_text="Instead of uploading displays a list of folders/files that "
                                               "need to be uploaded.")
         add_project_name_or_id_arg(upload_parser, help_text_suffix="upload files/folders to.")
         _add_folders_positional_arg(upload_parser)
         _add_follow_symlinks_arg(upload_parser)
+        upload_parser.add_argument(
+            "--no-check",
+            help="Skip checking/waiting for uploaded files to be in the valid/downloadable state.",
+            action='store_false',
+            dest='check',
+            default=True)
         upload_parser.set_defaults(func=upload_func)
 
     def register_add_user_command(self, add_user_func):

--- a/ddsc/core/consistency.py
+++ b/ddsc/core/consistency.py
@@ -99,7 +99,7 @@ class ProjectChecker(object):
     def wait_for_consistency(self, wait_sec=5):
         while True:
             try:
-                print("Checking files for project {}".format(self.project.name))
+                print("Checking files for project {}.".format(self.project.name))
                 self._try_fetch_project_files()
                 # if we are able to fetch all files project is in a consistent state
                 print("Project {} is consistent.".format(self.project.name))

--- a/ddsc/core/tests/test_consistency.py
+++ b/ddsc/core/tests/test_consistency.py
@@ -131,9 +131,9 @@ class TestProjectChecker(TestCase):
         ]
         self.checker.wait_for_consistency(wait_sec=10)
         mock_print.assert_has_calls([
-            call('Checking files for project Mouse'),
+            call('Checking files for project Mouse.'),
             call('Project not consistent yet. Waiting.'),
-            call('Checking files for project Mouse'),
+            call('Checking files for project Mouse.'),
             call('Project Mouse is consistent.')
         ])
         mock_time.sleep.assert_called_with(10)

--- a/ddsc/ddsclient.py
+++ b/ddsc/ddsclient.py
@@ -64,7 +64,7 @@ class DDSClient(object):
         return parser
 
     def use_azure_commands(self, args):
-        return args.azure or self.config.backing_storage == "azure"
+        return False
 
     def list_command(self, args):
         command_constructor = ListCommand

--- a/ddsc/ddsclient.py
+++ b/ddsc/ddsclient.py
@@ -253,6 +253,7 @@ class UploadCommand(BaseCommand):
         folders = args.folders                  # list of local files/folders to upload into the project
         follow_symlinks = args.follow_symlinks  # should we follow symlinks when traversing folders
         dry_run = args.dry_run                  # do not upload anything, instead print out what you would upload
+        check_file_consistency = args.check     # should we check download URLs after uploading
 
         # Find files and folders to upload
         local_project = LocalProject(followsymlinks=follow_symlinks, file_exclude_regex=self.config.file_exclude_regex)
@@ -285,6 +286,22 @@ class UploadCommand(BaseCommand):
                 print('\n')
             print(project_upload.get_url_msg())
             project_upload.cleanup()
+
+            # check for consistency unless user passes --no-check flag
+            if check_file_consistency:
+                self.wait_for_consistency(local_project.remote_id)
+
+    def wait_for_consistency(self, project_id):
+        client = Client(self.config)
+        project = client.get_project_by_id(project_id)
+        checker = ProjectChecker(self.config, project)
+        try:
+            checker.wait_for_consistency()
+        except DSHashMismatchError:
+            checker.print_bad_uploads_table()
+            sys.exit(1)
+        finally:
+            client.close()
 
 
 class DownloadCommand(ClientCommand):

--- a/ddsc/tests/test_cmdparser.py
+++ b/ddsc/tests/test_cmdparser.py
@@ -227,3 +227,23 @@ class TestCommandParser(TestCase):
         command_parser.run_command(['check', '-p', 'mouse'])
         self.assertEqual(self.parsed_args.project_name, 'mouse')
         self.assertEqual(self.parsed_args.project_id, None)
+
+    def test_register_upload_command_project_name(self):
+        command_parser = CommandParser(version_str='1.0')
+        command_parser.register_upload_command(self.set_parsed_args)
+        self.assertEqual(['upload'], list(command_parser.subparsers.choices.keys()))
+        command_parser.run_command(['upload', '-p', 'myproj', '/tmp'])
+        self.assertEqual('myproj', self.parsed_args.project_name)
+        self.assertEqual(None, self.parsed_args.project_id)
+        self.assertEqual(['/tmp'], self.parsed_args.folders)
+        self.assertEqual(True, self.parsed_args.check)
+
+    def test_register_upload_command_project_name__no_check(self):
+        command_parser = CommandParser(version_str='1.0')
+        command_parser.register_upload_command(self.set_parsed_args)
+        self.assertEqual(['upload'], list(command_parser.subparsers.choices.keys()))
+        command_parser.run_command(['upload', '-p', 'myproj', '/tmp', '--no-check'])
+        self.assertEqual('myproj', self.parsed_args.project_name)
+        self.assertEqual(None, self.parsed_args.project_id)
+        self.assertEqual(['/tmp'], self.parsed_args.folders)
+        self.assertEqual(False, self.parsed_args.check)


### PR DESCRIPTION
Runs the `check --wait` logic as part of the `upload` command. 
The check can be turned off by including the `--no-check` argument.
Disables azure flag since that back end is not ready yet.
